### PR TITLE
feat: Add three more distinct CSS themes

### DIFF
--- a/_includes/footer-custom.html
+++ b/_includes/footer-custom.html
@@ -25,6 +25,9 @@
   <option value="ai">AI</option>
   <option value="audio.css">Audio</option>
   <option value="spoof">Spoof</option>
+  <option value="code-deconstruct.css">Code Deconstruct</option>
+  <option value="ghost-network.css">Ghost Network</option>
+  <option value="system-alert.css">System Alert</option>
   <option value="oceanic-depths.css">Oceanic Depths</option>
   <option value="retro-gamification.css">Retro Gamification</option>
   <option value="minimalist-ink.css">Minimalist Ink</option>

--- a/themes/code-deconstruct.css
+++ b/themes/code-deconstruct.css
@@ -1,0 +1,147 @@
+@import url('https://fonts.googleapis.com/css2?family=Fira+Code&display=swap');
+
+body {
+  background: #1E1E1E; /* Dark background */
+  color: #D4D4D4; /* Light gray for general text */
+  font-family: 'Segoe UI', Arial, sans-serif; /* Clean sans-serif */
+  line-height: 1.6;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  color: #EAEAEA; /* Slightly brighter than body text */
+  font-family: 'Segoe UI', Arial, sans-serif; /* Consistent modern sans-serif */
+  margin-top: 1.2em;
+  margin-bottom: 0.6em;
+}
+
+h1 {
+  font-size: 2.4em;
+  border-bottom: 2px solid #4E9AF1; /* Accent color border */
+  padding-bottom: 0.3em;
+}
+
+h2 {
+  font-size: 2em;
+}
+
+h3 {
+  font-size: 1.7em;
+}
+
+h4 {
+  font-size: 1.4em;
+}
+
+h5 {
+  font-size: 1.2em;
+}
+
+h6 {
+  font-size: 1em;
+  color: #CECECE; /* Slightly dimmer for less emphasis */
+}
+
+p, li {
+  color: #D4D4D4;
+  margin-bottom: 1em;
+}
+
+a {
+  color: #4E9AF1; /* Vibrant blue */
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+blockquote {
+  background: #252526; /* Slightly different dark shade */
+  border-left: 4px solid #4E9AF1; /* Link blue accent */
+  padding: 0.5em 1em;
+  margin: 1em 0;
+  color: #CCC; /* Specific text color for blockquotes */
+  font-style: italic; /* Common styling for quotes */
+}
+
+pre {
+  background: #161616; /* Slightly different from body */
+  border: 1px solid #333;
+  border-radius: 4px;
+  padding: 1em;
+  overflow-x: auto; /* For horizontal scroll on wide code blocks */
+}
+
+code {
+  font-family: 'Fira Code', Consolas, Menlo, monospace; /* Fira Code with fallbacks */
+  font-size: 0.95em; /* Slightly smaller for code context */
+}
+
+/* Syntax Highlighting (inspired by IDEs) */
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+  color: #6A9955; /* Green */
+}
+
+.token.punctuation {
+  color: #D4D4D4; /* Light gray */
+}
+
+.token.property,
+.token.tag,
+.token.boolean,
+.token.number,
+.token.constant,
+.token.symbol,
+.token.deleted {
+  color: #CE9178; /* Peach/orange */
+}
+
+.token.selector,
+.token.attr-name,
+.token.string,
+.token.char,
+.token.builtin,
+.token.inserted {
+  color: #569CD6; /* Blue */
+}
+
+.token.operator,
+.token.entity,
+.token.url,
+.language-css .token.string, /* Specificity for CSS strings if needed */
+.style .token.string {       /* Specificity for style strings if needed */
+  color: #D4D4D4; /* Light gray, similar to punctuation or default text */
+}
+
+.token.atrule,
+.token.attr-value,
+.token.keyword {
+  color: #C586C0; /* Purple */
+}
+
+.token.function,
+.token.class-name {
+  color: #DCDCAA; /* Yellowish */
+}
+
+.token.regex,
+.token.important,
+.token.variable {
+  color: #9CDCFE; /* Light blue */
+}
+
+.token.important,
+.token.bold {
+  font-weight: bold;
+}
+
+.token.italic {
+  font-style: italic;
+}
+
+.token.entity {
+  cursor: help; /* Example for entities if they represent links or tooltips */
+}

