### PR TITLE
Surveillance theme: drop the panel and fake radius, add OSM search

### DIFF
--- a/themes/Surveillance.html
+++ b/themes/Surveillance.html
@@ -4,10 +4,13 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Surveillance</title>
-    <!-- Leaflet from CDN. For production, add SRI integrity hashes to these. -->
+    <!-- Leaflet + the OSM/Nominatim geocoder. For production add SRI hashes. -->
     <link
       rel="stylesheet"
       href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/leaflet-control-geocoder@2.4.0/dist/Control.Geocoder.css" />
     <style>
       html,
       body {
@@ -25,53 +28,34 @@
       .leaflet-container {
         background: #0b0f14;
       }
-      #panel {
-        position: fixed;
-        left: 16px;
-        bottom: 16px;
-        max-width: 330px;
-        z-index: 1000;
-        padding: 12px 14px;
-        border-radius: 12px;
-        background: rgba(8, 14, 20, 0.82);
-        border: 1px solid rgba(120, 200, 255, 0.25);
-        box-shadow: 0 10px 40px rgba(0, 0, 0, 0.5);
-        backdrop-filter: blur(12px);
-        -webkit-backdrop-filter: blur(12px);
-        font-size: 12.5px;
-        line-height: 1.55;
+      /* Make the search control fit the dark map */
+      .leaflet-control-geocoder,
+      .leaflet-control-geocoder-alternatives {
+        background: #0b0f14;
+        border: 1px solid rgba(120, 200, 255, 0.3);
+        color: #d7e6f0;
       }
-      #panel h2 {
-        margin: 0 0 6px;
-        font-size: 12px;
-        letter-spacing: 0.08em;
-        text-transform: uppercase;
-        color: #ff7676;
+      .leaflet-control-geocoder-form input {
+        color: #d7e6f0;
+        background: transparent;
       }
-      #panel b {
-        color: #8ad0ff;
+      .leaflet-control-geocoder-alternatives a {
+        color: #d7e6f0;
       }
-      #panel .muted {
-        color: rgba(215, 230, 240, 0.6);
-        font-size: 11px;
-      }
-      #panel .cam {
-        color: #ffd166;
+      .leaflet-control-geocoder-alternatives li:hover {
+        background: rgba(120, 200, 255, 0.12);
       }
     </style>
   </head>
   <body>
     <div id="map"></div>
-    <div id="panel">
-      <h2>📍 A website just located you</h2>
-      <div id="info">Locating you by IP…</div>
-    </div>
 
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+    <script src="https://unpkg.com/leaflet-control-geocoder@2.4.0/dist/Control.Geocoder.js"></script>
     <script>
       'use strict';
 
