### PR TITLE
Theme: live data defaults switch to api.ndev.tk (horizon-live)

### DIFF
--- a/themes/Horizon.html
+++ b/themes/Horizon.html
@@ -2069,16 +2069,17 @@
         p.mesh.visible = true;
       }
 
-      // Live aircraft: the horizon-adsb Cloudflare worker
-      // (themes/horizon/worker) adds the CORS header no public
-      // ADS-B feed provides, proxying adsb.lol near the visitor.
-      // Cruise traffic claims contrail slots with its REAL
-      // position, altitude, track and speed; Schmidt-Appleman still
-      // decides whether the trail exists. Unreachable worker (not
-      // deployed yet, offline harness): the ambient traffic above
-      // stands in. ?adsb=URL overrides the proxy.
-      const ADSB_PROXY =
-        params.get('adsb') ?? 'https://horizon-adsb.ndevtk.workers.dev/adsb';
+      // Live aircraft: the horizon-live daemon (themes/horizon/
+      // server, on the owner's dedicated-IP box) proxies the
+      // readsb feeds no browser can reach - measured from its own
+      // IP: adsb.lol answers first, the rich feed Cloudflare
+      // egress never got. Cruise traffic claims contrail slots
+      // with its REAL position, altitude, track and speed;
+      // Schmidt-Appleman still decides whether the trail exists.
+      // Unreachable daemon (offline harness): the ambient traffic
+      // above stands in. ?adsb=URL overrides (e.g. the retired
+      // horizon-adsb worker, kept as documented fallback).
+      const ADSB_PROXY = params.get('adsb') ?? 'https://api.ndev.tk/adsb';
       let liveTraffic = null; // queue of unclaimed cruise snapshots
       const seenFlights = new Map(); // hex -> last spawn ms
       async function syncTraffic() {
@@ -2138,11 +2139,12 @@
         }
       }
 
-      // ---- Live ships: AIS via the same worker (/ais route).
-      // aisstream.io position reports around the visitor; the API
-      // key lives ONLY in the worker (aisstream's terms forbid
-      // exposing it to a browser, which a static site could never
-      // honour). Ships dead-reckon on the tide-following water
+      // ---- Live ships: AIS via the same daemon (/ais route).
+      // horizon-live holds ONE persistent global aisstream.io
+      // subscription (the API key lives only on the box -
+      // aisstream's terms forbid exposing it to a browser) and
+      // answers from its in-RAM picture: ~23k vessels resident
+      // when first deployed. Ships dead-reckon on the tide-following water
       // plane between reports and carry COLREGS navigation lights
       // after sunset (ships.js: Rule 21 arcs, Rule 22 ranges,
       // Annex I candela through Allard's law - beyond a light's
@@ -2153,8 +2155,7 @@
       // the lights and kinematics are the physics. ?ais=URL
       // overrides the proxy; ?ship=N spawns N deterministic
       // synthetic vessels for the offline harness.
-      const AIS_PROXY =
-        params.get('ais') ?? 'https://horizon-adsb.ndevtk.workers.dev/ais';
+      const AIS_PROXY = params.get('ais') ?? 'https://api.ndev.tk/ais';
       const SHIP_N = 8;
       const SHIP_LOA = 90 / 57.14; // scene units (90 m)
       const NAV_COLOR = {

--- a/themes/horizon/WEBGPU-PLAN.md
+++ b/themes/horizon/WEBGPU-PLAN.md
@@ -1549,11 +1549,24 @@ Scenes (all at Grindelwald unless noted):
       deliberately a few KB). Optional: Cloudflare orange-cloud
       in FRONT for inbound shielding while outbound keeps the
       clean IP - the best of both measured worlds.
-    - After the box exists: /probe from ITS IP decides upstream
-      order (and whether OpenSky rejoins); theme tested via
-      ?ais=/?adsb= overrides, then ADSB_PROXY/AIS_PROXY defaults
-      switch in Horizon.html and the worker retires or stays as
-      documented fallback.
+    - DEPLOYED at https://api.ndev.tk (GCP box behind
+      Cloudflare orange-cloud with an Origin CA cert, Full
+      strict - the 525 on first try was the Caddy-ACME
+      chicken-and-egg, solved exactly that way). Measured from
+      ITS IP via /probe: control 200, opensky-api 200/683 ms
+      (OpenSky IS back on a dedicated IP), adsb.lol 200 (serving
+      /adsb first, 10 aircraft over Heathrow), adsb.fi 200,
+      airplanes.live 200 - EVERYTHING answers; the shared-egress
+      thesis fully confirmed. /health on first full deploy:
+      23,344 ships resident in 917 grid cells, ~104 frames/s,
+      badFrames 0 (the ships:0 mystery was OUR Blob bug, fixed
+      and gated - the owner's key was fine all along); Dover
+      Strait answered with named vessels (ZIM VIETNAM 14.5 kt
+      hdg 017, GAS NOBLE, NAVIGATOR LUNA...). Origin lock holds
+      through Cloudflare: foreign origin 403, site origin exact
+      echo. ADSB_PROXY/AIS_PROXY defaults in Horizon.html now
+      point at api.ndev.tk; the horizon-adsb worker stays
+      deployed as documented fallback (?adsb=/?ais= overrides).
   - OPEN (environment, not code): today's fixture rig drops the
     volumetric cloud decks and spams "2D view of 3D texture" Dawn
     validation errors from the Nubis noise volumes - bisect-shot


### PR DESCRIPTION
The daemon is deployed and measured healthy end to end:
- /health: 23,344 ships resident in 917 grid cells, ~104 frames/s, badFrames 0 - the ships:0 mystery was the Blob decode bug (fixed last commit); the owner's key was fine
- /probe from the box's own IP: control, opensky-api (683 ms!), adsb.lol, adsb.fi, airplanes.live ALL answer 200 - the shared-egress thesis fully confirmed, OpenSky is reachable again on a dedicated IP
- /adsb serves adsb.lol (the rich feed) - 10 aircraft over Heathrow; /ais answers the Dover Strait with named vessels (ZIM VIETNAM 14.5 kt hdg 017, GAS NOBLE, NAVIGATOR LUNA)
- origin lock holds through Cloudflare: foreign origin 403, site origin exact CORS echo

ADSB_PROXY and AIS_PROXY defaults now point at api.ndev.tk; ?adsb=/?ais= overrides remain (the horizon-adsb worker stays as documented fallback). Plan updated with the measured deploy record. 20/20 reference sets pass.


Claude-Session: https://claude.ai/code/session_01NKKBen9kkD562HDVr7cXAx