### PR TITLE
Satellite fleet: CelesTrak's visual group under the ISS physics

### DIFF
--- a/themes/Horizon.html
+++ b/themes/Horizon.html
@@ -218,6 +218,7 @@
       } from './horizon/navlights.js';
       import {earthshineRatio} from './horizon/earthshine.js';
       import {BETA_MIN_DEG, seasonEnvelope} from './horizon/nlc.js';
+      import {parseTLEs, satMagnitude, sunlitEci} from './horizon/sats.js';
       import {lineStrengths} from './horizon/airglow.js';
       import {fR, ZL_OMEGA} from './horizon/zodiacal.js';
       import {
@@ -2960,6 +2961,54 @@
         }
       }
 
+      // The naked-eye fleet: CelesTrak's `visual` group (the
+      // curated ~150 brightest satellites) via the daemon's /tles
+      // route (6 h cache - CelesTrak's own request), each
+      // propagated with the SAME SGP4 as the ISS and shown under
+      // the SAME visibility physics: above the horizon, outside
+      // Vallado's shadow cylinder, sky dark. Brightness from the
+      // McCants magnitude law (sats.js) on the Lambert phase law
+      // shared with earthshine; sets are checksum-verified before
+      // a single element is trusted. The ISS keeps its own path
+      // and is excluded here. ?tles=URL overrides the proxy.
+      const TLE_PROXY = params.get('tles') ?? 'https://api.ndev.tk/tles';
+      let satFleet = [];
+      async function syncFleet() {
+        try {
+          const text = await (
+            await fetch(TLE_PROXY, {credentials: 'omit'})
+          ).text();
+          const sets = parseTLEs(text).filter((s) => s.norad !== 25544);
+          if (!sets.length || !window.satellite) return;
+          satFleet = sets.map((s) => ({
+            name: s.name,
+            satrec: satellite.twoline2satrec(s.l1, s.l2),
+            r: null,
+            v: null,
+            t0: 0
+          }));
+          record(
+            'CelesTrak visual group',
+            satFleet.length + ' naked-eye satellites · SGP4 · checksummed'
+          );
+        } catch {
+          // keep the previous fleet; SGP4 holds for days
+        }
+      }
+      const SAT_DOT_N = 12;
+      const satDots = [];
+      {
+        const geo = new THREE.SphereGeometry(1.6, 8, 6);
+        for (let i = 0; i < SAT_DOT_N; i++) {
+          const m = new THREE.MeshBasicNodeMaterial({color: '#f2f5ff'});
+          aerial.applyTone(m);
+          const mesh = new THREE.Mesh(geo, m);
+          mesh.visible = false;
+          scene.add(mesh);
+          satDots.push(mesh);
+        }
+      }
+
       // Precipitation: one particle field, styled as rain or snow.
       const PRECIP_N = 1600;
       const precipArr = new Float32Array(PRECIP_N * 3);
@@ -4362,6 +4411,82 @@
           }
         }
 
