### PR TITLE
Unified /stream + gate-checked self-deploys

### DIFF
--- a/themes/Horizon.html
+++ b/themes/Horizon.html
@@ -2104,46 +2104,51 @@
             )
           ).json();
           if (!Array.isArray(r.ac)) return;
-          const ref = {
-            lat: state.lat,
-            lon: state.lon,
-            halfM: DEM_HALF_M,
-            world: WORLD,
-            centerElev,
-            mpu: 57.14
-          };
-          const now_ = Date.now();
-          for (const [hex, t] of seenFlights)
-            if (now_ - t > 600e3) seenFlights.delete(hex);
-          liveTraffic = [];
-          const names = [];
-          for (const ac of r.ac) {
-            if (
-              typeof ac.lat !== 'number' ||
-              typeof ac.lon !== 'number' ||
-              typeof ac.gs !== 'number' ||
-              typeof ac.track !== 'number' ||
-              typeof ac.alt_baro !== 'number' ||
-              ac.alt_baro < 26000 || // cruise only: ~8 km up
-              seenFlights.has(ac.hex)
-            )
-              continue;
-            const s = adsbToScene(ac, ref);
-            if (Math.abs(s.x) > 220 || Math.abs(s.z) > 220) continue;
-            s.flight = (ac.flight ?? ac.hex ?? '').trim();
-            s.hex = ac.hex;
-            liveTraffic.push(s);
-            names.push(s.flight + ' FL' + Math.round(ac.alt_baro / 100));
-          }
-          if (names.length)
-            record(
-              'ADS-B live aircraft (worker)',
-              names.slice(0, 4).join(' · ') +
-                (names.length > 4 ? ' +' + (names.length - 4) : '')
-            );
+          applyTraffic(r.ac);
         } catch {
           liveTraffic = null; // ambient traffic stands in
         }
+      }
+      // Apply one aircraft list (from the 60 s poll OR a pushed
+      // `adsb` stream event - both carry the same schema).
+      function applyTraffic(acList) {
+        const ref = {
+          lat: state.lat,
+          lon: state.lon,
+          halfM: DEM_HALF_M,
+          world: WORLD,
+          centerElev,
+          mpu: 57.14
+        };
+        const now_ = Date.now();
+        for (const [hex, t] of seenFlights)
+          if (now_ - t > 600e3) seenFlights.delete(hex);
+        liveTraffic = [];
+        const names = [];
+        for (const ac of acList) {
+          if (
+            typeof ac.lat !== 'number' ||
+            typeof ac.lon !== 'number' ||
+            typeof ac.gs !== 'number' ||
+            typeof ac.track !== 'number' ||
+            typeof ac.alt_baro !== 'number' ||
+            ac.alt_baro < 26000 || // cruise only: ~8 km up
+            seenFlights.has(ac.hex)
+          )
+            continue;
+          const s = adsbToScene(ac, ref);
+          if (Math.abs(s.x) > 220 || Math.abs(s.z) > 220) continue;
+          s.flight = (ac.flight ?? ac.hex ?? '').trim();
+          s.hex = ac.hex;
+          liveTraffic.push(s);
+          names.push(s.flight + ' FL' + Math.round(ac.alt_baro / 100));
+        }
+        if (names.length)
+          record(
+            'ADS-B live aircraft (daemon)',
+            names.slice(0, 4).join(' · ') +
+              (names.length > 4 ? ' +' + (names.length - 4) : '')
+          );
       }
 
       // ---- Live ships: AIS via the same daemon (/ais route).
@@ -2281,70 +2286,76 @@
             )
           ).json();
           if (!Array.isArray(r.ships)) return;
