### PR TITLE
Lightning: Blitzortung strikes flash on the horizon (SSE push)

### DIFF
--- a/themes/Horizon.html
+++ b/themes/Horizon.html
@@ -190,7 +190,8 @@
         createPrecipSprites,
         createZodiacalMaterial,
         createMeteorMaterial,
-        createContrailMaterial
+        createContrailMaterial,
+        createFlashMaterial
       } from './horizon/sky-objects-tsl.js';
       import {adsbToScene, appleman} from './horizon/contrails.js';
       import {
@@ -202,6 +203,12 @@
         relBearing,
         SUNSET_ELEV
       } from './horizon/ships.js';
+      import {
+        apparentFlash,
+        flashAmplitude,
+        strikeBearing,
+        strokeSequence
+      } from './horizon/lightning.js';
       import {lineStrengths} from './horizon/airglow.js';
       import {fR, ZL_OMEGA} from './horizon/zodiacal.js';
       import {
@@ -2320,6 +2327,113 @@
           // worker unreachable - the sea keeps its last ships
         }
       }
+
+      // ---- Live lightning: Blitzortung.org via the daemon's SSE
+      // stream (/lightning/stream - origin-scoped server-side:
+      // EventSource bypasses CORS, so the daemon's Origin
+      // allowlist IS the protection). Each pushed strike becomes
+      // a flash whose FLICKER IS THE PHYSICS (lightning.js): a
+      // Rakov-Uman stroke sequence - 15-20% single-stroke, mean
+      // multiplicity 3-5, ~60 ms interstroke intervals,
+      // continuing-current plateaus - viewed through Koschmieder
+      // extinction and the inverse square at the strike's true
+      // great-circle distance, hung at its true bearing. The glow
+      // quad itself is the documented display shape; the timing
+      // and brightness are measured + published physics. Data CC
+      // BY-SA Blitzortung.org (credited in the provenance panel).
+      // ?lightning=URL overrides the endpoint; ?strike=N spawns
+      // deterministic synthetic flashes for the offline harness.
+      const LIGHTNING_PROXY =
+        params.get('lightning') ?? 'https://api.ndev.tk/lightning';
+      const FLASH_N = 5;
+      const flashPool = [];
+      for (let i = 0; i < FLASH_N; i++) {
+        const fm = createFlashMaterial();
+        const mesh = new THREE.Mesh(
+          new THREE.PlaneGeometry(90, 55),
+          fm.material
+        );
+        mesh.visible = false;
+        scene.add(mesh);
+        flashPool.push({
+          mesh,
+          u: fm.u,
+          active: false,
+          t: 0,
+          seq: null,
+          amp0: 0
+        });
+      }
+      let strikeCount = 0;
+      function spawnFlash(azDeg, distKm, rands) {
+        const p = flashPool.find((f) => !f.active) ?? flashPool[0];
+        p.seq = strokeSequence(rands);
+        p.amp0 = Math.min(apparentFlash(distKm), 4);
+        p.t = 0;
+        p.active = true;
+        const az = azDeg * RAD;
+        const R = 235;
+        p.mesh.position.set(
+          camera.position.x + Math.sin(az) * R,
+          38,
+          camera.position.z - Math.cos(az) * R
+        );
+        const s = THREE.MathUtils.clamp(60 / Math.max(distKm, 10), 0.5, 2.5);
+        p.mesh.scale.set(s, s, 1);
+        p.mesh.lookAt(camera.position);
+        p.mesh.visible = true;
+        strikeCount++;
+      }
+      const strikeOv = params.has('strike') ? +params.get('strike') : null;
+      if (strikeOv !== null) {
+        // Offline harness: deterministic flashes in the camera
+        // cone on a fixed cadence (fixed uniform table - no
+        // Math.random, pinned shots stay reproducible).
+        const RANDS = [
+          0.31, 0.62, 0.08, 0.77, 0.45, 0.91, 0.19, 0.54, 0.36, 0.83, 0.27, 0.7,
+          0.12, 0.6, 0.48, 0.95
+        ];
+        let k = 0;
+        setInterval(() => {
+          if (k >= strikeOv && strikeOv > 0) k = 0;
+          camera.getWorldDirection(mFlashDir);
+          const az =
+            (Math.atan2(mFlashDir.x, -mFlashDir.z) / RAD +
+              (((k * 37) % 60) - 30) +
+              360) %
+            360;
+          spawnFlash(az, 12 + ((k * 23) % 60), RANDS.slice(k % 8));
+          k++;
+        }, 1700);
+      } else if (typeof EventSource !== 'undefined') {
+        const src = () =>
+          LIGHTNING_PROXY +
+          '/stream?lat=' +
+          state.lat.toFixed(3) +
+          '&lon=' +
+          state.lon.toFixed(3) +
+          '&km=200';
+        const es = new EventSource(src());
+        es.onmessage = (ev) => {
+          try {
+            const s = JSON.parse(ev.data);
+            const az = strikeBearing({lat: state.lat, lon: state.lon}, s);
+            spawnFlash(
+              az,
+              s.km,
+              Array.from({length: 12}, () => Math.random())
+            );
+            record(
+              'Blitzortung.org lightning (CC BY-SA)',
+              strikeCount + ' strikes streamed · nearest ' + s.km + ' km'
+            );
+          } catch {
+            // heartbeat or malformed event
+          }
+        };
+        // EventSource reconnects itself; nothing else to manage.
+      }
+      const mFlashDir = new THREE.Vector3();
       const mV1 = new THREE.Vector3();
       const mV2 = new THREE.Vector3();
       const mV3 = new THREE.Vector3();
@@ -3426,6 +3540,21 @@
                   .multiplyScalar(0.4 + 3.6 * amp);
             }
           }