+        // The fleet: every naked-eye satellite above the horizon,
+        // under the ISS's exact visibility physics (sats.js:
+        // Vallado shadow cylinder, McCants magnitude on the
+        // shared Lambert law). SGP4 refreshes round-robin (8 per
+        // frame, each ~10 us); between refreshes positions ride
+        // the stored velocity - under 10 ms of drift.
+        {
+          let dotI = 0;
+          if (satFleet.length && window.satellite && sun.alt < -0.05) {
+            const sEq2 = sunEquatorial(d);
+            const sHat = {
+              x: Math.cos(sEq2.dec) * Math.cos(sEq2.ra),
+              y: Math.cos(sEq2.dec) * Math.sin(sEq2.ra),
+              z: Math.sin(sEq2.dec)
+            };
+            const gmstNow = satellite.gstime(d);
+            const obsGd = {
+              latitude: state.lat * RAD,
+              longitude: state.lon * RAD,
+              height: centerElev / 1000
+            };
+            const obsEci = satellite.ecfToEci(
+              satellite.geodeticToEcf(obsGd),
+              gmstNow
+            );
+            const nowMs = d.getTime();
+            let refreshed = 0;
+            for (const f of satFleet) {
+              if (refreshed < 8 && nowMs - f.t0 > 10000) {
+                refreshed++;
+                f.t0 = nowMs;
+                const pv = satellite.propagate(f.satrec, d);
+                if (pv.position && pv.velocity) {
+                  f.r = pv.position;
+                  f.v = pv.velocity;
+                } else {
+                  f.r = null; // decayed or bad set - never drawn
+                }
+              }
+              if (!f.r || dotI >= SAT_DOT_N) continue;
+              const dtE = (nowMs - f.t0) / 1000;
+              const P = {
+                x: f.r.x + f.v.x * dtE,
+                y: f.r.y + f.v.y * dtE,
+                z: f.r.z + f.v.z * dtE
+              };
+              if (!sunlitEci(P, sHat)) continue;
+              const lk = satellite.ecfToLookAngles(
+                obsGd,
+                satellite.eciToEcf(P, gmstNow)
+              );
+              if (lk.elevation < 0.09) continue;
+              const tox = obsEci.x - P.x;
+              const toy = obsEci.y - P.y;
+              const toz = obsEci.z - P.z;
+              const tl = Math.hypot(tox, toy, toz);
+              const beta = Math.acos(
+                THREE.MathUtils.clamp(
+                  (tox * sHat.x + toy * sHat.y + toz * sHat.z) / tl,
+                  -1,
+                  1
+                )
+              );
+              const m = satMagnitude(lk.rangeSat, beta);
+              if (m > 4.6) continue; // below the naked eye
+              const dot = satDots[dotI++];
+              dot.visible = true;
+              dot.position.copy(skyPoint(lk.elevation, lk.azimuth, 820));
+              dot.scale.setScalar(
+                THREE.MathUtils.clamp(2.3 - 0.38 * m, 0.55, 3.2)
+              );
+            }
+          }
+          for (; dotI < SAT_DOT_N; dotI++) satDots[dotI].visible = false;
+        }
+
         let shakeX = 0;
         let shakeY = 0;
         if (state.shake > 0.005 && !reduceMotion) {
@@ -4569,6 +4694,8 @@
         setInterval(syncOvation, 30 * 60 * 1000);
         syncISS();
         setInterval(syncISS, 6 * 60 * 60 * 1000);
+        syncFleet();
+        setInterval(syncFleet, 6 * 60 * 60 * 1000);
         if (params.get('dem') !== '0') {
           try {
             demData = await fetchDEMTiles(state.lat, state.lon);

--- a/themes/horizon/WEBGPU-PLAN.md
+++ b/themes/horizon/WEBGPU-PLAN.md
@@ -1771,6 +1771,37 @@ Scenes (all at Grindelwald unless noted):
     slant-path thickening and silvery-blue tint are the
     documented display elements. ?nlc=N forces the envelope
     (geometry stays exact) for pinned shots.
+  - DONE: the naked-eye satellite fleet (sats.js) - the ISS's
+    visibility physics generalised to CelesTrak's curated
+    `visual` group (157 objects when fetched), Starlink trains
+    and all:
+    - daemon /tles route: CelesTrak GP data cached 6 h in memory
+      (their own request of clients), stale-served through
+      outages (TLEs hold for days), origin-locked like every
+      route - verified live (157 sets, cache hit on repeat)
+    - sats.js (gate set 26, 4 landmarks): TLE parsing gated by
+      the format's OWN integrity check (the modulo-10 checksum -
+      a one-digit corruption drops the set); Vallado's
+      cylindrical shadow with the boundary exactly at R_eq; the
+      McCants standard-magnitude law (m_std at 1000 km half
+      phase; +5 mag at 10x range exactly; full phase 2.5 log10
+      pi brighter) on the Lambert phase law IMPORTED from
+      earthshine.js - one phase law now serves the moon,
+      earthshine and satellites; and the vendored satellite.js
+      (Vallado's SGP4 - it runs unmodified in node, so the gate
+      drives the REAL propagator) holds a real 1963 element set
+      inside its own orbit band computed from the set's n and e.
+      Intrinsic magnitudes are not distributed with GP data: the
+      naked-eye class default 4.0 is the documented display
+      choice; every pass's GEOMETRY is exact.
+    - Theme: syncFleet (6 h, checksummed, ISS excluded - its
+      certified path stays); 12-dot pool; per frame SGP4
+      refreshes round-robin (8/frame, ~10 us each) with
+      velocity extrapolation between refreshes (<10 ms drift);
+      drawn only above the horizon, outside the shadow cylinder,
+      sun below -0.05 rad, and brighter than mag 4.6 - typically
+      a handful of moving points, which is what the real night
+      sky shows. ?tles=URL overrides the proxy.
   - OPEN (environment, not code): today's fixture rig drops the
     volumetric cloud decks and spams "2D view of 3D texture" Dawn
     validation errors from the Nubis noise volumes - bisect-shot

--- a/themes/horizon/harness/validate.sh
+++ b/themes/horizon/harness/validate.sh
@@ -24,7 +24,7 @@ REFDIR=${REFDIR:-..} # where the *-reference.mjs live
 fail=0
 
 echo "== CPU references (double precision, ground truth) =="
-for name in ocean atmo moon optics surf glint aurora leadr radar igrf scintillation ross-li cn2 airglow zodiacal meteors contrails ships navlights lightning milkyway earthshine nlc worker server; do
+for name in ocean atmo moon optics surf glint aurora leadr radar igrf scintillation ross-li cn2 airglow zodiacal meteors contrails ships navlights lightning milkyway earthshine nlc sats worker server; do
   ref="$REFDIR/$name-reference.mjs"
   if [ ! -f "$ref" ]; then echo "[FAIL] $name-reference.mjs missing"; fail=1; continue; fi
   if out=$(node "$ref" 2>&1); then

--- a/themes/horizon/sats-reference.mjs
+++ b/themes/horizon/sats-reference.mjs
@@ -1,0 +1,107 @@
+// Reference printer for the satellite fleet (node
+// sats-reference.mjs). The model lives once in sats.js; the
+// element set below is REAL (CelesTrak visual group, fetched
+// 2026-07-06: ATLAS CENTAUR 2, in orbit since 1963). Landmarks:
+//  - the TLE format's own integrity check: both lines' modulo-10
+//    checksums recompute to their column-69 digits; corrupting
+//    one digit is caught and the set is dropped
+//  - the vendored satellite.js (Vallado's SGP4) propagates the
+//    set to a radius inside its own orbit band: mean motion
+//    14.1255 rev/day -> a = 7233 km, e = 0.0546 -> r in
+//    6838..7628 km
+//  - Vallado's cylindrical shadow: sunward always lit; behind
+//    the Earth on-axis shadowed; behind but one radius off-axis
+//    lit; the boundary is R_eq exactly
+//  - the McCants magnitude law: m = m_std exactly at 1000 km and
+//    half phase; +5 mag at 10x the range (inverse square in
+//    magnitudes); full phase brighter by 2.5 log10(pi) = 1.24
+//    mag (the Lambert law is IMPORTED from earthshine.js - one
+//    phase law for moon, earthshine and satellites)
+import {createRequire} from 'node:module';
+import {
+  parseTLEs,
+  satMagnitude,
+  STD_MAG_DEFAULT,
+  sunlitEci,
+  tleChecksum
+} from './sats.js';
+
+const require = createRequire(import.meta.url);
+const satellite = require('./satellite.min.js');
+
+let fail = 0;
+const check = (name, ok, detail) => {
+  console.log(`${ok ? 'REF' : 'FAIL'} ${name}: ${detail}`);
+  if (!ok) fail++;
+};
+
+const NAME = 'ATLAS CENTAUR 2';
+const L1 =
+  '1 00694U 63047A   26187.22180987  .00001171  00000+0  13245-3 0  9997';
+const L2 =
+  '2 00694  30.3521 252.9455 0545738  45.3796 319.0018 14.12553441148390';
+
+{
+  const parsed = parseTLEs(NAME + '\n' + L1 + '\n' + L2 + '\n');
+  const corrupted = parseTLEs(
+    NAME + '\n' + L1.slice(0, 20) + '9' + L1.slice(21) + '\n' + L2 + '\n'
+  );
+  check(
+    'TLE checksums',
+    tleChecksum(L1) === Number(L1[68]) &&
+      tleChecksum(L2) === Number(L2[68]) &&
+      parsed.length === 1 &&
+      parsed[0].norad === 694 &&
+      parsed[0].name === NAME &&
+      corrupted.length === 0,
+    `both lines recompute to their column-69 digits (${L1[68]}/${L2[68]}); norad 694 parsed; a one-digit corruption drops the set`
+  );
+}
+
+{
+  const rec = satellite.twoline2satrec(L1, L2);
+  const pv = satellite.propagate(rec, new Date(Date.UTC(2026, 6, 6, 12)));
+  const r = Math.hypot(pv.position.x, pv.position.y, pv.position.z);
+  // n = 14.12553441 rev/day -> a = (mu/n^2)^(1/3) = 7233 km;
+  // e = 0.0545738 -> r in [a(1-e), a(1+e)]
+  const n = (14.12553441 * 2 * Math.PI) / 86400;
+  const a = Math.cbrt(398600.4418 / (n * n));
+  const lo = a * (1 - 0.0545738);
+  const hi = a * (1 + 0.0545738);
+  check(
+    'SGP4 orbit band',
+    r > lo && r < hi && Math.abs(a - 7233) < 5,
+    `propagated |r| = ${r.toFixed(0)} km inside [${lo.toFixed(0)}, ${hi.toFixed(0)}] from the set's own n and e (a = ${a.toFixed(0)} km)`
+  );
+}
+
+{
+  const s = {x: 1, y: 0, z: 0};
+  const lit = sunlitEci({x: 7000, y: 0, z: 0}, s);
+  const behind = sunlitEci({x: -7000, y: 0, z: 0}, s);
+  const offAxis = sunlitEci({x: -7000, y: 6400, z: 0}, s);
+  const justIn = sunlitEci({x: -7000, y: 6378, z: 0}, s);
+  check(
+    'shadow cylinder',
+    lit && !behind && offAxis && !justIn,
+    `sunward lit; on-axis behind shadowed; 6400 km off-axis lit, 6378 km (R_eq boundary) still shadowed - Vallado sec. 5.3`
+  );
+}
+
+{
+  const half = satMagnitude(1000, Math.PI / 2);
+  const far = satMagnitude(10000, Math.PI / 2);
+  const full = satMagnitude(1000, 0);
+  check(
+    'McCants magnitude law',
+    Math.abs(half - STD_MAG_DEFAULT) < 1e-12 &&
+      Math.abs(far - half - 5) < 1e-12 &&
+      Math.abs(half - full - 2.5 * Math.log10(Math.PI)) < 1e-12,
+    `m(1000 km, 90 deg) = m_std = ${half}; 10x range -> +5.000 mag exactly; full phase -> ${(half - full).toFixed(3)} mag brighter (2.5 log10(pi) exactly, Lambert law shared with earthshine)`
+  );
+}
+
+if (fail) {
+  console.log(`${fail} LANDMARK(S) FAILED`);
+  process.exit(1);
+}

--- a/themes/horizon/sats.js
+++ b/themes/horizon/sats.js
@@ -1,0 +1,98 @@
+/**
+ * Bright satellites - the single source shared by the theme's
+ * satellite fleet (Horizon.html) and the reference printer
+ * (sats-reference.mjs).
+ *
+ * The fleet is MEASURED: CelesTrak's `visual` group - the
+ * curated list of the ~150 satellites bright enough for the
+ * naked eye - fetched as two-line elements through the daemon
+ * (/tles, 6 h cache: CelesTrak asks exactly that of clients) and
+ * propagated in the page with SGP4 via the vendored satellite.js
+ * (Vallado's "Revisiting Spacetrack Report #3" implementation -
+ * the research code itself, also exercised by this module's
+ * reference against a real element set). The ISS keeps its own
+ * existing path and is excluded from the fleet.
+ *
+ * What this module owns:
+ *  - TLE parsing WITH the format's own integrity check: the
+ *    modulo-10 checksum (sum of digits, minus signs count 1) in
+ *    column 69 of each line - corrupted feeds are dropped line
+ *    by line, never propagated
+ *  - the cylindrical Earth-shadow test (Vallado sec. 5.3): a
+ *    satellite is sunlit unless it sits behind the terminator
+ *    plane AND within one Earth radius of the shadow axis - the
+ *    same construction the ISS block and the NLC shell use
+ *  - the standard-magnitude law of visual satellite observing
+ *    (McCants convention, used by every prediction service):
+ *    m = m_std + 5 log10(d / 1000 km)
+ *        - 2.5 log10(f(beta) / f(90 deg))
+ *    with f the Lambertian sphere phase law IMPORTED from
+ *    earthshine.js - the third body lit by reflection in this
+ *    theme, one phase law for all of them. m_std is the
+ *    magnitude at 1000 km and half phase; intrinsic values are
+ *    not distributed with GP data, so the fleet uses the
+ *    naked-eye class default 4.0 (documented display choice -
+ *    the GEOMETRY of every pass is exact).
+ */
+
+import {lambertPhase} from './earthshine.js';
+
+export const STD_MAG_DEFAULT = 4.0; // naked-eye class, 1000 km half phase
+export const R_EARTH_EQ = 6378.137; // WGS-84 equatorial radius, km
+
+// TLE line checksum: digits sum, '-' counts 1, modulo 10 equals
+// the last column.
+export function tleChecksum(line) {
+  let s = 0;
+  for (let i = 0; i < 68; i++) {
+    const c = line[i];
+    if (c >= '0' && c <= '9') s += c.charCodeAt(0) - 48;
+    else if (c === '-') s += 1;
+  }
+  return s % 10;
+}
+
+// Parse a name/line1/line2 TLE text into {name, norad, l1, l2}
+// entries, dropping any set whose checksum fails.
+export function parseTLEs(text) {
+  const lines = text.split(/\r?\n/);
+  const out = [];
+  for (let i = 0; i + 2 < lines.length + 1; i++) {
+    const l1 = lines[i + 1] || '';
+    const l2 = lines[i + 2] || '';
+    if (!l1.startsWith('1 ') || !l2.startsWith('2 ')) continue;
+    if (l1.length < 69 || l2.length < 69) continue;
+    if (tleChecksum(l1) !== Number(l1[68])) continue;
+    if (tleChecksum(l2) !== Number(l2[68])) continue;
+    out.push({
+      name: lines[i].trim(),
+      norad: Number(l1.slice(2, 7)),
+      l1,
+      l2
+    });
+    i += 2;
+  }
+  return out;
+}
+
+// Vallado's cylindrical shadow: rEci in km, sunDir a unit vector
+// toward the sun (equatorial frame). Sunlit on the sun side of
+// the terminator plane, or outside the shadow cylinder.
+export function sunlitEci(rEci, sunDir) {
+  const dp = rEci.x * sunDir.x + rEci.y * sunDir.y + rEci.z * sunDir.z;
+  if (dp >= 0) return true;
+  const px = rEci.x - dp * sunDir.x;
+  const py = rEci.y - dp * sunDir.y;
+  const pz = rEci.z - dp * sunDir.z;
+  return Math.hypot(px, py, pz) > R_EARTH_EQ;
+}
+
+// Apparent magnitude at range dKm and phase angle beta (rad).
+export function satMagnitude(dKm, beta, mStd = STD_MAG_DEFAULT) {
+  return (
+    mStd +
+    5 * Math.log10(Math.max(dKm, 1) / 1000) -
+    2.5 *
+      Math.log10(Math.max(lambertPhase(beta), 1e-9) / lambertPhase(Math.PI / 2))
+  );
+}

--- a/themes/horizon/server/src/index.mjs
+++ b/themes/horizon/server/src/index.mjs
@@ -571,6 +571,7 @@ function main() {
   const SSE_MAX = Number(env.SSE_MAX || 25);
   runBlitzSocket(blitz, sseClients, log);
 
+  let tlesCache = {t: 0, body: null}; // CelesTrak visual group
   const adsbCache = new Map(); // area key -> {t, body, src}
   setInterval(() => {
     const now = Date.now();
@@ -638,6 +639,45 @@ function main() {
         'content-type': 'application/json',
         ...extra
       });
+
+    if (url.pathname === '/tles') {
+      // CelesTrak's visual group (the ~150 naked-eye satellites)
+      // for the theme's SGP4 fleet. CelesTrak asks clients to
+      // fetch element sets at most every few hours - the 6 h
+      // in-memory cache honours that whatever the visitor count,
+      // and a stale copy serves through upstream outages (TLEs
+      // stay accurate for days).
+      if (tlesCache.body && Date.now() - tlesCache.t < 6 * 3600e3) {
+        return send(200, tlesCache.body, {
+          'content-type': 'text/plain',
+          'cache-control': 'public, max-age=21600',
+          'x-tle-source': 'celestrak.org (cached)'
+        });
+      }
+      try {
+        const r = await fetch(
+          'https://celestrak.org/NORAD/elements/gp.php?GROUP=visual&FORMAT=tle',
+          {signal: AbortSignal.timeout(15000), headers: {'user-agent': UA}}
+        );
+        if (!r.ok) throw new Error('celestrak ' + r.status);
+        const body = await r.text();
+        tlesCache = {t: Date.now(), body};
+        return send(200, body, {
+          'content-type': 'text/plain',
+          'cache-control': 'public, max-age=21600',
+          'x-tle-source': 'celestrak.org'
+        });
+      } catch {
+        if (tlesCache.body) {
+          return send(200, tlesCache.body, {
+            'content-type': 'text/plain',
+            'cache-control': 'public, max-age=3600',
+            'x-tle-source': 'celestrak.org (stale)'
+          });
+        }
+        return send(502, 'tles unavailable');
+      }
+    }
 
     if (url.pathname === '/health' || url.pathname === '/probe') {
       const ais = {


### PR DESCRIPTION
The last scouted sky item: the ISS's visibility physics generalised to the whole naked-eye satellite population - CelesTrak's curated `visual` group, 157 objects when fetched, Starlink trains included.

Daemon /tles: CelesTrak GP data cached 6 h in memory (their own request of clients), stale-served through upstream outages (TLEs hold for days), origin-locked like every route. Verified live: 157 element sets, cache hit on repeat.

sats.js (gate set 26, 4 landmarks):
- TLE parsing gated by the format's OWN integrity check - the modulo-10 checksum in column 69; a one-digit corruption drops the set before anything is propagated
- Vallado's cylindrical Earth-shadow test with the boundary exactly at R_eq
- the McCants standard-magnitude law: m_std at 1000 km half phase exactly, +5 mag at 10x range exactly, full phase 2.5 log10(pi) brighter - on the Lambert phase law IMPORTED from earthshine.js: one phase law now serves the moon, earthshine and the satellites
- the vendored satellite.js (Vallado's SGP4) runs unmodified in node, so the gate drives the REAL propagator: a real 1963 element set (ATLAS CENTAUR 2, checksum-verified, embedded verbatim) propagates inside the orbit band computed from its own mean motion and eccentricity

Intrinsic magnitudes are not distributed with GP data; the naked-eye class default (4.0) is the documented display choice - every pass's GEOMETRY is exact.

Theme: syncFleet every 6 h (checksummed, ISS excluded - its certified path stays); a 12-dot pool; SGP4 refreshes round-robin (8 per frame, ~10 us each) with velocity extrapolation between refreshes (<10 ms drift); drawn only above the horizon, outside the shadow cylinder, sky dark, and brighter than mag 4.6 - typically a handful of moving points, exactly what the real night sky shows. ?tles=URL overrides the proxy.

Gate: 26/26 reference sets pass.


Claude-Session: https://claude.ai/code/session_01NKKBen9kkD562HDVr7cXAx