-          const ref = {
-            lat: state.lat,
-            lon: state.lon,
-            halfM: DEM_HALF_M,
-            world: WORLD,
-            mpu: 57.14
-          };
-          const now_ = Date.now();
-          const names = [];
-          for (const ship of r.ships) {
-            const sc = aisToScene(ship, ref);
-            if (Math.abs(sc.x) > 150 || Math.abs(sc.z) > 150) continue;
-            const slot =
-              shipPool.find((s) => s.active && s.mmsi === ship.mmsi) ??
-              shipPool.find((s) => !s.active);
-            if (!slot) break;
-            Object.assign(slot, {
-              mmsi: ship.mmsi,
-              name: ship.name,
-              x: sc.x,
-              z: sc.z,
-              vx: sc.vx,
-              vz: sc.vz,
-              hdg: ship.hdg ?? ship.cog ?? 0,
-              seen: now_,
-              active: true
-            });
-            names.push(
-              (ship.name || ship.mmsi) + ' ' + Math.round(ship.sog) + ' kt'
-            );
-          }
-          for (const s of shipPool)
-            if (s.active && now_ - s.seen > 360e3) {
-              s.active = false;
-              s.g.visible = false;
-            }
-          if (names.length)
-            record(
-              'AIS live ships (worker)',
-              names.slice(0, 4).join(' · ') +
-                (names.length > 4 ? ' +' + (names.length - 4) : '')
-            );
+          applyShips(r.ships);
         } catch {
-          // worker unreachable - the sea keeps its last ships
+          // daemon unreachable - the sea keeps its last ships
         }
       }
+      // Apply one ship list (from the 120 s poll OR a pushed
+      // `ais` stream event - both carry the same schema).
+      // Idempotent by MMSI, so the two paths coexist safely.
+      function applyShips(shipList) {
+        const ref = {
+          lat: state.lat,
+          lon: state.lon,
+          halfM: DEM_HALF_M,
+          world: WORLD,
+          mpu: 57.14
+        };
+        const now_ = Date.now();
+        const names = [];
+        for (const ship of shipList) {
+          const sc = aisToScene(ship, ref);
+          if (Math.abs(sc.x) > 150 || Math.abs(sc.z) > 150) continue;
+          const slot =
+            shipPool.find((s) => s.active && s.mmsi === ship.mmsi) ??
+            shipPool.find((s) => !s.active);
+          if (!slot) break;
+          Object.assign(slot, {
+            mmsi: ship.mmsi,
+            name: ship.name,
+            x: sc.x,
+            z: sc.z,
+            vx: sc.vx,
+            vz: sc.vz,
+            hdg: ship.hdg ?? ship.cog ?? 0,
+            seen: now_,
+            active: true
+          });
+          names.push(
+            (ship.name || ship.mmsi) + ' ' + Math.round(ship.sog) + ' kt'
+          );
+        }
+        for (const s of shipPool)
+          if (s.active && now_ - s.seen > 360e3) {
+            s.active = false;
+            s.g.visible = false;
+          }
+        if (names.length)
+          record(
+            'AIS live ships (daemon)',
+            names.slice(0, 4).join(' · ') +
+              (names.length > 4 ? ' +' + (names.length - 4) : '')
+          );
+      }
 
-      // ---- Live lightning: Blitzortung.org via the daemon's SSE
-      // stream (/lightning/stream - origin-scoped server-side:
-      // EventSource bypasses CORS, so the daemon's Origin
-      // allowlist IS the protection). Each pushed strike becomes
-      // a flash whose FLICKER IS THE PHYSICS (lightning.js): a
-      // Rakov-Uman stroke sequence - 15-20% single-stroke, mean
-      // multiplicity 3-5, ~60 ms interstroke intervals,
-      // continuing-current plateaus - viewed through Koschmieder
-      // extinction and the inverse square at the strike's true
-      // great-circle distance, hung at its true bearing. The glow
-      // quad itself is the documented display shape; the timing
-      // and brightness are measured + published physics. Data CC
+      // ---- Live lightning: Blitzortung.org over the daemon's
+      // UNIFIED stream (/stream - one origin-scoped EventSource
+      // carries strike + ais + adsb named events; EventSource
+      // bypasses CORS, so the daemon's Origin allowlist IS the
+      // protection). Each pushed strike becomes a flash whose
+      // FLICKER IS THE PHYSICS (lightning.js): a Rakov-Uman
+      // stroke sequence - 15-20% single-stroke, mean multiplicity
+      // 3-5, ~60 ms interstroke intervals, continuing-current
+      // plateaus - viewed through Koschmieder extinction and the
+      // inverse square at the strike's true great-circle
+      // distance, hung at its true bearing. The glow quad itself
+      // is the documented display shape; the timing and
+      // brightness are measured + published physics. Data CC
       // BY-SA Blitzortung.org (credited in the provenance panel).
