### PR TITLE
feat: Add three new CSS themes and update footer

### DIFF
--- a/_includes/footer-custom.html
+++ b/_includes/footer-custom.html
@@ -25,6 +25,9 @@
   <option value="ai">AI</option>
   <option value="audio.css">Audio</option>
   <option value="spoof">Spoof</option>
+  <option value="oceanic-depths.css">Oceanic Depths</option>
+  <option value="retro-gamification.css">Retro Gamification</option>
+  <option value="minimalist-ink.css">Minimalist Ink</option>
   <option value="noscript.css" selected>NoScript</option>
 </select>
 

--- a/themes/minimalist-ink.css
+++ b/themes/minimalist-ink.css
@@ -1,0 +1,158 @@
+body {
+  background: #FAFAFA;
+  color: #202020;
+  font-family: Georgia, 'Times New Roman', serif;
+  line-height: 1.7;
+  margin: 0;
+  padding: 0;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  color: #101010;
+  font-family: Georgia, 'Times New Roman', serif; /* Consistent with body or can be a contrasting clean sans-serif */
+  margin-top: 1.5em;
+  margin-bottom: 0.5em;
+  line-height: 1.2;
+}
+
+h1 {
+  font-size: 2.8em;
+  font-weight: bold;
+}
+
+h2 {
+  font-size: 2.2em;
+  font-weight: bold;
+}
+
+h3 {
+  font-size: 1.8em;
+  font-weight: bold;
+}
+
+h4 {
+  font-size: 1.5em;
+  font-weight: normal; /* Less emphasis for h4 */
+}
+
+h5 {
+  font-size: 1.2em;
+  font-weight: normal;
+}
+
+h6 {
+  font-size: 1em;
+  font-weight: normal;
+  font-style: italic; /* More distinct h6 */
+}
+
+p {
+  margin-bottom: 1.5em; /* Generous margin for paragraphs */
+}
+
+li {
+  margin-bottom: 0.5em; /* Spacing for list items */
+}
+
+a {
+  color: #0056b3; /* Muted blue accent */
+  text-decoration: none; /* Cleaner look, hover provides underline */
+}
+
+a:hover {
+  color: #003d80; /* Darken blue on hover */
+  text-decoration: underline;
+}
+
+blockquote {
+  padding-left: 2em;
+  margin-left: 0;
+  border-left: 2px solid #303030;
+  font-style: italic;
+  color: #505050; /* Slightly lighter text for quotes */
+  margin-top: 1.5em;
+  margin-bottom: 1.5em;
+}
+
+pre, code {
+  font-family: Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+  background: #F0F0F0;
+  color: #101010;
+  padding: 8px 12px;
+  border-radius: 3px; /* Subtle rounding */
+  font-size: 0.95em;
+  line-height: 1.5;
+  overflow-x: auto;
+  border: 1px solid #D0D0D0; /* Alternative: no background, just border */
+}
+
+code { /* Inline code style adjustments */
+  padding: 2px 4px;
+  background: #F0F0F0; /* Consistent with pre or slightly different */
+  border-radius: 2px;
+}
+
+/* Minimalist Syntax Highlighting - mostly grays, bold for keywords */
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+  color: #708090; /* Slate gray */
+}
+
+.token.punctuation {
+  color: #505050; /* Darker gray */
+}
+
+.token.property,
+.token.tag,
+.token.boolean,
+.token.number,
+.token.constant,
+.token.symbol,
+.token.deleted {
+  color: #303030; /* Very dark gray */
+}
+
+.token.selector,
+.token.attr-name,
+.token.string,
+.token.char,
+.token.builtin,
+.token.inserted {
+  color: #404040; /* Dark gray */
+}
+
+.token.operator,
+.token.entity,
+.token.url,
+.language-css .token.string,
+.style .token.string {
+  color: #202020; /* Near black */
+}
+
+.token.atrule,
+.token.attr-value,
+.token.keyword {
+  color: #101010; /* Black */
+  font-weight: bold;
+}
+
+.token.function,
+.token.class-name {
+  color: #101010; /* Black */
+}
+
+.token.regex,
+.token.important,
+.token.variable {
+  color: #0056b3; /* Accent color for important tokens */
+}
+
+/* Add some general spacing and max-width for readability on wide screens */
+body {
+  max-width: 800px; /* Or your preferred reading width */
+  margin-left: auto;
+  margin-right: auto;
+  padding: 20px; /* Padding around the content */
+}

--- a/themes/oceanic-depths.css
+++ b/themes/oceanic-depths.css
@@ -1,0 +1,102 @@
+body {
+  background: #0A2F35; /* Dark blue/teal */
+  color: #E0F4F4; /* Off-white/light cyan */
+  font-family: Arial, sans-serif;
+}
+
+h1 {
+  color: #90D0D8; /* Lighter blue */
+}
+
+h2 {
+  color: #7ABCC4; /* Seafoam green */
+}
+
+h3, h4, h5, h6 {
+  color: #A0D0D8; /* Lighter shades of blue for other headings */
+}
+
+p, li {
+  color: #E0F4F4; /* Off-white/light cyan */
+}
+
+a {
+  color: #FF7F50; /* Coral */
+  text-decoration: none;
+}
+
+a:hover {
+  color: #FFFF80; /* Bright yellow on hover */
+  text-decoration: underline; /* Optional: or a wave animation */
+}
+
+blockquote {
+  background: rgba(15, 68, 78, 0.7); /* Semi-transparent darker teal */
+  border-left: 4px solid #FF7F50; /* Coral */
+  padding: 10px;
+  margin: 10px;
+}
+
+pre, code {
+  background: #072428; /* Very dark desaturated cyan */
+  color: #C0E0E0;
+  padding: 5px;
+  border-radius: 4px;
+  font-family: "Courier New", Courier, monospace;
+}
+
+/* Basic syntax highlighting placeholders */
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+  color: #6A9955; /* Green */
+}
+
+.token.punctuation {
+  color: #D4D4D4; /* Light gray */
+}
+
+.token.property,
+.token.tag,
+.token.boolean,
+.token.number,
+.token.constant,
+.token.symbol,
+.token.deleted {
+  color: #569CD6; /* Blue */
+}
+
+.token.selector,
+.token.attr-name,
+.token.string,
+.token.char,
+.token.builtin,
+.token.inserted {
+  color: #CE9178; /* Orange/Coral */
+}
+
+.token.operator,
+.token.entity,
+.token.url,
+.language-css .token.string,
+.style .token.string {
+  color: #DCDCAA; /* Yellow */
+}
+
+.token.atrule,
+.token.attr-value,
+.token.keyword {
+  color: #C586C0; /* Purple */
+}
+
+.token.function,
+.token.class-name {
+  color: #4EC9B0; /* Teal */
+}
+
+.token.regex,
+.token.important,
+.token.variable {
+  color: #D16969; /* Reddish */
+}

