### PR TITLE
Wallpaper toggle: accessible name + focus visibility

### DIFF
--- a/js/footer.js
+++ b/js/footer.js
@@ -144,15 +144,19 @@ if (theme.endsWith('.html')) {
   var btn = document.createElement('button');
   btn.textContent = '✦';
   btn.title = 'Wallpaper controls';
+  // The visible glyph is just a star; give assistive tech a real name.
+  btn.setAttribute('aria-label', 'Wallpaper controls');
   btn.style.cssText =
     'position:fixed;left:20px;top:20px;width:42px;height:42px;border:0;' +
     'border-radius:13px;cursor:pointer;z-index:2147483647;color:#fff;' +
     'background:rgba(16,16,22,.42);backdrop-filter:blur(18px);' +
     '-webkit-backdrop-filter:blur(18px);font-size:18px;line-height:1;opacity:.5;';
-  btn.onmouseenter = function () {
+  // Surface it on hover or keyboard focus (the browser focus ring stays, since
+  // cssText never clears outline) so it isn't a faint, easy-to-miss glyph.
+  btn.onmouseenter = btn.onfocus = function () {
     btn.style.opacity = '1';
   };
-  btn.onmouseleave = function () {
+  btn.onmouseleave = btn.onblur = function () {
     btn.style.opacity = '.5';
   };
 


### PR DESCRIPTION
The ✦ controls button only had a title and a bare star glyph, so screen readers announced the star. Add an aria-label, and surface the button on keyboard focus the same way it already does on hover (its default focus ring is preserved, since cssText never clears outline).


Claude-Session: https://claude.ai/code/session_012Y31k2fRGnrx2NzYjmB8MW