-      // ?lightning=URL overrides the endpoint; ?strike=N spawns
+      // ?live=URL overrides the stream base; ?strike=N spawns
       // deterministic synthetic flashes for the offline harness.
-      const LIGHTNING_PROXY =
-        params.get('lightning') ?? 'https://api.ndev.tk/lightning';
+      const LIVE_STREAM = params.get('live') ?? 'https://api.ndev.tk/stream';
       const FLASH_N = 5;
       const flashPool = [];
       for (let i = 0; i < FLASH_N; i++) {
@@ -2406,15 +2417,21 @@
           k++;
         }, 1700);
       } else if (typeof EventSource !== 'undefined') {
-        const src = () =>
-          LIGHTNING_PROXY +
-          '/stream?lat=' +
-          state.lat.toFixed(3) +
-          '&lon=' +
-          state.lon.toFixed(3) +
-          '&km=200';
-        const es = new EventSource(src());
-        es.onmessage = (ev) => {
+        // One connection, three layers: strikes flash the moment
+        // Blitzortung locates them; ship and aircraft deltas ride
+        // the same channel (30 s / 20 s server cadence), applied
+        // through the SAME functions the polling fallback uses -
+        // the polls stay armed as belt and braces, application is
+        // idempotent by MMSI/hex.
+        const es = new EventSource(
+          LIVE_STREAM +
+            '?lat=' +
+            state.lat.toFixed(3) +
+            '&lon=' +
+            state.lon.toFixed(3) +
+            '&km=200&ais=8&adsb=15'
+        );
+        es.addEventListener('strike', (ev) => {
           try {
             const s = JSON.parse(ev.data);
             const az = strikeBearing({lat: state.lat, lon: state.lon}, s);
@@ -2428,9 +2445,25 @@
               strikeCount + ' strikes streamed · nearest ' + s.km + ' km'
             );
           } catch {
-            // heartbeat or malformed event
+            // malformed event
           }
-        };
+        });
+        es.addEventListener('ais', (ev) => {
+          try {
+            const j = JSON.parse(ev.data);
+            if (Array.isArray(j.ships)) applyShips(j.ships);
+          } catch {
+            // malformed event
+          }
+        });
+        es.addEventListener('adsb', (ev) => {
+          try {
+            const j = JSON.parse(ev.data);
+            if (Array.isArray(j.ac)) applyTraffic(j.ac);
+          } catch {
+            // malformed event
+          }
+        });
         // EventSource reconnects itself; nothing else to manage.
       }
       const mFlashDir = new THREE.Vector3();

--- a/themes/horizon/WEBGPU-PLAN.md
+++ b/themes/horizon/WEBGPU-PLAN.md
@@ -1610,6 +1610,45 @@ Scenes (all at Grindelwald unless noted):
       uniform table, camera-cone azimuths) for pinned shots;
       ?lightning=URL overrides the endpoint. EventSource
       reconnects itself.
