### PR TITLE
Add Advisories theme: live GitHub security advisory feed

### DIFF
--- a/_includes/footer-custom.html
+++ b/_includes/footer-custom.html
@@ -8,6 +8,7 @@
   <option value="chromecast.html">Chrome Cast</option>
   <option value="Surveillance.html">Surveillance</option>
   <option value="Chromium.html">Chromium</option>
+  <option value="Advisories.html">Advisories</option>
   <option value="ParentalControlLock.css">ParentalControlLock</option>
   <option value="light.css">Light</option>
   <option value="cyberpunk.css">Cyberpunk</option>

--- a/themes/Advisories.html
+++ b/themes/Advisories.html
@@ -1,0 +1,345 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Advisories</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        height: 100%;
+        overflow: hidden;
+        background: #0b0f14;
+        color: #d7e6f0;
+        font-family: ui-monospace, 'Consolas', 'Courier New', monospace;
+      }
+      #feed {
+        position: fixed;
+        inset: 0;
+        overflow-y: auto;
+        padding: 14px 16px 40vh;
+        box-sizing: border-box;
+        scrollbar-width: thin;
+        scrollbar-color: rgba(138, 180, 248, 0.4) transparent;
+      }
+      #feed::-webkit-scrollbar {
+        width: 8px;
+      }
+      #feed::-webkit-scrollbar-thumb {
+        background: rgba(138, 180, 248, 0.35);
+        border-radius: 8px;
+      }
+      .row {
+        display: flex;
+        gap: 10px;
+        align-items: flex-start;
+        padding: 8px 10px;
+        border-bottom: 1px solid rgba(138, 180, 248, 0.08);
+      }
+      .row:hover {
+        background: rgba(138, 180, 248, 0.06);
+      }
+      .sev {
+        flex: 0 0 auto;
+        align-self: flex-start;
+        min-width: 64px;
+        padding: 2px 8px;
+        border-radius: 6px;
+        text-align: center;
+        font-family: system-ui, 'Segoe UI', Roboto, sans-serif;
+        font-size: 11px;
+        font-weight: 700;
+        letter-spacing: 0.3px;
+        color: #0b0f14;
+      }
+      .body {
+        flex: 1;
+        min-width: 0;
+      }
+      .subj {
+        font-family: system-ui, 'Segoe UI', Roboto, sans-serif;
+        font-size: 14px;
+        line-height: 1.35;
+        color: #e7eef6;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .meta {
+        margin-top: 2px;
+        font-size: 12px;
+        color: #7f9bb6;
+      }
+      .meta .id {
+        color: #8ab4f8;
+        text-decoration: none;
+      }
+      .meta .id:hover {
+        text-decoration: underline;
+      }
+      .note {
+        padding: 14px 10px;
+        text-align: center;
+        font-size: 13px;
+        color: #9bb0c4;
+      }
+      /* Brand pill, opposite corner from the host's ✦ controls button */
+      .brand {
+        position: fixed;
+        left: 16px;
+        bottom: 16px;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 6px 10px;
+        border-radius: 999px;
+        font-size: 12px;
+        color: #c7d6e6;
+        background: rgba(11, 15, 20, 0.7);
+        border: 1px solid rgba(138, 180, 248, 0.18);
+        pointer-events: none;
+      }
+      .brand .dots {
+        display: inline-flex;
+        gap: 3px;
+      }
+      .brand .dots i {
+        display: inline-block;
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="feed" aria-label="Latest GitHub security advisories">
+      <div class="note" id="note">Loading GitHub security advisories…</div>
+      <div id="sentinel"></div>
+    </div>
+    <div class="brand" aria-hidden="true">
+      <span class="dots"
+        ><i style="background: #f85149"></i><i style="background: #f0883e"></i
+        ><i style="background: #e3b341"></i><i style="background: #7d8db0"></i
+      ></span>
+      github advisories
+    </div>
+
+    <script>
+      'use strict';
+
+      const feed = document.getElementById('feed');
+      const sentinel = document.getElementById('sentinel');
+      const note = document.getElementById('note');
+
+      // GitHub Global Advisory Database — public (no auth), CORS-enabled,
+      // cookieless. Paginated newest-first via the Link header's cursor.
+      const API =
+        'https://api.github.com/advisories?per_page=100&sort=published&direction=desc';
+      const CAP = 700; // bound the DOM so infinite scroll never grows unbounded
+
+      let nextUrl = API;
+      let loading = false;
+      let paused = false; // set briefly when GitHub rate-limits us
+
+      // Only ever render https URLs the API hands us — never trust a scheme.
+      function safeUrl(u) {
+        return typeof u === 'string' && /^https:\/\//i.test(u) ? u : null;
+      }
+
+      // Severity -> badge label + colour.
+      function sevInfo(severity) {
+        switch (String(severity || '').toLowerCase()) {
+          case 'critical':
+            return {label: 'CRITICAL', color: '#f85149'};
+          case 'high':
+            return {label: 'HIGH', color: '#f0883e'};
+          case 'medium':
+          case 'moderate':
+            return {label: 'MEDIUM', color: '#e3b341'};
+          case 'low':
+            return {label: 'LOW', color: '#7d8db0'};
+          default:
+            return {label: 'UNKNOWN', color: '#6e7681'};
+        }
+      }
+
+      // Pull the rel="next" cursor URL out of a Link header.
+      function nextLink(header) {
+        if (!header) return null;
+        const m = header.match(/<([^>]+)>;\s*rel="next"/);
+        return m ? m[1] : null;
+      }
+
+      // Compact "3m / 4h / 2d ago" relative time.
+      function ago(iso) {
+        const t = new Date(iso).getTime();
+        if (!isFinite(t)) return '';
+        const s = Math.max(0, (Date.now() - t) / 1000);
+        const units = [
+          [31536000, 'y'],
+          [2592000, 'mo'],
+          [604800, 'w'],
+          [86400, 'd'],
+          [3600, 'h'],
+          [60, 'm']
+        ];
+        for (const [secs, label] of units) {
+          if (s >= secs) return Math.floor(s / secs) + label + ' ago';
+        }
+        return 'just now';
+      }
+
+      // Build an advisory row entirely from DOM nodes — no innerHTML, so the
+      // feed is XSS-proof and runs unchanged under a Trusted-Types policy.
+      function renderRow(a) {
+        const row = document.createElement('div');
+        row.className = 'row';
+
+        const sev = sevInfo(a.severity);
+        const pill = document.createElement('span');
+        pill.className = 'sev';
+        pill.style.background = sev.color;
+        pill.textContent = sev.label;
+        row.appendChild(pill);
+
+        const body = document.createElement('div');
+        body.className = 'body';
+
+        const summary = a.summary || '(no summary)';
+        const subj = document.createElement('div');
+        subj.className = 'subj';
+        subj.textContent = summary;
+        subj.title = summary;
+        body.appendChild(subj);
+
+        const meta = document.createElement('div');
+        meta.className = 'meta';
+        const idText = a.cve_id || a.ghsa_id || '';
+        const link = safeUrl(a.html_url);
+        if (idText && link) {
+          const el = document.createElement('a');
+          el.className = 'id';
+          el.href = link;
+          el.target = '_blank';
+          el.rel = 'noreferrer noopener';
+          el.textContent = idText;
+          meta.appendChild(el);
+        } else if (idText) {
+          const el = document.createElement('span');
+          el.className = 'id';
+          el.textContent = idText;
+          meta.appendChild(el);
+        }
+
+        const bits = [];
+        const vulns = Array.isArray(a.vulnerabilities) ? a.vulnerabilities : [];
+        const pkg = vulns[0] && vulns[0].package;
+        if (pkg && pkg.name) {
+          let label = (pkg.ecosystem ? pkg.ecosystem + ': ' : '') + pkg.name;
+          if (vulns.length > 1) label += ' (+' + (vulns.length - 1) + ')';
+          bits.push(label);
+        }
+        if (a.cvss && typeof a.cvss.score === 'number' && a.cvss.score > 0)
+          bits.push('CVSS ' + a.cvss.score);
+        if (a.published_at) bits.push(ago(a.published_at));
+        if (bits.length)
+          meta.appendChild(
+            document.createTextNode((idText ? '  ·  ' : '') + bits.join('  ·  '))
+          );
+
+        body.appendChild(meta);
+        row.appendChild(body);
+        feed.insertBefore(row, sentinel);
+      }
+
+      // Keep the DOM bounded: drop rows off the top and hold the scroll
+      // position steady so the stream stays continuous.
+      function trim() {
+        let rows = feed.querySelectorAll('.row');
+        while (rows.length > CAP) {
+          const first = rows[0];
+          const h = first.getBoundingClientRect().height;
+          first.remove();
+          feed.scrollTop = Math.max(0, feed.scrollTop - h);
+          rows = feed.querySelectorAll('.row');
+        }
+      }
+
+      async function loadMore() {
+        if (loading || paused || !nextUrl) return;
+        loading = true;
+        try {
+          const r = await fetch(nextUrl, {credentials: 'omit'});
+          if (r.status === 403 || r.status === 429) {
+            note.textContent = 'GitHub rate limit reached — resuming shortly…';
+            note.style.display = '';
+            paused = true;
+            setTimeout(() => {
+              paused = false;
+            }, 60000);
+            return;
+          }
+          const data = await r.json();
+          if (!Array.isArray(data) || data.length === 0) {
+            nextUrl = null;
+            return;
+          }
+          data.forEach(renderRow);
+          nextUrl = nextLink(r.headers.get('Link'));
+          note.style.display = 'none';
+          trim();
+        } catch (e) {
+          note.textContent = 'Could not reach GitHub.';
+          note.style.display = '';
+        } finally {
+          loading = false;
+        }
+      }
+
+      // Load more as the bottom approaches.
+      new IntersectionObserver(
+        (entries) => {
+          if (entries.some((e) => e.isIntersecting)) loadMore();
+        },
+        {root: feed, rootMargin: '800px'}
+      ).observe(sentinel);
+
+      loadMore();
+
+      // Gentle auto-scroll so it lives as a wallpaper; pauses while you read it
+      // (controls shown) or when the tab is hidden.
+      let shown = false;
+      function frame() {
+        if (!shown && !document.hidden) {
+          feed.scrollTop += 0.4;
+          if (feed.scrollTop + feed.clientHeight >= feed.scrollHeight - 1)
+            feed.scrollTop = 0;
+        }
+        requestAnimationFrame(frame);
+      }
+      requestAnimationFrame(frame);
+
+      // ---------- Host bridge (shaderwall protocol) ----------
+      function setShown(value) {
+        shown = value;
+        window.parent.postMessage(
+          {type: 'shaderwall', state: shown ? 'shown' : 'hidden'},
+          location.origin
+        );
+      }
+      addEventListener('message', (e) => {
+        if (e.origin != location.origin) return;
+        const d = e.data || {};
+        if (d.type !== 'shaderwall') return;
+        if (d.action === 'show') setShown(true);
+        else if (d.action === 'hide') setShown(false);
+        else if (d.action === 'toggle') setShown(!shown);
+      });
+      addEventListener('keydown', (e) => {
+        if (e.key === 'h' || e.key === 'H') setShown(!shown);
+      });
+      setShown(false);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
A dark, infinite-scrolling wallpaper streaming the GitHub Global Advisory Database (api.github.com/advisories) — public, CORS-enabled, cookieless, same proven infra as the Chromium feed. Each row shows a severity badge (critical/high/medium/low), the summary, the GHSA/CVE id linking to the advisory, the affected ecosystem:package, CVSS score and published time.

Paginates newest-first via the Link header's rel="next" cursor and backs off on 403/429 rate limits. Rows are built from DOM nodes (no innerHTML), so the feed is XSS-proof and Trusted-Types ready; the DOM is capped for bounded memory with a gentle auto-scroll that pauses when controls are shown or the tab is hidden. Wired into the dropdown next to Chromium.


Claude-Session: https://claude.ai/code/session_012Y31k2fRGnrx2NzYjmB8MW