+        }
+        // Lightning: advance each live flash along its Rakov-Uman
+        // stroke sequence - the 60 Hz frame cadence resolves the
+        // ~60 ms interstroke flicker and the continuing-current
+        // glow directly; amp0 already carries Koschmieder + 1/d^2.
+        for (const p of flashPool) {
+          if (!p.active) continue;
+          p.t += dt;
+          if (p.t > p.seq.dur) {
+            p.active = false;
+            p.mesh.visible = false;
+            p.u.amp.value = 0;
+            continue;
+          }
+          p.u.amp.value = flashAmplitude(p.seq, p.t) * p.amp0 * 2.2;
         }
         if (constMat) constMat.opacity = nightSky * (1 - cloudy * 0.9) * 0.2;
         // Venus and Jupiter pierce twilight a little before the stars.

--- a/themes/horizon/WEBGPU-PLAN.md
+++ b/themes/horizon/WEBGPU-PLAN.md
@@ -1567,6 +1567,49 @@ Scenes (all at Grindelwald unless noted):
       echo. ADSB_PROXY/AIS_PROXY defaults in Horizon.html now
       point at api.ndev.tk; the horizon-adsb worker stays
       deployed as documented fallback (?adsb=/?ais= overrides).
+  - DONE (live end-to-end): real-time lightning - Blitzortung.org
+    strikes flash on the horizon, the item the worker era had to
+    shelve because it needs a PERSISTENT socket. First use of the
+    daemon's client-facing push, and the owner asked the right
+    question at the right moment: EventSource/WebSocket BYPASS
+    CORS, so client streams are origin-scoped server-side - the
+    daemon's global Origin allowlist gate 403s foreign origins
+    before a stream opens (verified live), and that check is the
+    ONLY origin protection such endpoints can have.
+    - Feed: Blitzortung's community sockets (ws1/ws7/ws8,
+      subscribe {"a":111}), wire format LZW-compressed JSON -
+      protocol verified LIVE before a line was written (Florida
+      storm strikes decoded on first connect). The daemon's
+      decoder is gated by round-trip against a spec-built encoder
+      INCLUDING the KwKwK corner case; strikes land in the same
+      1-degree grid pattern as ships (ns -> ms time base, 15 min
+      retention), queried by EXACT haversine after a cell
+      prefilter. /lightning snapshot + /lightning/stream SSE
+      (25-s heartbeats, 30-min lifetime, SSE_MAX cap). Live
+      check: 106 strikes resident 12 s after boot; the Orlando
+      storm streamed 18 strikes in a 20 s listen window with
+      exact ranges. Data CC BY-SA, credited in the provenance
+      panel.
+    - Physics (lightning.js, gate set 21 - 5 landmarks): Rakov &
+      Uman 2003 flash structure - 15-20% single-stroke, mean
+      multiplicity 3-5 (median 3), ~60 ms geometric-mean
+      interstroke intervals, subsequent strokes ~0.4 of the
+      first, continuing current in 30-50% of flashes (20k-draw
+      statistics all inside the published bands); Koschmieder
+      T = exp(-3.912 d/V) with the exact-2%-at-V landmark;
+      haversine on the IUGG mean radius (equatorial degree
+      111.1949 km exact); apparent brightness T/d^2.
+    - Theme: SSE strikes become flash events whose FLICKER IS THE
+      PHYSICS - the 60 Hz frame loop evaluates the stroke
+      sequence directly (the ~60 ms restrikes and continuing-
+      current glow are frame-resolvable), amplitude carries
+      Koschmieder + inverse-square at the true distance, the glow
+      quad hangs at the true bearing (createFlashMaterial - the
+      radial shape is the one documented display element).
+      ?strike=N spawns deterministic synthetic flashes (fixed
+      uniform table, camera-cone azimuths) for pinned shots;
+      ?lightning=URL overrides the endpoint. EventSource
+      reconnects itself.
   - OPEN (environment, not code): today's fixture rig drops the
     volumetric cloud decks and spams "2D view of 3D texture" Dawn
     validation errors from the Nubis noise volumes - bisect-shot

--- a/themes/horizon/harness/validate.sh
+++ b/themes/horizon/harness/validate.sh
@@ -24,7 +24,7 @@ REFDIR=${REFDIR:-..} # where the *-reference.mjs live
 fail=0
 
 echo "== CPU references (double precision, ground truth) =="
-for name in ocean atmo moon optics surf glint aurora leadr radar igrf scintillation ross-li cn2 airglow zodiacal meteors contrails ships worker server; do
+for name in ocean atmo moon optics surf glint aurora leadr radar igrf scintillation ross-li cn2 airglow zodiacal meteors contrails ships lightning worker server; do
   ref="$REFDIR/$name-reference.mjs"
   if [ ! -f "$ref" ]; then echo "[FAIL] $name-reference.mjs missing"; fail=1; continue; fi
   if out=$(node "$ref" 2>&1); then