+  - DONE: the unified live channel + gate-checked self-deploys -
+    the two pieces the owner picked after the daemon proved out
+    (200 GB/mo egress confirmed comfortable: ~130 MB/mo per
+    always-on viewer BEFORE Cloudflare's edge cache absorbs
+    repeats).
+    - /stream (daemon): ONE origin-scoped EventSource per viewer
+      multiplexes named events - `strike` the instant Blitzortung
+      locates one, `ais` ship deltas every 30 s from the in-RAM
+      global picture, `adsb` aircraft every 20 s through the
+      shared per-area cache (many viewers in one place still cost
+      ONE upstream request; the readsb rate budget is managed in
+      one place, server-side). Initial ais/adsb push on connect;
+      25 s heartbeats; 30 min lifetime onto EventSource's
+      auto-reconnect; SSE_MAX cap shared with the legacy
+      /lightning/stream (kept for one deploy cycle). sseEvent()
+      framing is spec-exact and landmarked. Live smoke on the
+      real upstreams: one 25 s connection carried 52 strikes
+      (Florida storm), 2 adsb pushes (14 aircraft) and the ais
+      event. Aircraft now appear within ~20 s of reality instead
+      of up to 60 s - a contrail starts where the plane IS.
+    - Theme: syncTraffic/syncShips refactored into fetch +
+      applyTraffic/applyShips; the unified EventSource feeds the
+      SAME apply functions (idempotent by hex/MMSI), the polls
+      stay armed as documented fallback. ?live=URL overrides the
+      stream base.
+    - Self-update (server/update.sh + systemd timer, armed by
+      install.sh): every 5 min the box fetches UPDATE_BRANCH
+      (default main - merging to main IS the deploy trigger,
+      matching Pages), and if server files changed it runs the
+      FULL reference gate ON THE BOX (validate.sh CPU sets -
+      plain node, which is the whole point of the gate) before
+      reinstalling; the previous install is kept at
+      /opt/horizon-live.prev for instant rollback and a failing
+      gate leaves the running version untouched (remembered, so
+      no retry spam). Nothing deploys unverified - ops now obeys
+      the same law as the code. Owner note: set
+      UPDATE_BRANCH=claude/website-themes-discussion-jjh4yp in
+      /etc/horizon-live.env to track the PR branch until #44
+      merges, or leave main and deploys begin at merge.
   - OPEN (environment, not code): today's fixture rig drops the
     volumetric cloud decks and spams "2D view of 3D texture" Dawn
     validation errors from the Nubis noise volumes - bisect-shot

--- a/themes/horizon/server-reference.mjs
+++ b/themes/horizon/server-reference.mjs
@@ -32,7 +32,8 @@ import {
   prune,
   pruneStrikes,
   query,
-  queryStrikes
+  queryStrikes,
+  sseEvent
 } from './server/src/index.mjs';
 import {aisBox} from './worker/src/index.js';
 import {haversineKm} from './lightning.js';
@@ -228,6 +229,17 @@ const FRAME = (mmsi, lat, lon, over = {}) => ({
       curl.ok &&
       curl.acao === null,
     `website origin -> exact CORS echo; foreign origin refused; no Origin passes with NO grant`
+  );
+}
+
+{
+  // SSE wire framing: the EventSource spec parses exactly this -
+  // an event line, one data line, a blank-line terminator.
+  const ev = sseEvent('strike', {km: 12});
+  check(
+    'SSE framing',
+    ev === 'event: strike\ndata: {"km":12}\n\n',
+    JSON.stringify(ev) + ' - spec-exact named event'
   );
 }
 

--- a/themes/horizon/server/README.md
+++ b/themes/horizon/server/README.md
@@ -65,6 +65,12 @@ by `../server-reference.mjs` — reference set 20 in
   EventSource bypasses CORS, so the Origin allowlist gate IS the
   protection here — foreign origins get 403 before the stream
   opens. Capped concurrent streams (`SSE_MAX`, default 25).
