### PR TITLE
horizon-live: explicit frame decode + badFrames diagnostics

### DIFF
--- a/themes/horizon/server-reference.mjs
+++ b/themes/horizon/server-reference.mjs
@@ -22,6 +22,7 @@
 import {
   createAisState,
   createLimiter,
+  decodeFrame,
   gridKey,
   ingest,
   originCheck,
@@ -103,6 +104,32 @@ const FRAME = (mmsi, lat, lon, over = {}) => ({
     'prune',
     n === 1 && st.ships.size === 1 && st.ships.has(2) && st.grid.size === 1,
     `at t0+103 with 100 ms max age: ship 1 (heard t0+2, age 101) pruned with its cell, ship 2 (t0+3, age exactly 100) kept`
+  );
+}
+
+{
+  // Frame decoding: WebSocket messages arrive as text OR binary.
+  // node's undici delivers binary as Blob by default, whose
+  // String() is "[object Blob]" - a silent zero-frames failure
+  // mode indistinguishable from a dead key. decodeFrame accepts
+  // string/ArrayBuffer/views exactly and THROWS on anything else
+  // (counted as badFrames in /health, never swallowed silently).
+  const json = '{"MessageType":"PositionReport"}';
+  const buf = new TextEncoder().encode(json);
+  let threw = null;
+  try {
+    decodeFrame({});
+  } catch (e) {
+    threw = String(e);
+  }
+  check(
+    'frame decode',
+    decodeFrame(json) === json &&
+      decodeFrame(buf.buffer) === json &&
+      decodeFrame(buf) === json &&
+      threw !== null &&
+      threw.includes('undecodable'),
+    `string passthrough exact; ArrayBuffer and Uint8Array utf8-decode exact; Blob-like object throws (-> badFrames), never a silent parse of "[object Blob]"`
   );
 }
 

--- a/themes/horizon/server/src/index.mjs
+++ b/themes/horizon/server/src/index.mjs
@@ -66,10 +66,24 @@ export function createAisState() {
     ships: new Map(), // mmsi -> normalized ship + {gk, t}
     grid: new Map(), // "lat:lon" 1-degree cell -> Set<mmsi>
     frames: 0,
+    badFrames: 0, // arrived but failed decode/parse - a nonzero
+    // count with zero frames means a WIRE problem, not a key one
     lastFrame: 0,
     connects: 0,
     started: Date.now()
   };
+}
+
+// WebSocket frames arrive as strings (text frames) or binary
+// (ArrayBuffer once binaryType is set - node's undici otherwise
+// defaults to Blob, whose String() is "[object Blob]" and parses
+// as NOTHING; that failure mode is exactly why this helper exists
+// and is gated). Accepts string, ArrayBuffer and views.
+export function decodeFrame(data) {
+  if (typeof data === 'string') return data;
+  if (data instanceof ArrayBuffer) return new TextDecoder().decode(data);
+  if (ArrayBuffer.isView(data)) return new TextDecoder().decode(data);
+  throw new Error('undecodable frame: ' + Object.prototype.toString.call(data));
 }
 
 export function gridKey(lat, lon) {
@@ -290,11 +304,17 @@ function runAisSocket(key, st, log) {
         })
       );
     });
+    try {
+      ws.binaryType = 'arraybuffer'; // never Blob (see decodeFrame)
+    } catch {
+      // runtime without binaryType - decodeFrame handles views
+    }
     ws.addEventListener('message', (ev) => {
       try {
-        ingest(st, JSON.parse(String(ev.data)));
-      } catch {
-        // malformed frame
+        ingest(st, JSON.parse(decodeFrame(ev.data)));
+      } catch (e) {
+        st.badFrames++;
+        if (st.badFrames === 1) log('first bad frame: ' + e);
       }
     });
     ws.addEventListener('close', reopen, {once: true});
@@ -316,7 +336,7 @@ function runAisSocket(key, st, log) {
   // dead upstream (a valid global subscription never goes quiet
   // that long - the world's oceans do not empty).
   setInterval(() => {
-    if (st.connects > 0 && Date.now() - st.lastFrame > 180e3) {
+    if (st.connects > 0 && Date.now() - (st.lastFrame || st.started) > 180e3) {
       log('ais watchdog: no frames for 180 s - cycling the socket');
       try {
         ws.close();
@@ -386,9 +406,11 @@ function main() {
         ships: st.ships.size,
         cells: st.grid.size,
         frames: st.frames,
+        badFrames: st.badFrames,
         lastFrameAgoMs: st.lastFrame ? Date.now() - st.lastFrame : null,
         connects: st.connects,
-        uptimeMs: Date.now() - st.started
+        uptimeMs: Date.now() - st.started,
+        keySet: !!env.AISSTREAM_KEY
       };
       if (url.pathname === '/health')
         return json(200, {ais}, {'cache-control': 'no-store'});


### PR DESCRIPTION
"ships":0 on the deployed box with the key set has three possible causes and /health could only see two. The hidden one was OURS: node's undici WebSocket delivers BINARY frames as Blob by default (the Cloudflare runtime hands ArrayBuffer - which is why the worker never hit this), and JSON.parse(String(blob)) throws on "[object Blob]" into a silent catch - frames stuck at zero, indistinguishable from a dead key.

- decodeFrame(): exported + gated - string passthrough, ArrayBuffer/view utf8 decode, anything else THROWS
- binaryType = 'arraybuffer' set on the socket
- badFrames counter in /health (nonzero with zero frames = wire problem, not key problem) + first bad frame logged
- keySet in /health; watchdog no longer cycles a young socket that has not yet seen its first frame

/health now separates the cases cleanly: frames climbing = all good; frames 0 + badFrames 0 after a minute = the key is wrong; badFrames climbing = decode regression, with the reason in the journal. Gate set 20 grows to 6 landmarks; 20/20 pass.


Claude-Session: https://claude.ai/code/session_01NKKBen9kkD562HDVr7cXAx