--- a/themes/retro-gamification.css
+++ b/themes/retro-gamification.css
@@ -1,0 +1,135 @@
+@import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap');
+
+body {
+  background: #202030;
+  /* Subtle pixel grid pattern */
+  background-image: 
+    repeating-linear-gradient(0deg, transparent, transparent 1px, rgba(255,255,255,0.05) 1px, rgba(255,255,255,0.05) 2px),
+    repeating-linear-gradient(90deg, transparent, transparent 1px, rgba(255,255,255,0.05) 1px, rgba(255,255,255,0.05) 2px);
+  background-size: 2px 2px;
+  color: #E0E0E0;
+  font-family: 'Press Start 2P', 'Courier New', monospace;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: 'Press Start 2P', 'Courier New', monospace;
+}
+
+h1 {
+  color: #FFFF00; /* yellow */
+}
+
+h2 {
+  color: #00FFFF; /* cyan */
+}
+
+h3 {
+  color: #FF00FF; /* magenta */
+}
+
+/* For h4-h6, we can cycle through the colors or use new ones */
+h4 {
+  color: #00FF00; /* green */
+}
+
+h5 {
+  color: #FFA500; /* orange */
+}
+
+h6 {
+  color: #FF0000; /* red */
+}
+
+p, li {
+  color: #E0E0E0;
+  line-height: 1.8; /* Increased line height for pixel font readability */
+}
+
+a {
+  color: #00FF00; /* Bright green */
+  text-decoration: none;
+  background-color: transparent;
+  padding: 2px 0; /* Minimal padding for non-hover state */
+  transition: background-color 0.2s ease-in-out, color 0.2s ease-in-out; /* Smooth transition */
+}
+
+a:hover {
+  background-color: #FFFF00; /* Contrasting dark shade - Yellow for button */
+  color: #202030; /* Text color to dark background color */
+  outline: 2px solid #FFFF00; /* Yellow outline for button effect */
+}
+
+blockquote {
+  border: 4px solid #FFFF00; /* yellow */
+  background: #303040;
+  padding: 15px;
+  margin: 15px 0;
+  font-size: 0.9em; /* Slightly smaller for dialogue box feel */
+  line-height: 1.6;
+}
+
+pre, code {
+  background: #101020;
+  color: #F0F0F0;
+  padding: 10px;
+  border-radius: 0; /* Blocky elements, no border-radius */
+  font-family: 'Press Start 2P', 'Courier New', monospace;
+  font-size: 0.9em; /* Adjust for readability */
+  overflow-x: auto; /* Ensure code blocks are scrollable */
+}
+
+/* Basic syntax highlighting placeholders - Classic game palette */
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+  color: #808080; /* Gray for comments */
+}
+
+.token.punctuation {
+  color: #FFFFFF; /* White */
+}
+
+.token.property,
+.token.tag,
+.token.boolean,
+.token.number,
+.token.constant,
+.token.symbol,
+.token.deleted {
+  color: #00FFFF; /* Cyan */
+}
+
+.token.selector,
+.token.attr-name,
+.token.string,
+.token.char,
+.token.builtin,
+.token.inserted {
+  color: #FFFF00; /* Yellow */
+}
+
+.token.operator,
+.token.entity,
+.token.url,
+.language-css .token.string,
+.style .token.string {
+  color: #00FF00; /* Green */
+}
+
+.token.atrule,
+.token.attr-value,
+.token.keyword {
+  color: #FF00FF; /* Magenta */
+}
+
+.token.function,
+.token.class-name {
+  color: #FFA500; /* Orange */
+}
+
+.token.regex,
+.token.important,
+.token.variable {
+  color: #FF0000; /* Red */
+}


### PR DESCRIPTION
This commit introduces three new, distinct CSS themes:

1.  **Oceanic Depths (`oceanic-depths.css`):** A dark theme inspired by the deep ocean, using dark blues and teals, with lighter contrasting text and coral/yellow accents.

2.  **Retro Gamification (`retro-gamification.css`):** A theme reminiscent of 8/16-bit video games, featuring a pixel grid background, the 'Press Start 2P' font, blocky elements, and a bright, contrasting color palette.

3.  **Minimalist Ink (`minimalist-ink.css`):** A clean, minimalist theme focused on typography and whitespace, primarily monochrome (black ink on off-white paper) with a single muted blue accent color.

These themes have been added to the theme selector dropdown in `_includes/footer-custom.html`.

The goal was to create themes that are very different from each other and from existing themes, offering you a wider range of visual styles.