--- a/themes/ghost-network.css
+++ b/themes/ghost-network.css
@@ -1,0 +1,139 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@300;400&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Source+Code+Pro&display=swap');
+
+body {
+  background: #2A2A2E; /* Dark, desaturated background */
+  /* Subtle noise pattern */
+  background-image: 
+    repeating-linear-gradient(45deg, rgba(0,0,0,0.02) 0, rgba(0,0,0,0.02) 1px, transparent 1px, transparent 2px),
+    repeating-linear-gradient(-45deg, rgba(0,0,0,0.02) 0, rgba(0,0,0,0.02) 1px, transparent 1px, transparent 2px);
+  background-size: 2px 2px;
+  color: #B5B5B5; /* Light gray for text */
+  font-family: 'Roboto', Helvetica, Arial, sans-serif;
+  font-weight: 400; /* Default weight for body */
+  line-height: 1.6;
+  /* text-shadow: 0 0 1px rgba(0,0,0,0.5); /* Subtle blur - use with caution */
+}
+
+h1, h2, h3, h4, h5, h6 {
+  color: #706080; /* Deep desaturated purple accent */
+  font-family: 'Roboto', Helvetica, Arial, sans-serif;
+  font-weight: 300; /* Thinner font weight */
+  margin-top: 1.2em;
+  margin-bottom: 0.5em;
+}
+
+h1 { font-size: 2.2em; }
+h2 { font-size: 1.9em; }
+h3 { font-size: 1.6em; }
+h4 { font-size: 1.3em; }
+h5 { font-size: 1.1em; }
+h6 { font-size: 1em; color: #605070; /* Even more muted for h6 */ }
+
+p, li {
+  color: #B5B5B5;
+  margin-bottom: 1em;
+}
+
+a {
+  color: #706080; /* Accent color */
+  text-decoration: none;
+  transition: text-shadow 0.3s ease;
+}
+
+a:hover, a:focus {
+  color: #8A7A9A; /* Slightly brighter accent on hover */
+  text-shadow: 0 0 8px #706080; /* Soft glow with current color */
+}
+
+pre {
+  background: #202023; /* Slightly darker than body */
+  border: 1px solid #404045;
+  border-radius: 3px;
+  padding: 1em;
+  overflow-x: auto;
+}
+
+code {
+  font-family: 'Source Code Pro', Menlo, monospace;
+  font-size: 0.95em;
+}
+
+/* Syntax Highlighting - Desaturated/Muted */
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+  color: #6A737D; /* Gray */
+}
+
+.token.punctuation {
+  color: #A0A0A0; /* Light gray (from text spec) */
+}
+
+.token.property,
+.token.tag,
+.token.boolean,
+.token.number,
+.token.constant,
+.token.symbol,
+.token.deleted {
+  color: #B08090; /* Muted purple/pink */
+}
+
+.token.selector,
+.token.attr-name,
+.token.string,
+.token.char,
+.token.builtin,
+.token.inserted {
+  color: #6090A0; /* Muted blue/teal */
+}
+
+.token.operator, /* Operators could be same as punctuation or slightly different */
+.token.entity,
+.token.url,
+.language-css .token.string,
+.style .token.string {
+  color: #A0A0A0; /* Matching punctuation for a more uniform look */
+}
+
+.token.atrule,
+.token.attr-value,
+.token.keyword {
+  color: #8070A0; /* Muted purple */
+}
+
+.token.function,
+.token.class-name {
+  color: #A09060; /* Muted yellow/brown */
+}
+
+.token.regex,
+.token.important,
+.token.variable {
+  color: #B080B0; /* A slightly different muted purple/magenta for variables */
+}
+
+.token.important,
+.token.bold {
+  font-weight: bold;
+}
+
+.token.italic {
+  font-style: italic;
+}
+
+blockquote {
+  border-left: 3px solid #706080; /* Accent color */
+  padding: 0.5em 1em;
+  margin: 1em 0;
+  color: #909090;
+  background-color: rgba(0,0,0,0.1); /* Very subtle dark background */
+  font-style: italic; /* Common for quotes */
+}
+
+img, video {
+  filter: saturate(70%) brightness(90%); /* Desaturated/dimmed look */
+  border-radius: 2px; /* Optional: slight rounding for images */
+}