--- a/themes/horizon/lightning-reference.mjs
+++ b/themes/horizon/lightning-reference.mjs
@@ -1,0 +1,153 @@
+// Reference printer for the lightning model (node
+// lightning-reference.mjs). The model lives once in lightning.js;
+// landmarks against Rakov & Uman (2003) climatology and exact
+// geometry:
+//  - haversine: 1 degree of longitude on the equator is exactly
+//    2 pi R / 360 = 111.1949 km; the antipodal distance is pi R
+//  - Koschmieder: transmission at d = V is exp(-3.912) = 0.0200
+//    EXACTLY - the 2% contrast threshold that DEFINES visibility
+//  - flash statistics over 20k seeded draws: single-stroke
+//    fraction 15-20%, mean multiplicity 3-5 (median 3),
+//    interstroke geometric mean near 60 ms, subsequent strokes
+//    ~0.4 of the first, continuing current in 30-50% of flashes
+//  - flashAmplitude peaks AT the strokes, is zero before the
+//    flash, and holds the continuing-current plateau between them
+//  - bearing: a strike due east of the observer is at 90 deg
+import {
+  apparentFlash,
+  CC_FRACTION,
+  flashAmplitude,
+  haversineKm,
+  KOSCHMIEDER,
+  R_EARTH,
+  strikeBearing,
+  strokeSequence,
+  transmission
+} from './lightning.js';
+
+let fail = 0;
+const check = (name, ok, detail) => {
+  console.log(`${ok ? 'REF' : 'FAIL'} ${name}: ${detail}`);
+  if (!ok) fail++;
+};
+
+{
+  const oneDeg = haversineKm(0, 0, 0, 1);
+  const exact = (2 * Math.PI * R_EARTH) / 360;
+  const anti = haversineKm(0, 0, 0, 180);
+  check(
+    'haversine',
+    Math.abs(oneDeg - exact) < 1e-9 &&
+      Math.abs(anti - Math.PI * R_EARTH) < 1e-6,
+    `1 deg equatorial lon = ${oneDeg.toFixed(4)} km (2 pi R/360 = ${exact.toFixed(4)}); antipodal = pi R exactly`
+  );
+}
+
+{
+  const t = transmission(25, 25);
+  const near = apparentFlash(10);
+  const far = apparentFlash(100);
+  check(
+    'Koschmieder',
+    Math.abs(t - Math.exp(-KOSCHMIEDER)) < 1e-15 &&
+      Math.abs(t - 0.02) < 2e-4 &&
+      near === 1 &&
+      far < 0.01 * near,
+    `T(d=V) = ${t.toFixed(5)} (exp(-3.912), the 2% contrast definition); flash at 10 km = 1 by construction, at 100 km ${(far / near).toExponential(2)} of it`
+  );
+}
+
+{
+  // Seeded LCG - the generator consumes explicit uniforms.
+  let s = 12345;
+  const lcg = () => (s = (s * 1103515245 + 12345) % 2147483648) / 2147483648;
+  const draw = () => Array.from({length: 64}, lcg);
+  const N = 20000;
+  let singles = 0;
+  let totalStrokes = 0;
+  let cc = 0;
+  let logIvl = 0;
+  let nIvl = 0;
+  let subRatios = [];
+  const counts = [];
+  for (let i = 0; i < N; i++) {
+    const q = strokeSequence(draw());
+    counts.push(q.strokes.length);
+    totalStrokes += q.strokes.length;
+    if (q.strokes.length === 1) singles++;
+    if (q.cc) cc++;
+    for (let k = 1; k < q.strokes.length; k++) {
+      logIvl += Math.log((q.strokes[k].t - q.strokes[k - 1].t) * 1000);
+      nIvl++;
+      subRatios.push(q.strokes[k].amp);
+    }
+  }
+  counts.sort((a, b) => a - b);
+  subRatios.sort((a, b) => a - b);
+  const mean = totalStrokes / N;
+  const median = counts[N / 2];
+  const gmIvl = Math.exp(logIvl / nIvl);
+  const medSub = subRatios[Math.floor(subRatios.length / 2)];
+  check(
+    'Rakov-Uman statistics',
+    singles / N > 0.14 &&
+      singles / N < 0.2 &&
+      mean > 3 &&
+      mean < 5 &&
+      median === 3 &&
+      gmIvl > 50 &&
+      gmIvl < 72 &&
+      medSub > 0.34 &&
+      medSub < 0.46 &&
+      cc / N > 0.3 &&
+      cc / N < 0.5 &&
+      Math.abs(cc / N - CC_FRACTION) < 0.02,
+    `20k flashes: single-stroke ${((singles / N) * 100).toFixed(1)}% (15-20); mean multiplicity ${mean.toFixed(2)} (3-5), median ${median}; interstroke geometric mean ${gmIvl.toFixed(1)} ms (~60); subsequent/first median ${medSub.toFixed(2)} (~0.4); continuing current ${((cc / N) * 100).toFixed(1)}% (30-50)`
+  );
+}
+
+{
+  // Shape: zero before the flash, peak AT each stroke, plateau
+  // during continuing current.
+  const seq = {
+    strokes: [
+      {t: 0, amp: 1},
+      {t: 0.06, amp: 0.4}
+    ],
+    cc: {t0: 0.06, dur: 0.1, amp: 0.12},
+    dur: 0.21
+  };
+  const before = flashAmplitude(seq, -0.001);
+  const p1 = flashAmplitude(seq, 0);
+  const between = flashAmplitude(seq, 0.04);
+  const p2 = flashAmplitude(seq, 0.06);
+  const plateau = flashAmplitude(seq, 0.12);
+  check(
+    'flash amplitude',
+    before === 0 &&
+      Math.abs(p1 - 1) < 1e-12 &&
+      between < 0.01 &&
+      p2 > 0.5 &&
+      Math.abs(plateau - 0.12) < 0.01,
+    `0 before; 1.000 at first stroke; ${between.toFixed(4)} mid-gap; ${p2.toFixed(2)} at the restrike; continuing-current plateau ${plateau.toFixed(3)} (0.12)`
+  );
+}
+
+{
+  const east = strikeBearing({lat: 46.6, lon: 8.0}, {lat: 46.6, lon: 8.5});
+  const north = strikeBearing({lat: 46.6, lon: 8.0}, {lat: 47.0, lon: 8.0});
+  const sw = strikeBearing({lat: 46.6, lon: 8.0}, {lat: 46.2, lon: 7.5});
+  check(
+    'strike bearing',
+    Math.abs(east - 90) < 1e-9 &&
+      Math.abs(north - 0) < 1e-9 &&
+      sw > 180 &&
+      sw < 270,
+    `due east -> ${east.toFixed(1)} deg, due north -> ${north.toFixed(1)}, southwest quadrant -> ${sw.toFixed(1)}`
+  );
+}
+
+if (fail) {
+  console.log(`${fail} LANDMARK(S) FAILED`);
+  process.exit(1);
+}