+- `GET /stream?lat&lon&km&ais&adsb` — the unified live channel:
+  one origin-scoped EventSource carries `strike` events
+  immediately, `ais` ship deltas every 30 s from RAM, and `adsb`
+  aircraft every 20 s through the shared per-area cache (many
+  viewers in one place still cost one upstream request). Initial
+  ais/adsb push on connect. Same cap as above.
 - `GET /health` — AIS + lightning engine stats.
 - `GET /probe` — health + the fixed-target reachability
   diagnostic, run from the box's own IP.
@@ -72,3 +78,17 @@ by `../server-reference.mjs` — reference set 20 in
 Browser access is origin-locked to `ALLOW_ORIGIN` (the website —
 this is not an open CORS proxy); everything is rate-limited per
 IP.
+
+## Self-update (no manual deploys)
+
+`install.sh` also arms `horizon-live-update.timer`: every 5
+minutes `update.sh` fetches the watched branch (`UPDATE_BRANCH`
+in `/etc/horizon-live.env`, default `main` — merging to main IS
+the deploy trigger, same as GitHub Pages). If the server files
+changed, it checks out the new revision and runs the FULL
+reference gate (`harness/validate.sh`, CPU sets) **on this box**;
+only a PASS reinstalls and restarts, with the previous install
+kept at `/opt/horizon-live.prev` for instant rollback. A failing
+gate leaves the running version untouched and lands in
+`journalctl -u horizon-live-update`. Nothing deploys unverified —
+the same rule the repo itself lives by.

--- a/themes/horizon/server/horizon-live-update.service
+++ b/themes/horizon/server/horizon-live-update.service
@@ -1,0 +1,9 @@
+# One self-update pass (see update.sh). Root: it installs files
+# and restarts horizon-live. Triggered by horizon-live-update.timer.
+[Unit]
+Description=horizon-live self-update
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/opt/horizon-live-update.sh

--- a/themes/horizon/server/horizon-live-update.timer
+++ b/themes/horizon/server/horizon-live-update.timer
@@ -1,0 +1,12 @@
+# Poll the repo every 5 minutes; the update script exits in
+# milliseconds when nothing changed. Installed by install.sh.
+[Unit]
+Description=horizon-live self-update poll
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=5min
+RandomizedDelaySec=30
+
+[Install]
+WantedBy=timers.target

--- a/themes/horizon/server/install.sh
+++ b/themes/horizon/server/install.sh
@@ -52,8 +52,16 @@ ENV
 fi
 
 install -m 644 horizon-live.service /etc/systemd/system/horizon-live.service
+# Self-update machinery: a timer runs update.sh every 5 minutes;
+# it deploys a new revision ONLY after the reference gate passes
+# on this box (see update.sh; branch via UPDATE_BRANCH in
+# /etc/horizon-live.env, default main).
+install -m 755 update.sh /opt/horizon-live-update.sh
+install -m 644 horizon-live-update.service /etc/systemd/system/
+install -m 644 horizon-live-update.timer /etc/systemd/system/
 systemctl daemon-reload
 systemctl enable --now horizon-live
+systemctl enable --now horizon-live-update.timer
 systemctl restart horizon-live
 sleep 1
 systemctl --no-pager -l status horizon-live | head -6

--- a/themes/horizon/server/src/index.mjs
+++ b/themes/horizon/server/src/index.mjs
@@ -277,6 +277,13 @@ export function queryStrikes(st, lat, lon, km, sinceMs, now = Date.now()) {
   return out;
 }
 
+// One server-sent event, exactly framed (the wire format the
+// EventSource spec parses: an event name line, one data line,
+// blank-line terminator). Exported for the reference gate.
+export function sseEvent(name, obj) {
+  return 'event: ' + name + '\ndata: ' + JSON.stringify(obj) + '\n\n';
+}
+
 // ---- Origin allowlist + per-IP rate limit ----------------------
 
 // Browser requests carry Origin; only the website's origin gets
