### PR TITLE
Improve readability of rainbow-text and Minecraft themes

### DIFF
--- a/themes/mc.css
+++ b/themes/mc.css
@@ -9,11 +9,29 @@
 }
 
 body {
-  background-image: url('/writeups/mc.webp');
+  /* Darken the busy screenshot so white text stays readable. The old
+     backdrop-filter blurred nothing here — a body's own background-image is
+     not its backdrop — so it gave no contrast at all. */
+  background-image:
+    linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)),
+    url('/writeups/mc.webp');
   background-size: cover;
   background-attachment: fixed;
-  backdrop-filter: blur(10px);
   color: white;
+}
+
+/* The signature Minecraft hard drop shadow: authentic and high-contrast over
+   any tile. Inherited across the content, then cleared on the light code
+   blocks where a dark shadow would only muddy things. */
+.markdown-body {
+  text-shadow: 2px 2px 0 #000;
+}
+
+pre,
+code,
+.highlight,
+.highlight * {
+  text-shadow: none;
 }
 
 .highlight {

--- a/themes/rainbow-text.css
+++ b/themes/rainbow-text.css
@@ -15,5 +15,12 @@ h3 {
     violet
   );
   -webkit-background-clip: text;
+  background-clip: text;
   -webkit-text-fill-color: transparent;
+  /* Heavier strokes plus a dark halo keep the light part of the gradient
+     (orange/yellowgreen) legible against the white background. */
+  font-weight: 600;
+  text-shadow:
+    0 0 1px rgba(0, 0, 0, 0.5),
+    0 1px 1px rgba(0, 0, 0, 0.3);
 }


### PR DESCRIPTION
rainbow-text: the orange/yellowgreen middle of the gradient washed out on the white background. Add a semibold weight and a thin dark halo (text-shadow through the transparent fill) so every hue keeps its edges and stays legible.

mc: the backdrop-filter blur was a no-op — a body's own background-image isn't its backdrop — so white text sat on a sharp, bright screenshot. Darken the image with a gradient overlay and add Minecraft's signature hard drop shadow (2px 2px 0 #000), cleared on the light code blocks. Authentic and high-contrast on any tile.

Verified before/after in a local Playwright harness rendering the real theme CSS and assets over sample writeup content.


Claude-Session: https://claude.ai/code/session_012Y31k2fRGnrx2NzYjmB8MW