--- a/themes/horizon/lightning.js
+++ b/themes/horizon/lightning.js
@@ -1,0 +1,138 @@
+/**
+ * Lightning - the single source shared by the theme's flash
+ * system (Horizon.html), the horizon-live daemon (server/src -
+ * imports the geometry helpers) and the reference printer
+ * (lightning-reference.mjs).
+ *
+ * The strikes are MEASURED: Blitzortung.org's community lightning
+ * location network, streamed over the daemon's persistent
+ * WebSocket (protocol verified live: LZW-compressed JSON state
+ * frames, each strike located by dozens of volunteer stations;
+ * data CC BY-SA, credited in the provenance panel). What this
+ * module owns is the PHYSICS of seeing a flash:
+ *
+ * Flash structure - Rakov & Uman, "Lightning: Physics and
+ * Effects" (Cambridge, 2003), the standard reference:
+ *  - a negative cloud-to-ground FLASH is a sequence of return
+ *    strokes: 15-20% are single-stroke; the rest carry 2..~15
+ *    strokes with an overall mean of 3-5 (Berger's Monte San
+ *    Salvatore climatology: ~3.5)
+ *  - interstroke intervals have a geometric mean near 60 ms
+ *  - subsequent strokes carry roughly 12 kA median peak current
+ *    vs ~30 kA for the first: optically ~0.4 of the first (peak
+ *    light output tracks peak current near-linearly)
+ *  - 30-50% of flashes contain a CONTINUING CURRENT phase tens
+ *    to ~250 ms long - the steady glow between the flickers
+ * The stroke sequence generator consumes an EXPLICIT uniform
+ * stream (no Math.random - deterministic under the pin harness)
+ * and the flash amplitude at any instant is a sum of per-stroke
+ * exponential decays plus the continuing-current plateau.
+ *
+ * Sight line - Koschmieder's law: atmospheric transmission over
+ * distance d with meteorological visibility V is
+ *   T = exp(-3.912 d / V)
+ * (3.912 = -ln(0.02): visibility is DEFINED as the range where
+ * contrast falls to 2%). Apparent flash brightness then falls as
+ * T / d^2. Distances are great-circle (haversine, mean Earth
+ * radius 6371.0088 km); the strike's scene azimuth comes from
+ * the same equirectangular frame every other layer uses.
+ */
+
+// Mean Earth radius, km (IUGG).
+export const R_EARTH = 6371.0088;
+
+// Koschmieder's constant: -ln(0.02).
+export const KOSCHMIEDER = 3.912;
+
+// Great-circle distance, km.
+export function haversineKm(lat1, lon1, lat2, lon2) {
+  const r = Math.PI / 180;
+  const sLat = Math.sin(((lat2 - lat1) * r) / 2);
+  const sLon = Math.sin(((lon2 - lon1) * r) / 2);
+  const a = sLat * sLat + Math.cos(lat1 * r) * Math.cos(lat2 * r) * sLon * sLon;
+  return 2 * R_EARTH * Math.asin(Math.min(Math.sqrt(a), 1));
+}
+
+// Atmospheric transmission over d km at visibility V km.
+export function transmission(dKm, visKm = 25) {
+  return Math.exp((-KOSCHMIEDER * dKm) / visKm);
+}
+
+// Relative apparent brightness of a flash at distance d:
+// inverse-square with Koschmieder extinction, normalized so
+// d = 10 km, V = 25 km gives 1 (a nearby storm).
+export function apparentFlash(dKm, visKm = 25) {
+  const d = Math.max(dKm, 1);
+  return (100 / (d * d)) * (transmission(d, visKm) / transmission(10, visKm));
+}
+
+// True bearing (deg, 0 = north, 90 = east) from the observer to
+// the strike in the local equirectangular frame - the same
+// small-domain approximation the DEM/OSM/traffic layers share.
+export function strikeBearing(obs, strike) {
+  const dLon =
+    (strike.lon - obs.lon) *
+    Math.cos(((obs.lat + strike.lat) / 2) * (Math.PI / 180));
+  const dLat = strike.lat - obs.lat;
+  return ((Math.atan2(dLon, dLat) * 180) / Math.PI + 360) % 360;
+}
+
+// ---- Rakov & Uman flash sequence -------------------------------
+// rand: array of uniforms in [0,1), consumed left to right (pass
+// seeded values; the generator itself never touches Math.random).
+// Returns {strokes: [{t (s), amp}], cc: {t0, dur, amp} | null,
+// dur} with the first stroke at t = 0 and amp = 1.
+export const SINGLE_STROKE_P = 0.17; // Rakov & Uman: 15-20%
+export const SUBSEQUENT_RATIO = 0.4; // ~12 kA / ~30 kA
+export const INTERSTROKE_MS = 60; // geometric mean
+export const CC_FRACTION = 0.4; // 30-50% carry continuing current
+
+export function strokeSequence(rand) {
+  let i = 0;
+  const u = () => rand[i++ % rand.length];
+  let n;
+  if (u() < SINGLE_STROKE_P) n = 1;
+  else n = Math.min(2 + Math.floor(Math.log(1 - u()) / Math.log(1 - 0.35)), 15);
+  const strokes = [{t: 0, amp: 1}];
+  let t = 0;
+  for (let k = 1; k < n; k++) {
+    // lognormal about the 60 ms geometric mean (sigma_ln 0.55)
+    const z =
+      Math.sqrt(-2 * Math.log(Math.max(u(), 1e-12))) *
+      Math.cos(2 * Math.PI * u());
+    t += (INTERSTROKE_MS / 1000) * Math.exp(0.55 * z);
+    const jz =
+      Math.sqrt(-2 * Math.log(Math.max(u(), 1e-12))) *
+      Math.cos(2 * Math.PI * u());
+    strokes.push({t, amp: SUBSEQUENT_RATIO * Math.exp(0.3 * jz)});
+  }
+  let cc = null;
+  if (u() < CC_FRACTION) {
+    const after = strokes[Math.min(Math.floor(u() * n), n - 1)];
+    cc = {
+      t0: after.t,
+      // 40-250 ms, log-uniform (Rakov & Uman's tens-to-hundreds)
+      dur: 0.04 * Math.exp(Math.log(250 / 40) * u()),
+      amp: 0.12
+    };
+  }
+  const end = Math.max(strokes[strokes.length - 1].t, cc ? cc.t0 + cc.dur : 0);
+  return {strokes, cc, dur: end + 0.05};
+}
+
+// Optical amplitude of the flash at time t (s) since the first
+// stroke: per-stroke exponential afterglow (tau ~ 8 ms - the
+// luminous phase plus display persistence) over the
+// continuing-current plateau.
+export const STROKE_TAU = 0.008;
+
+export function flashAmplitude(seq, t) {
+  let a = 0;
+  for (const s of seq.strokes) {
+    if (t >= s.t) a += s.amp * Math.exp(-(t - s.t) / STROKE_TAU);
+  }
+  if (seq.cc && t >= seq.cc.t0 && t <= seq.cc.t0 + seq.cc.dur) {
+    a += seq.cc.amp;
+  }
+  return a;
+}