--- a/themes/system-alert.css
+++ b/themes/system-alert.css
@@ -1,0 +1,144 @@
+body {
+  background: #D4D0C8; /* Classic OS gray */
+  color: #000000; /* Black text */
+  font-family: Tahoma, 'MS Sans Serif', Arial, sans-serif;
+  line-height: 1.5;
+  margin: 0; /* Remove default margin */
+}
+
+h1, h2, h3, h4, h5, h6 {
+  color: #000000;
+  font-family: Tahoma, 'MS Sans Serif', Arial, sans-serif;
+  margin-top: 1em;
+  margin-bottom: 0.5em;
+}
+
+h1 {
+  background-color: #005A9E; /* Dark blue title bar */
+  color: #FFFFFF; /* White text */
+  padding: 5px 10px;
+  font-size: 1.2em; /* More like a title bar font size */
+  border: 1px solid #000000; /* Simple border */
+  border-bottom: 1px solid #000000; /* Ensure bottom border is also black for title bar effect */
+  font-weight: bold;
+  margin-top: 0; /* H1 often at the top, no extra margin */
+}
+
+h2 {
+  font-size: 1.5em;
+  font-weight: bold;
+}
+
+h3 {
+  font-size: 1.3em;
+  font-weight: bold;
+}
+
+h4 {
+  font-size: 1.1em;
+  font-weight: bold;
+}
+
+h5 {
+  font-size: 1em;
+  font-weight: bold;
+}
+
+h6 {
+  font-size: 0.9em;
+  font-weight: bold;
+}
+
+p, li {
+  color: #000000;
+  margin-bottom: 0.8em;
+}
+
+a {
+  color: #0000EE; /* Standard system blue */
+  text-decoration: underline;
+}
+
+a:hover {
+  color: #3366CC; /* Slightly different blue on hover */
+}
+
+pre {
+  background: #FFFFFF; /* White */
+  border: 1px inset #7F7F7F; /* Inset text area look */
+  padding: 0.5em;
+  overflow-x: auto;
+  margin: 1em 0; /* Added margin for spacing */
+}
+
+code {
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 1em; /* Match surrounding text or slightly smaller if preferred */
+}
+
+/* Syntax Highlighting - Minimal */
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+  color: #008000; /* Dark green */
+}
+
+.token.keyword {
+  color: #000080; /* Dark blue */
+  font-weight: bold;
+}
+
+/* Default for other tokens - already black due to body, but can be explicit */
+.token.punctuation,
+.token.property,
+.token.tag,
+.token.boolean,
+.token.number,
+.token.constant,
+.token.symbol,
+.token.deleted,
+.token.selector,
+.token.attr-name,
+.token.string,
+.token.char,
+.token.builtin,
+.token.inserted,
+.token.operator,
+.token.entity,
+.token.url,
+.language-css .token.string,
+.style .token.string,
+.token.function,
+.token.class-name,
+.token.regex,
+.token.important,
+.token.variable {
+  color: #000000;
+}
+
+blockquote {
+  background-color: #FFFFE1; /* Light yellow for alert box */
+  border: 1px solid #FFD700; /* Gold/dark yellow border */
+  padding: 1em;
+  margin: 1em 0; /* Standard margin */
+  color: #000000; /* Text should be black for readability */
+}
+
+/* Optional: if want to style a page to look more like a dialog */
+/*
+.dialog-container {
+  max-width: 600px;
+  margin: 50px auto;
+  border: 2px outset #C0C0C0; 
+  box-shadow: 5px 5px 10px rgba(0,0,0,0.2);
+  padding: 0; 
+}
+*/
+
+/* Ensure no extra padding/margin if h1 is first in a container */
+/*
+.dialog-container h1:first-child {
+  margin-top: 0;
+}
+*/


### PR DESCRIPTION
This commit introduces three additional new CSS themes, each with a unique concept inspired by site content:

1.  **Code Deconstruct (`code-deconstruct.css`):** Inspired by IDEs and debugging, this dark theme focuses on code readability with rich syntax highlighting. It uses Fira Code font for code and a vibrant blue accent.

2.  **Ghost Network (`ghost-network.css`):** Evokes digital anonymity (inspired by Tor posts) with a dark, desaturated palette, subtle noise effects, muted purple/teal accents, and desaturated syntax highlighting. Uses Roboto and Source Code Pro fonts.

3.  **System Alert (`system-alert.css`):** Mimics classic OS dialogs and warnings. Features a gray background, system-like fonts (Tahoma, Courier New), a title-bar style for H1, and alert-box styling for blockquotes.

These themes have been added to the theme selector dropdown in `_includes/footer-custom.html`. This batch follows the previous addition of themes, further expanding your choice.