-      // HTML-escape anything that comes from a third party before it touches the DOM.
+      // HTML-escape OSM tag values before they touch a popup.
       function esc(value) {
         return String(value == null ? '' : value).replace(
           /[&<>"']/g,
@@ -86,13 +70,7 @@
         );
       }
 
-      const info = document.getElementById('info');
-      const RADIUS = 2000; // metres to scan for cameras
-
-      const map = L.map('map', {
-        zoomControl: true,
-        attributionControl: true
-      }).setView([25, 0], 2);
+      const map = L.map('map', {zoomControl: true}).setView([25, 0], 2);
       L.tileLayer(
         'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png',
         {
@@ -102,117 +80,77 @@
         }
       ).addTo(map);
 
-      async function locate() {
-        let g = {};
-        let lat;
-        let lon;
-        try {
-          const res = await fetch('https://get.geojs.io/v1/ip/geo.json', {
-            credentials: 'omit'
-          });
-          g = await res.json();
-          lat = parseFloat(g.latitude);
-          lon = parseFloat(g.longitude);
-        } catch (e) {
-          /* fall through to the not-found message */
-        }
+      // Search (OpenStreetMap / Nominatim, keyless).
+      L.Control.geocoder({
+        collapsed: false,
+        defaultMarkGeocode: true,
+        position: 'topright'
+      }).addTo(map);
 
-        if (!isFinite(lat) || !isFinite(lon)) {
-          info.textContent =
-            'Could not geolocate your IP (request blocked, or no network).';
+      // Cameras for whatever is currently on screen — no invented radius.
+      const cameras = L.layerGroup().addTo(map);
+      const MIN_ZOOM = 14; // below this the view is too large to query responsibly
+
+      function refresh() {
+        if (map.getZoom() < MIN_ZOOM) {
+          cameras.clearLayers();
           return;
         }
-
-        map.setView([lat, lon], 15);
-        // A fuzzy ring as an honest reminder that IP geolocation is approximate.
-        L.circle([lat, lon], {
-          radius: 1200,
-          color: '#8ad0ff',
-          weight: 1,
-          fillColor: '#8ad0ff',
-          fillOpacity: 0.07
-        }).addTo(map);
-        L.circleMarker([lat, lon], {
-          radius: 7,
-          color: '#8ad0ff',
-          weight: 2,
-          fillColor: '#1f6feb',
-          fillOpacity: 0.9
-        })
-          .addTo(map)
-          .bindPopup('You — approximate, from your IP');
-
-        const org = g.organization_name || g.organization || 'unknown network';
-        const asn = g.asn ? ' · AS' + esc(g.asn) : '';
-        info.innerHTML =
-          'Approx <b>' +
-          esc(g.city || '?') +
-          ', ' +
-          esc(g.country || '?') +
-          '</b><br>via IP <b>' +
-          esc(g.ip) +
-          '</b><br><span class="muted">' +
-          esc(org) +
-          asn +
-          '</span><br><span id="cams" class="cam">Scanning OpenStreetMap…</span>' +
-          '<br><span class="muted">IP-based &amp; approximate. No cookies, nothing stored.</span>';
-
-        cameras(lat, lon);
-      }
-
-      async function cameras(lat, lon) {
+        const b = map.getBounds();
         const query =
-          '[out:json][timeout:25];node["man_made"="surveillance"](around:' +
-          RADIUS +
+          '[out:json][timeout:25];node["man_made"="surveillance"](' +
+          b.getSouth() +
           ',' +
-          lat +
+          b.getWest() +
           ',' +
-          lon +
-          ');out body 400;';
-        let data;
-        try {
-          const res = await fetch(
-            'https://overpass-api.de/api/interpreter?data=' +
-              encodeURIComponent(query),
-            {credentials: 'omit'}
-          );
-          data = await res.json();
-        } catch (e) {
-          const el = document.getElementById('cams');
-          if (el) el.textContent = 'Overpass unreachable.';
-          return;
-        }
-
-        const cams = (data.elements || []).filter((n) => n.lat && n.lon);
-        cams.forEach((n) => {
-          const kind = n.tags && n.tags['surveillance:type'];
-          L.circleMarker([n.lat, n.lon], {
-            radius: 4,
-            color: '#ff5f5f',
-            weight: 1,
-            fillColor: '#ffd166',
-            fillOpacity: 0.85
+          b.getNorth() +
+          ',' +
+          b.getEast() +
+          ');out body 800;';
+        fetch(
+          'https://overpass-api.de/api/interpreter?data=' +
+            encodeURIComponent(query),
+          {credentials: 'omit'}
+        )
+          .then((r) => r.json())
+          .then((d) => {
+            cameras.clearLayers();
+            (d.elements || []).forEach((n) => {
+              if (!n.lat || !n.lon) return;
+              const kind = n.tags && n.tags['surveillance:type'];
+              L.circleMarker([n.lat, n.lon], {
+                radius: 4,
+                color: '#ff5f5f',
+                weight: 1,
+                fillColor: '#ffd166',
+                fillOpacity: 0.85
+              })
+                .bindPopup(
+                  '📷 Surveillance camera' +
+                    (kind ? ' (' + esc(kind) + ')' : '')
+                )
+                .addTo(cameras);
+            });
           })
-            .addTo(map)
-            .bindPopup(
-              '📷 Surveillance camera' + (kind ? ' (' + esc(kind) + ')' : '')
-            );
-        });
-
-        const el = document.getElementById('cams');
-        if (el) {
-          el.innerHTML =
-            '📷 <b>' +
-            cams.length +
-            '</b> surveillance camera' +
-            (cams.length === 1 ? '' : 's') +
-            ' mapped within ' +
-            RADIUS / 1000 +
-            ' km';
-        }
+          .catch(() => {});
       }
 
-      locate();
+      let timer;
+      map.on('moveend', () => {
+        clearTimeout(timer);
+        timer = setTimeout(refresh, 600);
+      });
+
+      // Open near the visitor (IP-based) as a starting point; search takes over.
+      fetch('https://get.geojs.io/v1/ip/geo.json', {credentials: 'omit'})
+        .then((r) => r.json())
+        .then((g) => {
+          const lat = parseFloat(g.latitude);
+          const lon = parseFloat(g.longitude);
+          if (isFinite(lat) && isFinite(lon)) map.setView([lat, lon], 16);
+          else refresh();
+        })
+        .catch(() => refresh());
 
       // ---------- Host bridge (shaderwall protocol) ----------
       let shown = false;


### PR DESCRIPTION
Per review: remove the info panel, the arbitrary 2 km 'around' query, and the fake accuracy ring. Cameras are now queried by the current map bounding box and refresh on pan/zoom (gated at zoom >= 14 so the view isn't too large to query politely). Add a keyless OpenStreetMap/Nominatim search box; GeoIP now only picks the initial map centre.


Claude-Session: https://claude.ai/code/session_012Y31k2fRGnrx2NzYjmB8MW