--- a/themes/horizon/server-reference.mjs
+++ b/themes/horizon/server-reference.mjs
@@ -22,14 +22,20 @@
 import {
   createAisState,
   createLimiter,
+  createStrikeState,
   decodeFrame,
   gridKey,
   ingest,
+  ingestStrike,
+  lzwDecode,
   originCheck,
   prune,
-  query
+  pruneStrikes,
+  query,
+  queryStrikes
 } from './server/src/index.mjs';
 import {aisBox} from './worker/src/index.js';
+import {haversineKm} from './lightning.js';
 
 let fail = 0;
 const check = (name, ok, detail) => {
@@ -130,6 +136,81 @@ const FRAME = (mmsi, lat, lon, over = {}) => ({
       threw !== null &&
       threw.includes('undecodable'),
     `string passthrough exact; ArrayBuffer and Uint8Array utf8-decode exact; Blob-like object throws (-> badFrames), never a silent parse of "[object Blob]"`
+  );
+}
+
+{
+  // Blitzortung LZW: a spec-built ENCODER (initial dictionary =
+  // single chars, new entry = previous word + first char of
+  // current) provides ground truth; the daemon's decoder must
+  // invert it exactly - including the KwKwK corner case ("aaaa"),
+  // where the decoder meets a code it has not built yet.
+  const lzwEncode = (s) => {
+    const dict = new Map();
+    let g = 256;
+    let w = s[0];
+    const out = [];
+    const emit = (word) =>
+      out.push(word.length === 1 ? word : String.fromCharCode(dict.get(word)));
+    for (let i = 1; i < s.length; i++) {
+      const wc = w + s[i];
+      if (dict.has(wc)) w = wc;
+      else {
+        emit(w);
+        dict.set(wc, g++);
+        w = s[i];
+      }
+    }
+    emit(w);
+    return out.join('');
+  };
+  const strike =
+    '{"time":1783372802970770000,"lat":28.204296,"lon":-81.011173,"alt":0,"pol":0,"sig":[{"sta":1},{"sta":2}]}';
+  const kwk = 'aaaaaaaa';
+  const mixed = 'ababababab{"lat":1.5,"lat":1.5,"lat":1.5}';
+  const ok =
+    lzwDecode(lzwEncode(strike)) === strike &&
+    lzwDecode(lzwEncode(kwk)) === kwk &&
+    lzwDecode(lzwEncode(mixed)) === mixed &&
+    lzwEncode(strike).length < strike.length;
+  check(
+    'Blitzortung LZW',
+    ok,
+    `round trip exact on a strike frame (${strike.length} -> ${lzwEncode(strike).length} chars), on "aaaaaaaa" (KwKwK) and on repeated JSON`
+  );
+}
+
+{
+  // Strike engine: ns -> ms time base, grid insert, exact
+  // haversine radius query with age filter, prune with cell
+  // cleanup.
+  const st = createStrikeState();
+  const now = 1_800_000_000_000;
+  const a = ingestStrike(
+    st,
+    {time: (now - 60e3) * 1e6, lat: 46.6, lon: 8.0},
+    now
+  );
+  ingestStrike(st, {time: (now - 5 * 60e3) * 1e6, lat: 47.4, lon: 8.6}, now);
+  ingestStrike(st, {time: (now - 60e3) * 1e6, lat: 50.0, lon: 8.0}, now); // 378 km north
+  ingestStrike(st, {lat: 'x'}, now); // junk
+  const d2 = haversineKm(46.6, 8.0, 47.4, 8.6);
+  const both = queryStrikes(st, 46.6, 8.0, 150, 10 * 60e3, now);
+  const near = queryStrikes(st, 46.6, 8.0, 50, 10 * 60e3, now);
+  const fresh = queryStrikes(st, 46.6, 8.0, 150, 2 * 60e3, now);
+  const pruned = pruneStrikes(st, 4 * 60e3, now);
+  check(
+    'strike engine',
+    a.t === now - 60e3 &&
+      st.total === 3 &&
+      both.length === 2 &&
+      both.some((s) => s.km === Math.round(d2)) &&
+      near.length === 1 &&
+      near[0].ageMs === 60e3 &&
+      fresh.length === 1 &&
+      pruned === 1 &&
+      st.count === 2,
+    `ns -> ms exact; radius 150 km finds 2 of 3 (third at 378 km), the second at its exact haversine ${d2.toFixed(0)} km; 50 km -> 1; 2 min age filter -> 1; prune drops the 5-min-old strike (${pruned})`
   );
 }
 

--- a/themes/horizon/server/README.md
+++ b/themes/horizon/server/README.md
@@ -57,8 +57,15 @@ by `../server-reference.mjs` — reference set 20 in
   round-trip).
 - `GET /adsb?lat&lon&dist` — aircraft via readsb failover
   (adsb.lol → adsb.fi → airplanes.live), 15 s cache.
