### PR TITLE
Add Chromium theme: live chromium/src commit feed

### DIFF
--- a/_includes/footer-custom.html
+++ b/_includes/footer-custom.html
@@ -7,6 +7,7 @@
   <option value="ShaderWallpapers.html">Shader Wallpapers</option>
   <option value="chromecast.html">Chrome Cast</option>
   <option value="Surveillance.html">Surveillance</option>
+  <option value="Chromium.html">Chromium</option>
   <option value="ParentalControlLock.css">ParentalControlLock</option>
   <option value="light.css">Light</option>
   <option value="cyberpunk.css">Cyberpunk</option>

--- a/themes/Chromium.html
+++ b/themes/Chromium.html
@@ -1,0 +1,315 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Chromium</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        height: 100%;
+        overflow: hidden;
+        background: #0b0f14;
+        color: #d7e6f0;
+        font-family: ui-monospace, 'Consolas', 'Courier New', monospace;
+      }
+      #feed {
+        position: fixed;
+        inset: 0;
+        overflow-y: auto;
+        padding: 14px 16px 40vh;
+        box-sizing: border-box;
+        scrollbar-width: thin;
+        scrollbar-color: rgba(138, 180, 248, 0.4) transparent;
+      }
+      #feed::-webkit-scrollbar {
+        width: 8px;
+      }
+      #feed::-webkit-scrollbar-thumb {
+        background: rgba(138, 180, 248, 0.35);
+        border-radius: 8px;
+      }
+      .row {
+        display: flex;
+        gap: 10px;
+        align-items: flex-start;
+        padding: 8px 10px;
+        border-bottom: 1px solid rgba(138, 180, 248, 0.08);
+      }
+      .row:hover {
+        background: rgba(138, 180, 248, 0.06);
+      }
+      .av {
+        flex: 0 0 auto;
+        width: 24px;
+        height: 24px;
+        border-radius: 50%;
+        background: #1b2430;
+        object-fit: cover;
+      }
+      .body {
+        flex: 1;
+        min-width: 0;
+      }
+      .subj {
+        font-family: system-ui, 'Segoe UI', Roboto, sans-serif;
+        font-size: 14px;
+        line-height: 1.35;
+        color: #e7eef6;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .meta {
+        margin-top: 2px;
+        font-size: 12px;
+        color: #7f9bb6;
+      }
+      .meta .sha {
+        color: #8ab4f8;
+        text-decoration: none;
+      }
+      .meta .sha:hover {
+        text-decoration: underline;
+      }
+      .note {
+        padding: 14px 10px;
+        text-align: center;
+        font-size: 13px;
+        color: #9bb0c4;
+      }
+      /* Brand pill, opposite corner from the host's ✦ controls button */
+      .brand {
+        position: fixed;
+        left: 16px;
+        bottom: 16px;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 6px 10px;
+        border-radius: 999px;
+        font-size: 12px;
+        color: #c7d6e6;
+        background: rgba(11, 15, 20, 0.7);
+        border: 1px solid rgba(138, 180, 248, 0.18);
+        pointer-events: none;
+      }
+      .brand .dots {
+        display: inline-flex;
+        gap: 3px;
+      }
+      .brand .dots i {
+        display: inline-block;
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="feed" aria-label="Latest chromium/src commits">
+      <div class="note" id="note">Loading chromium/src commits…</div>
+      <div id="sentinel"></div>
+    </div>
+    <div class="brand" aria-hidden="true">
+      <span class="dots"
+        ><i style="background: #8ab4f8"></i><i style="background: #ea4335"></i
+        ><i style="background: #fbbc05"></i><i style="background: #34a853"></i
+      ></span>
+      chromium/src
+    </div>
+
+    <script>
+      'use strict';
+
+      const feed = document.getElementById('feed');
+      const sentinel = document.getElementById('sentinel');
+      const note = document.getElementById('note');
+
+      // GitHub mirror of chromium/src — keyless, CORS-enabled, cookieless.
+      // (The canonical Gitiles host does not send CORS headers.)
+      const API =
+        'https://api.github.com/repos/chromium/chromium/commits?per_page=100';
+      const CAP = 700; // bound the DOM so infinite scroll never grows unbounded
+
+      let lastSha = null;
+      let loading = false;
+      let paused = false; // set briefly when GitHub rate-limits us
+
+      // Only ever render https URLs the API hands us — never trust a scheme.
+      function safeUrl(u) {
+        return typeof u === 'string' && /^https:\/\//i.test(u) ? u : null;
+      }
+
+      // Compact "3m / 4h / 2d ago" relative time.
+      function ago(iso) {
+        const t = new Date(iso).getTime();
+        if (!isFinite(t)) return '';
+        const s = Math.max(0, (Date.now() - t) / 1000);
+        const units = [
+          [31536000, 'y'],
+          [2592000, 'mo'],
+          [604800, 'w'],
+          [86400, 'd'],
+          [3600, 'h'],
+          [60, 'm']
+        ];
+        for (const [secs, label] of units) {
+          if (s >= secs) return Math.floor(s / secs) + label + ' ago';
+        }
+        return 'just now';
+      }
+
+      // Build a commit row entirely from DOM nodes — no innerHTML, so the feed
+      // is XSS-proof and needs no Trusted-Types policy to run under enforcement.
+      function renderRow(c) {
+        const row = document.createElement('div');
+        row.className = 'row';
+
+        const img = document.createElement('img');
+        img.className = 'av';
+        img.width = 24;
+        img.height = 24;
+        img.loading = 'lazy';
+        img.referrerPolicy = 'no-referrer';
+        img.alt = '';
+        const avatar = c.author && safeUrl(c.author.avatar_url);
+        if (avatar) img.src = avatar + '&s=48';
+        row.appendChild(img);
+
+        const body = document.createElement('div');
+        body.className = 'body';
+
+        const message = (c.commit && c.commit.message) || '';
+        const subj = document.createElement('div');
+        subj.className = 'subj';
+        subj.textContent = message.split('\n')[0] || '(no message)';
+        subj.title = message;
+        body.appendChild(subj);
+
+        const meta = document.createElement('div');
+        meta.className = 'meta';
+        const sha = (c.sha || '').slice(0, 7);
+        const link = safeUrl(c.html_url);
+        if (link) {
+          const a = document.createElement('a');
+          a.className = 'sha';
+          a.href = link;
+          a.target = '_blank';
+          a.rel = 'noreferrer noopener';
+          a.textContent = sha;
+          meta.appendChild(a);
+        } else {
+          const span = document.createElement('span');
+          span.className = 'sha';
+          span.textContent = sha;
+          meta.appendChild(span);
+        }
+        const who =
+          (c.commit && c.commit.author && c.commit.author.name) ||
+          (c.author && c.author.login) ||
+          'unknown';
+        const when = c.commit && c.commit.author && c.commit.author.date;
+        meta.appendChild(
+          document.createTextNode(
+            '  ·  ' + who + (when ? '  ·  ' + ago(when) : '')
+          )
+        );
+        body.appendChild(meta);
+
+        row.appendChild(body);
+        feed.insertBefore(row, sentinel);
+      }
+
+      // Keep the DOM bounded: drop rows off the top and hold the scroll
+      // position steady so the stream stays continuous.
+      function trim() {
+        let rows = feed.querySelectorAll('.row');
+        while (rows.length > CAP) {
+          const first = rows[0];
+          const h = first.getBoundingClientRect().height;
+          first.remove();
+          feed.scrollTop = Math.max(0, feed.scrollTop - h);
+          rows = feed.querySelectorAll('.row');
+        }
+      }
+
+      async function loadMore() {
+        if (loading || paused) return;
+        loading = true;
+        try {
+          const r = await fetch(API + (lastSha ? '&sha=' + lastSha : ''), {
+            credentials: 'omit'
+          });
+          if (r.status === 403 || r.status === 429) {
+            note.textContent = 'GitHub rate limit reached — resuming shortly…';
+            note.style.display = '';
+            paused = true;
+            setTimeout(() => {
+              paused = false;
+            }, 60000);
+            return;
+          }
+          const data = await r.json();
+          if (!Array.isArray(data) || data.length === 0) return;
+          // When continuing from a cursor the first item repeats lastSha.
+          const items = lastSha ? data.slice(1) : data;
+          items.forEach(renderRow);
+          lastSha = data[data.length - 1].sha;
+          note.style.display = 'none';
+          trim();
+        } catch (e) {
+          note.textContent = 'Could not reach GitHub.';
+          note.style.display = '';
+        } finally {
+          loading = false;
+        }
+      }
+
+      // Load more as the bottom approaches.
+      new IntersectionObserver(
+        (entries) => {
+          if (entries.some((e) => e.isIntersecting)) loadMore();
+        },
+        {root: feed, rootMargin: '800px'}
+      ).observe(sentinel);
+
+      loadMore();
+
+      // Gentle auto-scroll so it lives as a wallpaper; pauses while you read it
+      // (controls shown) or when the tab is hidden.
+      let shown = false;
+      function frame() {
+        if (!shown && !document.hidden) {
+          feed.scrollTop += 0.4;
+          if (feed.scrollTop + feed.clientHeight >= feed.scrollHeight - 1)
+            feed.scrollTop = 0;
+        }
+        requestAnimationFrame(frame);
+      }
+      requestAnimationFrame(frame);
+
+      // ---------- Host bridge (shaderwall protocol) ----------
+      function setShown(value) {
+        shown = value;
+        window.parent.postMessage(
+          {type: 'shaderwall', state: shown ? 'shown' : 'hidden'},
+          location.origin
+        );
+      }
+      addEventListener('message', (e) => {
+        if (e.origin != location.origin) return;
+        const d = e.data || {};
+        if (d.type !== 'shaderwall') return;
+        if (d.action === 'show') setShown(true);
+        else if (d.action === 'hide') setShown(false);
+        else if (d.action === 'toggle') setShown(!shown);
+      });
+      addEventListener('keydown', (e) => {
+        if (e.key === 'h' || e.key === 'H') setShown(!shown);
+      });
+      setShown(false);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
A dark, infinite-scrolling wallpaper that streams recent chromium/src commits. Uses the GitHub mirror's commits API (keyless, CORS-enabled, cookieless) since the canonical Gitiles host sends no CORS headers; paginates by sha cursor and backs off on 403/429 rate limits.

Rows are built entirely from DOM nodes (no innerHTML), so the feed is XSS-proof and runs unchanged under a Trusted-Types policy. The DOM is trimmed to a cap for bounded memory, and a gentle auto-scroll keeps it alive as a background, pausing when controls are shown or the tab hides. Wired into the theme dropdown next to Surveillance.


Claude-Session: https://claude.ai/code/session_012Y31k2fRGnrx2NzYjmB8MW