@@ -494,10 +501,13 @@ function runBlitzSocket(st, clients, log) {
         for (const cl of clients) {
           const d = haversineKm(cl.lat, cl.lon, s.lat, s.lon);
           if (d <= cl.km) {
+            const payload = {lat: s.lat, lon: s.lon, km: Math.round(d)};
+            // named event on the multiplexed /stream, bare data
+            // on the legacy /lightning/stream
             cl.res.write(
-              'data: ' +
-                JSON.stringify({lat: s.lat, lon: s.lon, km: Math.round(d)}) +
-                '\n\n'
+              cl.named
+                ? sseEvent('strike', payload)
+                : 'data: ' + JSON.stringify(payload) + '\n\n'
             );
           }
         }
@@ -561,11 +571,42 @@ function main() {
   const SSE_MAX = Number(env.SSE_MAX || 25);
   runBlitzSocket(blitz, sseClients, log);
 
-  const adsbCache = new Map(); // url -> {t, body}
+  const adsbCache = new Map(); // area key -> {t, body, src}
   setInterval(() => {
     const now = Date.now();
     for (const [k, v] of adsbCache) if (now - v.t > 30e3) adsbCache.delete(k);
   }, 30e3).unref();
+  // Aircraft near a point via the readsb failover chain, shared
+  // by GET /adsb and the /stream pushes - the 15 s per-area cache
+  // means many viewers in one place cost ONE upstream request,
+  // and stream pushes never exceed the feeds' documented rates.
+  async function fetchAdsb(lat, lon, dist) {
+    const la = lat.toFixed(3);
+    const lo = lon.toFixed(3);
+    const d = Math.round(dist);
+    const ck = la + '/' + lo + '/' + d;
+    const hit = adsbCache.get(ck);
+    if (hit && Date.now() - hit.t < 15e3) {
+      return {body: hit.body, src: hit.src + ' (cached)'};
+    }
+    for (const mk of ADSB_UPSTREAMS) {
+      const u = mk(la, lo, d);
+      try {
+        const r = await fetch(u, {
+          signal: AbortSignal.timeout(FETCH_MS),
+          headers: {'user-agent': UA}
+        });
+        if (!r.ok) continue;
+        const body = {ac: normalize(await r.json())};
+        const src = new URL(u).hostname;
+        adsbCache.set(ck, {t: Date.now(), body, src});
+        return {body, src};
+      } catch {
+        // timeout or malformed - next upstream
+      }
+    }
+    return null;
+  }
 
   const server = http.createServer(async (req, res) => {
     const ip = TRUST
@@ -703,36 +744,77 @@ function main() {
     if (url.pathname === '/adsb') {
       const dist = Math.min(Number(url.searchParams.get('dist')) || 15, 60);
       if (!(dist > 0)) return send(400, 'bad request');
-      const la = lat.toFixed(3);
-      const lo = lon.toFixed(3);
-      const d = Math.round(dist);
-      const ck = la + '/' + lo + '/' + d;
-      const hit = adsbCache.get(ck);
-      if (hit && Date.now() - hit.t < 15e3)
-        return json(200, hit.body, {
-          'cache-control': 'public, max-age=15',
-          'x-adsb-source': hit.src + ' (cached)'
-        });
-      for (const mk of ADSB_UPSTREAMS) {
-        const u = mk(la, lo, d);
-        try {
-          const r = await fetch(u, {
-            signal: AbortSignal.timeout(FETCH_MS),
-            headers: {'user-agent': UA}
-          });
-          if (!r.ok) continue;
-          const body = {ac: normalize(await r.json())};
-          const src = new URL(u).hostname;
-          adsbCache.set(ck, {t: Date.now(), body, src});
-          return json(200, body, {
-            'cache-control': 'public, max-age=15',
-            'x-adsb-source': src
-          });
-        } catch {
-          // timeout or malformed - next upstream
+      const got = await fetchAdsb(lat, lon, dist);
+      if (!got) return json(502, {ac: [], upstream: 'unavailable'});
+      return json(200, got.body, {
+        'cache-control': 'public, max-age=15',
+        'x-adsb-source': got.src
+      });
+    }
+
+    if (url.pathname === '/stream') {
+      // The unified live channel: ONE origin-scoped EventSource
+      // per viewer carries everything time-sensitive as named
+      // events - `strike` the moment Blitzortung locates one,
+      // `ais` ship deltas every 30 s from the in-RAM picture,
+      // `adsb` aircraft every 20 s through the shared per-area
+      // cache (many viewers in one place still cost one upstream
+      // request). Initial ais/adsb push on connect so the page
+      // paints immediately. Origin scoping: EventSource bypasses
+      // CORS, so the global allowlist gate above IS the
+      // protection - foreign origins were 403'd before this line.
+      const km = Math.min(Number(url.searchParams.get('km')) || 150, 250);
+      const aisDist = Math.min(Number(url.searchParams.get('ais')) || 8, 30);
+      const adsbDist = Math.min(Number(url.searchParams.get('adsb')) || 15, 60);
+      if (sseClients.size >= SSE_MAX) return send(503, 'stream capacity');
+      res.writeHead(
+        200,
+        head({
+          'content-type': 'text/event-stream',
+          'cache-control': 'no-store'
+        })
+      );
+      res.write(': horizon-live unified stream\n\n');
+      const client = {res, lat, lon, km, named: true};
+      sseClients.add(client);
+      const pushAis = () => {
+        if (env.AISSTREAM_KEY) {
+          try {
+            res.write(sseEvent('ais', {ships: query(st, lat, lon, aisDist)}));
+          } catch {
+            // closing below
+          }
         }
-      }
-      return json(502, {ac: [], upstream: 'unavailable'});
+      };
+      const pushAdsb = async () => {
+        const got = await fetchAdsb(lat, lon, adsbDist);
+        if (!got) return;
+        try {
+          res.write(sseEvent('adsb', got.body));
+        } catch {
+          // closing below
+        }
+      };
+      pushAis();
+      pushAdsb();
+      const iAis = setInterval(pushAis, 30e3);
+      const iAdsb = setInterval(pushAdsb, 20e3);
+      const hb = setInterval(() => {
+        try {
+          res.write(': hb\n\n');
+        } catch {
+          // closing below
+        }
+      }, 25e3);
+      const bye = setTimeout(() => res.end(), 30 * 60e3);
+      req.on('close', () => {
+        clearInterval(iAis);
+        clearInterval(iAdsb);
+        clearInterval(hb);
+        clearTimeout(bye);
+        sseClients.delete(client);
+      });
+      return;
     }
 
     return send(404, 'not found');

--- a/themes/horizon/server/update.sh
+++ b/themes/horizon/server/update.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# horizon-live self-updater - the box deploys ITSELF, gated by the
+# same reference suite the repo trusts. Run by the systemd timer
+# (horizon-live-update.timer); safe to run by hand.
+#
+# Flow: fetch the watched branch of the repo; if the server files
+# changed since the last considered revision, check out the new
+# tree, run the FULL CPU reference gate on the box (plain node -
+# that portability is the point of the gate), and only on PASS
+# back up /opt/horizon-live and reinstall. A failing gate leaves
+# the running version untouched and is remembered so the journal
+# is not spammed every five minutes. Rollback: the previous
+# install is kept at /opt/horizon-live.prev.
+#
+# Config (optional, in /etc/horizon-live.env):
+#   UPDATE_REPO    git URL   (default the NDevTK/writeups repo)
+#   UPDATE_BRANCH  branch    (default main - merging to main IS
+#                             the deploy trigger, same as Pages)
+set -euo pipefail
+[ -f /etc/horizon-live.env ] && set -a && . /etc/horizon-live.env && set +a
+REPO=${UPDATE_REPO:-https://github.com/NDevTK/writeups}
+BRANCH=${UPDATE_BRANCH:-main}
+CLONE=/opt/horizon-live-repo
+STATE=/opt/horizon-live-update.state
+
+if [ ! -d "$CLONE/.git" ]; then
+  git clone --branch "$BRANCH" "$REPO" "$CLONE"
+fi
+cd "$CLONE"
+git fetch origin "$BRANCH" --quiet
+NEW=$(git rev-parse "origin/$BRANCH")
+LAST=$(cat "$STATE" 2>/dev/null || echo none)
+[ "$NEW" = "$LAST" ] && exit 0
+
+CUR=$(git rev-parse HEAD)
+CHANGED=$(git diff --name-only "$CUR" "$NEW" -- \
+  themes/horizon/server themes/horizon/worker/src \
+  themes/horizon/lightning.js themes/horizon/'*-reference.mjs' \
+  themes/horizon/harness/validate.sh 2>/dev/null || echo forced)
+git checkout --quiet "$NEW"
+if [ -z "$CHANGED" ]; then
+  # unrelated commit (site content etc.) - considered, no deploy
+  echo "$NEW" >"$STATE"
+  exit 0
+fi
+
+echo "horizon-live update: $CUR -> $NEW (gating...)"
+if (cd themes/horizon/harness && SHOOT_CHROME= ./validate.sh); then
+  rm -rf /opt/horizon-live.prev
+  [ -d /opt/horizon-live ] && cp -a /opt/horizon-live /opt/horizon-live.prev
+  ./themes/horizon/server/install.sh
+  echo "$NEW" >"$STATE"
+  echo "horizon-live update: deployed $NEW (previous kept at /opt/horizon-live.prev)"
+else
+  # remember the failure so the timer does not retry it forever;
+  # the RUNNING version is untouched
+  echo "$NEW" >"$STATE"
+  echo "horizon-live update: GATE FAILED for $NEW - keeping current deploy" >&2
+  exit 1
+fi


### PR DESCRIPTION
The two pieces agreed after the daemon proved out.

/stream (daemon): one origin-scoped EventSource per viewer multiplexes named events - `strike` the instant Blitzortung locates one, `ais` ship deltas every 30 s from the in-RAM global picture, `adsb` aircraft every 20 s through the shared per-area cache, so many viewers in one place still cost ONE upstream request and the readsb rate budget is managed server-side in one place. Initial ais/adsb push on connect, 25 s heartbeats, 30 min lifetime onto EventSource auto-reconnect, shared SSE_MAX cap; legacy /lightning/stream kept for one deploy cycle. sseEvent() framing is spec-exact and landmarked (gate set 20 -> 9 landmarks). Live smoke against the real upstreams: one 25 s connection carried 52 strikes (Florida storm), 2 adsb pushes (14 aircraft) and the ais event. Aircraft now appear within ~20 s of reality instead of up to 60 - a contrail starts where the plane IS.

Theme: syncTraffic/syncShips refactored into fetch + applyTraffic/applyShips; the unified EventSource feeds the SAME apply functions (idempotent by hex/MMSI); the polls stay armed as documented fallback; ?live=URL overrides the stream base.

Self-update (update.sh + horizon-live-update.timer, armed by install.sh): every 5 min the box fetches UPDATE_BRANCH (default main - merging to main IS the deploy trigger, matching Pages); if server files changed it checks out the revision and runs the FULL reference gate ON THE BOX before reinstalling - previous install kept at /opt/horizon-live.prev for instant rollback, a failing gate leaves the running version untouched and is remembered. Nothing deploys unverified - ops now obeys the same law as the code.

Gate: 21/21 reference sets pass.

Last manual deploy: on the box, git pull && sudo ./install.sh (arms the timer; set UPDATE_BRANCH in /etc/horizon-live.env to track this branch until PR #44 merges, or leave main).


Claude-Session: https://claude.ai/code/session_01NKKBen9kkD562HDVr7cXAx