-- `GET /health` — AIS engine stats (ships resident, frames,
-  socket age).
+- `GET /lightning?lat&lon&km` — strikes of the last 10 minutes
+  within km (≤ 250) of the point, with ages and exact
+  great-circle distances (Blitzortung.org, CC BY-SA).
+- `GET /lightning/stream?lat&lon&km` — server-sent events:
+  strikes pushed the moment the network locates them.
+  EventSource bypasses CORS, so the Origin allowlist gate IS the
+  protection here — foreign origins get 403 before the stream
+  opens. Capped concurrent streams (`SSE_MAX`, default 25).
+- `GET /health` — AIS + lightning engine stats.
 - `GET /probe` — health + the fixed-target reachability
   diagnostic, run from the box's own IP.
 

--- a/themes/horizon/server/install.sh
+++ b/themes/horizon/server/install.sh
@@ -27,14 +27,15 @@ if ! command -v caddy >/dev/null; then
   apt-get update && apt-get install -y caddy
 fi
 
-# The daemon: one file, zero npm dependencies. It imports the
-# worker's normalizers, so ship both files preserving layout.
+# The daemon: zero npm dependencies. It imports the worker's
+# normalizers and the lightning geometry, so ship those files too.
 mkdir -p /opt/horizon-live/worker/src
 install -m 644 src/index.mjs /opt/horizon-live/index.mjs
 install -m 644 ../worker/src/index.js /opt/horizon-live/worker/src/index.js
-# The import path '../../worker/src/index.js' must keep resolving
-# from /opt/horizon-live/index.mjs - rewrite it for the flat deploy.
-sed -i "s#'../../worker/src/index.js'#'./worker/src/index.js'#" /opt/horizon-live/index.mjs
+install -m 644 ../lightning.js /opt/horizon-live/lightning.js
+# The '../../' import paths must keep resolving from
+# /opt/horizon-live/index.mjs - rewrite them for the flat deploy.
+sed -i "s#'../../worker/src/index.js'#'./worker/src/index.js'#;s#'../../lightning.js'#'./lightning.js'#" /opt/horizon-live/index.mjs
 
 # Environment (created once; never overwritten - your key lives here).
 if [ ! -f /etc/horizon-live.env ]; then

--- a/themes/horizon/server/src/index.mjs
+++ b/themes/horizon/server/src/index.mjs
@@ -54,6 +54,7 @@
 
 import http from 'node:http';
 import {aisBox, normalize, normalizeShip} from '../../worker/src/index.js';
+import {haversineKm} from '../../lightning.js';
 
 const AIS_WS = 'wss://stream.aisstream.io/v0/stream';
 const UA = 'horizon-live/1.0 (+https://github.com/NDevTK/writeups)';
@@ -167,6 +168,109 @@ export function query(st, lat, lon, dist, limit = 80) {
           hdg: s.hdg
         });
         if (out.length >= limit) return out;
+      }
+    }
+  }
+  return out;
+}
+
+// ---- Lightning (Blitzortung.org community network) -------------
+// Strikes stream over another persistent WebSocket; the wire
+// format is LZW-compressed JSON (their map client's scheme -
+// protocol verified live: subscribe with {"a":111}, frames decode
+// to {time (ns), lat, lon, ...}). Data CC BY-SA; the theme
+// credits Blitzortung.org in its provenance panel.
+const BLITZ_HOSTS = [
+  'wss://ws1.blitzortung.org',
+  'wss://ws7.blitzortung.org',
+  'wss://ws8.blitzortung.org'
+];
+
+// Their LZW: dictionary starts at code 256, entries are built as
+// previous-word + first-char, unknown codes mean word + word[0].
+// Exported and gated by a round-trip against a spec-built encoder.
+export function lzwDecode(b) {
+  const d = b.split('');
+  const e = {};
+  let c = d[0];
+  let f = c;
+  let g = 256;
+  const out = [c];
+  for (let i = 1; i < d.length; i++) {
+    const cc = d[i].charCodeAt(0);
+    const w = cc < 256 ? d[i] : (e[cc] ?? f + c);
+    out.push(w);
+    c = w.charAt(0);
+    e[g++] = f + c;
+    f = w;
+  }
+  return out.join('');
+}
+
+export function createStrikeState() {
+  return {
+    grid: new Map(), // "lat:lon" 1-degree cell -> [{t, lat, lon}]
+    count: 0,
+    total: 0,
+    lastStrike: 0,
+    connects: 0
+  };
+}
+
+// Ingest one decoded Blitzortung frame. Time arrives in
+// NANOSECONDS since epoch; stored in ms. Returns the stored
+// strike or null.
+export function ingestStrike(st, j, now = Date.now()) {
+  if (!j || typeof j.lat !== 'number' || typeof j.lon !== 'number') return null;
+  const s = {
+    t: typeof j.time === 'number' ? Math.round(j.time / 1e6) : now,
+    lat: j.lat,
+    lon: j.lon
+  };
+  const gk = gridKey(j.lat, j.lon);
+  let cell = st.grid.get(gk);
+  if (!cell) st.grid.set(gk, (cell = []));
+  cell.push(s);
+  st.count++;
+  st.total++;
+  st.lastStrike = now;
+  return s;
+}
+
+// Strikes older than maxAgeMs leave the picture (a flash matters
+// for minutes, not hours). Returns the number pruned.
+export function pruneStrikes(st, maxAgeMs = 15 * 60e3, now = Date.now()) {
+  let n = 0;
+  for (const [gk, cell] of st.grid) {
+    const keep = cell.filter((s) => now - s.t <= maxAgeMs);
+    n += cell.length - keep.length;
+    if (keep.length) st.grid.set(gk, keep);
+    else st.grid.delete(gk);
+  }
+  st.count -= n;
+  return n;
+}
+
+// Strikes within km of the point in the last sinceMs, EXACT
+// great-circle distances (haversine from lightning.js - the model
+// lives once) after a conservative grid-cell prefilter. Ages out,
+// so the client can replay timing faithfully.
+export function queryStrikes(st, lat, lon, km, sinceMs, now = Date.now()) {
+  const dLat = Math.ceil(km / 110) + 0; // 1 deg lat >= 110.57 km
+  const dLon = Math.ceil(
+    km / Math.max(111.32 * Math.cos((lat * Math.PI) / 180), 1)
+  );
+  const out = [];
+  for (let a = Math.floor(lat) - dLat; a <= Math.floor(lat) + dLat; a++) {
+    for (let o = Math.floor(lon) - dLon; o <= Math.floor(lon) + dLon; o++) {
+      const cell = st.grid.get(a + ':' + o);
+      if (!cell) continue;
+      for (const s of cell) {
+        if (now - s.t > sinceMs) continue;
+        const d = haversineKm(lat, lon, s.lat, s.lon);
+        if (d > km) continue;
+        out.push({ageMs: now - s.t, lat: s.lat, lon: s.lon, km: Math.round(d)});
+        if (out.length >= 200) return out;
       }
     }
   }
@@ -348,6 +452,89 @@ function runAisSocket(key, st, log) {
   setInterval(() => prune(st), 60e3).unref();
 }
 
+// Persistent Blitzortung socket: rotate hosts on reconnect,
+// subscribe on open, ingest strikes, fan out to SSE clients.
+function runBlitzSocket(st, clients, log) {
+  const bootT = Date.now();
+  let hostIdx = 0;
+  let ws = null;
+  let backoff = 1000;
+  const connect = () => {
+    let ended = false;
+    const reopen = () => {
+      if (ended) return;
+      ended = true;
+      backoff = Math.min(backoff * 2, 60e3);
+      hostIdx = (hostIdx + 1) % BLITZ_HOSTS.length;
+      log(`blitzortung socket down - next host in ${backoff / 1000}s`);
+      setTimeout(connect, backoff);
+    };
+    try {
+      ws = new WebSocket(BLITZ_HOSTS[hostIdx]);
+    } catch (e) {
+      log('blitzortung constructor failed: ' + e);
+      reopen();
+      return;
+    }
+    try {
+      ws.binaryType = 'arraybuffer';
+    } catch {
+      // decodeFrame handles views
+    }
+    ws.addEventListener('open', () => {
+      st.connects++;
+      backoff = 1000;
+      log('blitzortung socket open (' + BLITZ_HOSTS[hostIdx] + ')');
+      ws.send(JSON.stringify({a: 111}));
+    });
+    ws.addEventListener('message', (ev) => {
+      try {
+        const s = ingestStrike(st, JSON.parse(lzwDecode(decodeFrame(ev.data))));
+        if (!s) return;
+        for (const cl of clients) {
+          const d = haversineKm(cl.lat, cl.lon, s.lat, s.lon);
+          if (d <= cl.km) {
+            cl.res.write(
+              'data: ' +
+                JSON.stringify({lat: s.lat, lon: s.lon, km: Math.round(d)}) +
+                '\n\n'
+            );
+          }
+        }
+      } catch {
+        // malformed frame
+      }
+    });
+    ws.addEventListener('close', reopen, {once: true});
+    ws.addEventListener(
+      'error',
+      () => {
+        try {
+          ws.close();
+        } catch {
+          // triggers reopen either way
+        }
+        reopen();
+      },
+      {once: true}
+    );
+  };
+  connect();
+  setInterval(() => {
+    // The planet always has thunderstorms; a long-quiet socket is
+    // dead upstream.
+    if (st.connects > 0 && Date.now() - (st.lastStrike || bootT) > 300e3) {
+      log('blitzortung watchdog: silent 300 s - cycling');
+      try {
+        ws.close();
+      } catch {
+        // reopen fires regardless
+      }
+    }
+    pruneStrikes(st);
+  }, 60e3).unref();
+}
+
 function main() {
   const env = process.env;
   const PORT = Number(env.PORT || 8127);
@@ -363,6 +550,16 @@ function main() {
   const log = (m) => console.log(new Date().toISOString(), m);
   if (env.AISSTREAM_KEY) runAisSocket(env.AISSTREAM_KEY, st, log);
   else log('AISSTREAM_KEY unset - /ais will answer 503');
+  // Lightning needs no key - Blitzortung's community sockets are
+  // open (data CC BY-SA, credited by the theme). SSE clients are
+  // origin-scoped by the SAME allowlist gate as every route
+  // (WebSockets/EventSource bypass CORS, so the Origin check IS
+  // the protection) and capped: streams are the one resource a
+  // client can hold open.
+  const blitz = createStrikeState();
+  const sseClients = new Set();
+  const SSE_MAX = Number(env.SSE_MAX || 25);
+  runBlitzSocket(blitz, sseClients, log);
 
   const adsbCache = new Map(); // url -> {t, body}
   setInterval(() => {
@@ -412,11 +609,21 @@ function main() {
         uptimeMs: Date.now() - st.started,
         keySet: !!env.AISSTREAM_KEY
       };
+      const lightning = {
+        strikes: blitz.count,
+        cells: blitz.grid.size,
+        total: blitz.total,
+        lastStrikeAgoMs: blitz.lastStrike
+          ? Date.now() - blitz.lastStrike
+          : null,
+        connects: blitz.connects,
+        streams: sseClients.size
+      };
       if (url.pathname === '/health')
-        return json(200, {ais}, {'cache-control': 'no-store'});
+        return json(200, {ais, lightning}, {'cache-control': 'no-store'});
       return json(
         200,
-        {ais, probe: await probeAll()},
+        {ais, lightning, probe: await probeAll()},
         {'cache-control': 'no-store'}
       );
     }
@@ -441,6 +648,56 @@ function main() {
             st.frames + ' frames, ' + st.ships.size + ' ships resident'
         }
       );
+    }
+
+    if (url.pathname === '/lightning') {
+      const km = Math.min(Number(url.searchParams.get('km')) || 150, 250);
+      if (!(km > 0)) return send(400, 'bad request');
+      return json(
+        200,
+        {strikes: queryStrikes(blitz, lat, lon, km, 10 * 60e3)},
+        {
+          'cache-control': 'public, max-age=30',
+          'x-lightning-source': 'blitzortung.org'
+        }
+      );
+    }
+
+    if (url.pathname === '/lightning/stream') {
+      // Server-sent events: strikes near the point, pushed the
+      // moment Blitzortung locates them. EventSource always sends
+      // Origin, and the global allowlist gate above already 403'd
+      // anything foreign - this stream is origin-scoped by
+      // construction. Capped globally and renewed by the client's
+      // built-in reconnect (we end streams after 30 min).
+      const km = Math.min(Number(url.searchParams.get('km')) || 150, 250);
+      if (!(km > 0)) return send(400, 'bad request');
+      if (sseClients.size >= SSE_MAX) return send(503, 'stream capacity');
+      res.writeHead(
+        200,
+        head({
+          'content-type': 'text/event-stream',
+          'cache-control': 'no-store',
+          'x-lightning-source': 'blitzortung.org'
+        })
+      );
+      res.write(': horizon-live lightning stream\n\n');
+      const client = {res, lat, lon, km};
+      sseClients.add(client);
+      const hb = setInterval(() => {
+        try {
+          res.write(': hb\n\n');
+        } catch {
+          // closing below
+        }
+      }, 25e3);
+      const bye = setTimeout(() => res.end(), 30 * 60e3);
+      req.on('close', () => {
+        clearInterval(hb);
+        clearTimeout(bye);
+        sseClients.delete(client);
+      });
+      return;
     }
 
     if (url.pathname === '/adsb') {

--- a/themes/horizon/sky-objects-tsl.js
+++ b/themes/horizon/sky-objects-tsl.js
@@ -672,3 +672,24 @@ export function createPrecipSprites(positions, dotTex, encodeFog) {
   mesh.frustumCulled = false;
   return {mesh, u, posAttr};
 }
+
+// One lightning flash (lightning.js decides the stroke sequence
+// and the apparent brightness): a soft radial glow quad hung at
+// the strike's azimuth behind/inside the cloud base. uv-radial
+// falloff; `amp` carries the instantaneous Rakov-Uman flash
+// amplitude times the Koschmieder/inverse-square viewing factor -
+// the flicker rhythm IS the physics, this node only shapes the
+// glow. Cool-white channel tint (~30000 K).
+export function createFlashMaterial() {
+  const u = {amp: uniform(0)};
+  const material = new NodeMaterial();
+  material.transparent = true;
+  material.depthWrite = false;
+  material.side = DoubleSide;
+  material.blending = AdditiveBlending;
+  const r2 = uv().sub(0.5).length().mul(2).clamp(0, 1).pow(2);
+  const glow = exp(r2.mul(-4));
+  material.colorNode = vec3(0.82, 0.87, 1.0).mul(glow.mul(u.amp));
+  material.opacityNode = float(1);
+  return {material, u};
+}


### PR DESCRIPTION
The item the worker era had to shelve - real-time lightning needs a persistent socket, which the daemon now has on both sides: inbound from Blitzortung.org and outbound to the page as the project's first client-facing stream. Client streams bypass CORS (EventSource/WebSocket are not subject to it), so they are origin-scoped SERVER-side: the daemon's global Origin allowlist gate 403s foreign origins before a stream opens - verified live.

Daemon:
- persistent Blitzortung socket (ws1/ws7/ws8 rotation, subscribe {"a":111}), wire format LZW-compressed JSON - protocol verified LIVE first (Florida storm strikes decoded on first connect); the decoder is gated by round-trip against a spec-built encoder including the KwKwK corner case
- strikes in the same 1-degree grid pattern as ships (ns -> ms time base, 15 min retention), queried by EXACT haversine after a cell prefilter (haversine imported from lightning.js - the model lives once)
- GET /lightning snapshot + GET /lightning/stream SSE (25 s heartbeats, 30 min lifetime, SSE_MAX cap, per-strike push with exact range); watchdog knows the planet never stops thundering
- live checks: 106 strikes resident 12 s after boot; the Orlando storm streamed 18 strikes in a 20 s listen; foreign origin on the stream -> 403

Physics (lightning.js, gate set 21):
- Rakov & Uman 2003 flash structure: 15-20% single-stroke, mean multiplicity 3-5 (median 3), ~60 ms geometric-mean interstroke intervals, subsequent strokes ~0.4 of the first, continuing current in 30-50% of flashes - 20k-draw statistics inside the published bands, generator consumes explicit uniforms
- Koschmieder T = exp(-3.912 d/V) with the exact 2%-at-V landmark
- haversine on the IUGG mean radius; apparent brightness T/d^2

Theme:
- SSE strikes become flashes whose FLICKER IS THE PHYSICS: the frame loop evaluates the stroke sequence directly (~60 ms restrikes and continuing-current glow are frame-resolvable at 60 Hz), amplitude carries Koschmieder + inverse-square at the true distance, the glow quad hangs at the true bearing
- createFlashMaterial (sky-objects-tsl): the radial glow is the one documented display element
- ?strike=N deterministic harness flashes; ?lightning=URL override; Blitzortung credited CC BY-SA in the provenance panel

Gate: 21/21 reference sets pass (lightning 5 landmarks; server set grows to 8 with LZW round-trip + strike engine).

Deploy: on the box, git pull && sudo ./install.sh (ships lightning.js and rewrites the flat-deploy import paths).


Claude-Session: https://claude.ai/code/session_01NKKBen9kkD562HDVr7cXAx