### PR TITLE
Eclipses done right: exact lens obscuration + lunar eclipses

### DIFF
--- a/themes/Horizon.html
+++ b/themes/Horizon.html
@@ -219,6 +219,7 @@
       import {earthshineRatio} from './horizon/earthshine.js';
       import {BETA_MIN_DEG, seasonEnvelope} from './horizon/nlc.js';
       import {parseTLEs, satMagnitude, sunlitEci} from './horizon/sats.js';
+      import {lunarEclipse, solarEclipse} from './horizon/eclipses.js';
       import {lineStrengths} from './horizon/airglow.js';
       import {fR, ZL_OMEGA} from './horizon/zodiacal.js';
       import {
@@ -2636,6 +2637,9 @@
       }
       const mFlashDir = new THREE.Vector3();
       const eshV = new THREE.Vector3(); // earthshine phase temp
+      // Danjon L2 copper for the fully eclipsed moon (display
+      // level ~10% of the sunlit albedo, strongly reddened).
+      const eclCopper = new THREE.Color(0.3, 0.09, 0.04);
       const mV1 = new THREE.Vector3();
       const mV2 = new THREE.Vector3();
       const mV3 = new THREE.Vector3();
@@ -3368,36 +3372,77 @@
               const h = AE.Horizon(d, obs, eq.ra, eq.dec, 'normal');
               return {alt: h.altitude * RAD, az: h.azimuth * RAD};
             };
-            astro.sun = pos(AE.Body.Sun);
-            astro.moon = pos(AE.Body.Moon);
+            const eqSun = AE.Equator(AE.Body.Sun, d, obs, true, true);
+            const eqMoon = AE.Equator(AE.Body.Moon, d, obs, true, true);
+            const hSun = AE.Horizon(d, obs, eqSun.ra, eqSun.dec, 'normal');
+            const hMoon = AE.Horizon(d, obs, eqMoon.ra, eqMoon.dec, 'normal');
+            astro.sun = {alt: hSun.altitude * RAD, az: hSun.azimuth * RAD};
+            astro.moon = {alt: hMoon.altitude * RAD, az: hMoon.azimuth * RAD};
             // True apparent size: the moon disc scales with its real
             // distance (supermoon vs apogee is a visible ~7%).
             const distKm = AE.GeoMoon(d).Length() * AE.KM_PER_AU;
             astro.moonScale = (1500 * 1737) / distKm / 24;
-            // Solar eclipse: topocentric angular separation against the
-            // two real disc radii. Nonzero only when one is underway.
+            // Solar eclipse (eclipses.js): topocentric separation
+            // against the two TRUE disc radii - the sun's swings
+            // +-1.7% over the year, the whole difference between a
+            // total and an annular eclipse - and the light dims by
+            // the covered AREA (the exact lens integral), not the
+            // linear magnitude the first-pass code used. Reference-
+            // gated against Dallas 2024 and Galicia 2026-08-12.
             const cosSep =
               Math.sin(astro.sun.alt) * Math.sin(astro.moon.alt) +
               Math.cos(astro.sun.alt) *
                 Math.cos(astro.moon.alt) *
                 Math.cos(astro.sun.az - astro.moon.az);
-            const sepDeg =
-              Math.acos(THREE.MathUtils.clamp(cosSep, -1, 1)) / RAD;
-            const moonR = Math.asin(1737 / distKm) / RAD;
-            astro.eclipse = THREE.MathUtils.clamp(
-              (0.267 + moonR - sepDeg) / (2 * 0.267),
-              0,
-              1
+            const se = solarEclipse(
+              Math.acos(THREE.MathUtils.clamp(cosSep, -1, 1)),
+              eqSun.dist * AE.KM_PER_AU,
+              eqMoon.dist * AE.KM_PER_AU
             );
+            astro.eclipse = params.has('eclipse')
+              ? +params.get('eclipse')
+              : se.obsc;
             if (astro.eclipse > 0.05 && !astro.eclipseSaid) {
               astro.eclipseSaid = true;
               say(
-                'solar eclipse in progress · ~' +
+                (se.annular ? 'annular' : 'solar') +
+                  ' eclipse in progress · ' +
                   Math.round(astro.eclipse * 100) +
-                  '% obscured'
+                  '% of the photosphere covered · magnitude ' +
+                  se.mag.toFixed(2)
               );
             } else if (astro.eclipse < 0.01) {
               astro.eclipseSaid = false;
+            }
+            // Lunar eclipse (eclipses.js): the moon against the
+            // Danjon-enlarged umbra, from the same geocentric
+            // vectors; the copper darkening rides the umbral
+            // immersion in the moon-disc block below.
+            if (astro.moon.alt > -0.05) {
+              const sv = AE.GeoVector(AE.Body.Sun, d, true);
+              const mv = AE.GeoVector(AE.Body.Moon, d, true);
+              const sl = Math.hypot(sv.x, sv.y, sv.z);
+              const ml = Math.hypot(mv.x, mv.y, mv.z);
+              const cosA =
+                (-sv.x * mv.x - sv.y * mv.y - sv.z * mv.z) / (sl * ml);
+              astro.lunarEcl = lunarEclipse(
+                Math.acos(THREE.MathUtils.clamp(cosA, -1, 1)),
+                sl * AE.KM_PER_AU,
+                ml * AE.KM_PER_AU
+              );
+              if (astro.lunarEcl.inUmbra > 0.02 && !astro.lunarSaid) {
+                astro.lunarSaid = true;
+                say(
+                  'lunar eclipse · ' +
+                    Math.round(astro.lunarEcl.inUmbra * 100) +
+                    '% of the moon in the umbra · umbral magnitude ' +
+                    astro.lunarEcl.umbraMag.toFixed(2)
+                );
+              } else if (astro.lunarEcl.inUmbra < 0.01) {
+                astro.lunarSaid = false;
+              }
+            } else {
+              astro.lunarEcl = null;
             }
             for (let i = 0; i < PLANETS.length; i++) {
               const p = pos(AE.Body[PLANETS[i]]);
@@ -3459,6 +3504,24 @@
               THREE.MathUtils.clamp(moonU.sunDirM.value.dot(eshV), -1, 1)
             )
           ) * (params.has('eshine') ? +params.get('eshine') : 1);
+        // Lunar eclipse: the umbral immersion (exact lens geometry,
+        // eclipses.js) drives the copper darkening - inside the
+        // umbra the moon glows only with sunlight refracted through
+        // every terrestrial sunrise and sunset at once (Danjon's
+        // ashen red; the tint/level is the documented display
+        // mapping of a mid-scale L2 eclipse). The penumbra dims
+        // gently, as it really does.
+        {
+          const le = astro.lunarEcl;
+          const imm = le ? THREE.MathUtils.clamp(le.inUmbra, 0, 1) : 0;
+          const pen = le
+            ? THREE.MathUtils.clamp(le.penMag, 0, 1) * (1 - imm)
+            : 0;
+          moonU.albM.value
+            .setHex(0xcdd4e2)
+            .multiplyScalar(1 - 0.18 * pen)
+            .lerp(eclCopper, imm);
+        }
 
         polar.rotation.x = -(90 - state.lat) * RAD;
         celestial.rotation.y = -(gmst(d) + state.lon * RAD);

--- a/themes/horizon/WEBGPU-PLAN.md
+++ b/themes/horizon/WEBGPU-PLAN.md
@@ -1802,6 +1802,43 @@ Scenes (all at Grindelwald unless noted):
       sun below -0.05 rad, and brighter than mag 4.6 - typically
       a handful of moving points, which is what the real night
       sky shows. ?tles=URL overrides the proxy.
+  - DONE: eclipses done RIGHT (eclipses.js) - the first-pass
+    solar-eclipse code was exactly the kind of approximation this
+    project exists to remove, and lunar eclipses did not exist:
+    - the old code dimmed the light by the linear MAGNITUDE
+      (diameter fraction) with a fixed 0.267-deg sun. Replaced:
+      illuminance follows the covered AREA - the exact two-disc
+      lens integral (at magnitude 0.5 the true obscuration is
+      0.391: every partial phase was over-darkened by up to
+      ~28%) - and the sun's radius now comes from the true VSOP87
+      distance (its +-1.7% annual swing IS the total-vs-annular
+      distinction; the annular branch returns (r_m/r_s)^2).
+    - lunar eclipses: the classical geocentric shadow
+      construction with Danjon's 2% enlargement (the Almanac's
+      rule) - umbral/penumbral magnitudes and the exact umbral
+      AREA immersion, which drives a copper darkening of the
+      Hapke moon disc (Danjon L2 tint as the documented display
+      mapping; the penumbra dims gently, as it really does).
+    - eclipses-reference.mjs (gate set 27, 5 landmarks) validates
+      the EXACT chain the page runs (the vendored
+      astronomy-engine in node) against PUBLISHED history: the
+      lens integral at its closed forms + a deterministic grid
+      integration; Dallas 2024-04-08 TOTAL at 18:42 UT with
+      magnitude 1.013 (published 1.018) and FIRST CONTACT
+      bracketed to the published 17:23 UT; Galicia 2026-08-12 -
+      the eclipse five weeks from this commit - max obscuration
+      100.0% over 17:00-20:00 UT (our own ephemeris confirms the
+      totality); the 2026-03-03 total lunar eclipse peaking at
+      umbral magnitude 1.16 fully immersed, with the
+      Danjon-enlarged umbra spanning 2.70 moon radii (classical
+      ~2.7).
+    - Theme: astro block feeds eclipses.js from the SAME
+      AE.Equator results (sun distance now captured); the
+      existing dimming plumbing (direct 1-0.93f, ambient 1-0.85f)
+      consumes the new area obscuration unchanged; say() reports
+      obscuration + magnitude + annular; ?eclipse=f harness
+      override. On 2026-08-12 every visitor in the path gets the
+      real darkness at the real minute.
   - OPEN (environment, not code): today's fixture rig drops the
     volumetric cloud decks and spams "2D view of 3D texture" Dawn
     validation errors from the Nubis noise volumes - bisect-shot

--- a/themes/horizon/eclipses-reference.mjs
+++ b/themes/horizon/eclipses-reference.mjs
@@ -1,0 +1,177 @@
+// Reference printer for eclipses (node eclipses-reference.mjs).
+// The model lives once in eclipses.js; the ephemeris is the
+// VENDORED astronomy-engine (the same instance the theme runs),
+// so the landmarks validate the exact chain the page executes -
+// against PUBLISHED eclipse history:
+//  - the lens integral at its closed forms: disjoint 0, total 1,
+//    annular (r_m/r_s)^2, equal discs at sep = r covering
+//    0.391000 (2 acos(1/2)/pi - sqrt(3)/(2 pi) exactly), and a
+//    deterministic grid integration agreeing to 1e-3
+//  - magnitude vs obscuration: at magnitude 0.5 (equal discs)
+//    the AREA obscuration is 0.391 - the ~28% of light the old
+//    linear dimming got wrong at every partial phase
+//  - 2024-04-08, Dallas (32.78 N, 96.80 W), 18:42 UT: TOTAL
+//    (obscuration = 1) - the historical record; 17:00 UT partial
+//    (0 < f < 1); the day before, nothing
+//  - 2026-08-12, Galicia (43.0 N, 8.0 W): the upcoming totality
+//    - max obscuration over 17:00-20:00 UT exceeds 0.95
+//  - 2026-03-03, ~11:33 UT: total LUNAR eclipse - umbral
+//    magnitude >= 1 with the moon fully immersed; the Danjon-
+//    enlarged umbra is ~2.7 moon diameters wide, the classical
+//    figure
+import {createRequire} from 'node:module';
+import {
+  DANJON,
+  discObscuration,
+  lunarEclipse,
+  solarEclipse
+} from './eclipses.js';
+
+const require = createRequire(import.meta.url);
+const AE = require('./astronomy.browser.min.js');
+const RAD = Math.PI / 180;
+
+let fail = 0;
+const check = (name, ok, detail) => {
+  console.log(`${ok ? 'REF' : 'FAIL'} ${name}: ${detail}`);
+  if (!ok) fail++;
+};
+
+// Topocentric solar-eclipse state at a site and instant.
+function solarAt(latDeg, lonDeg, date) {
+  const obs = new AE.Observer(latDeg, lonDeg, 100);
+  const s = AE.Equator(AE.Body.Sun, date, obs, true, true);
+  const m = AE.Equator(AE.Body.Moon, date, obs, true, true);
+  const sep = Math.acos(
+    Math.min(
+      1,
+      Math.sin(s.dec * RAD) * Math.sin(m.dec * RAD) +
+        Math.cos(s.dec * RAD) *
+          Math.cos(m.dec * RAD) *
+          Math.cos((s.ra - m.ra) * 15 * RAD)
+    )
+  );
+  return solarEclipse(sep, s.dist * AE.KM_PER_AU, m.dist * AE.KM_PER_AU);
+}
+
+// Geocentric lunar-eclipse state at an instant.
+function lunarAt(date) {
+  const sv = AE.GeoVector(AE.Body.Sun, date, true);
+  const mv = AE.GeoVector(AE.Body.Moon, date, true);
+  const sl = Math.hypot(sv.x, sv.y, sv.z);
+  const ml = Math.hypot(mv.x, mv.y, mv.z);
+  // separation of the moon from the ANTISOLAR direction
+  const cosSep = (-sv.x * mv.x - sv.y * mv.y - sv.z * mv.z) / (sl * ml);
+  const sep = Math.acos(Math.max(-1, Math.min(1, cosSep)));
+  return lunarEclipse(sep, sl * AE.KM_PER_AU, ml * AE.KM_PER_AU);
+}
+
+{
+  const equalAtR = discObscuration(1, 1, 1);
+  const exact = (2 * Math.acos(0.5)) / Math.PI - Math.sqrt(3) / (2 * Math.PI);
+  // deterministic grid integration of the same case
+  const N = 1500;
+  let inside = 0;
+  let total = 0;
+  for (let i = 0; i < N; i++) {
+    for (let j = 0; j < N; j++) {
+      const x = ((i + 0.5) / N) * 2 - 1;
+      const y = ((j + 0.5) / N) * 2 - 1;
+      if (x * x + y * y > 1) continue;
+      total++;
+      const dx = x - 1;
+      if (dx * dx + y * y <= 1) inside++;
+    }
+  }
+  check(
+    'lens integral',
+    discObscuration(3, 1, 1) === 0 &&
+      discObscuration(0.1, 1, 1.5) === 1 &&
+      Math.abs(discObscuration(0, 1, 0.5) - 0.25) < 1e-15 &&
+      Math.abs(equalAtR - exact) < 1e-15 &&
+      Math.abs(equalAtR - inside / total) < 1e-3,
+    `disjoint 0; total 1; annular (r_m/r_s)^2 = 0.25 exact; equal discs at sep = r -> ${equalAtR.toFixed(6)} (closed form ${exact.toFixed(6)}, grid ${(inside / total).toFixed(6)})`
+  );
+}
+
+{
+  // The correction this module exists for: magnitude 0.5 is NOT
+  // half the light gone.
+  const e = solarEclipse(
+    0.005,
+    695990 / Math.sin(0.005),
+    1737.4 / Math.sin(0.005)
+  );
+  // build an exact equal-disc, sep = r case instead:
+  const r = 0.005;
+  const obsc = discObscuration(r, r, r);
+  check(
+    'magnitude vs obscuration',
+    Math.abs(obsc - 0.391) < 5e-4 && e.obsc >= 0,
+    `equal discs, magnitude 0.5 -> area obscuration ${obsc.toFixed(4)} - the ~28% of light the old linear dimming overdarkened`
+  );
+}
+
+{
+  const total = solarAt(32.78, -96.8, new Date(Date.UTC(2024, 3, 8, 18, 42)));
+  const before = solarAt(32.78, -96.8, new Date(Date.UTC(2024, 3, 8, 17, 20)));
+  const after = solarAt(32.78, -96.8, new Date(Date.UTC(2024, 3, 8, 17, 30)));
+  const none = solarAt(32.78, -96.8, new Date(Date.UTC(2024, 3, 7, 18, 42)));
+  check(
+    'Dallas 2024-04-08',
+    total.obsc === 1 &&
+      !total.annular &&
+      total.mag > 1.005 &&
+      total.mag < 1.03 &&
+      before.obsc === 0 &&
+      after.obsc > 0 &&
+      after.obsc < 0.1 &&
+      none.obsc === 0,
+    `18:42 UT -> obscuration 1 (TOTAL, as history records; magnitude ${total.mag.toFixed(3)}, published 1.018); FIRST CONTACT bracketed: 17:20 UT -> 0, 17:30 UT -> ${(after.obsc * 100).toFixed(1)}% (published 17:23); the day before 0`
+  );
+}
+
+{
+  // The upcoming one: 2026-08-12, totality over Galicia near
+  // sunset. Max obscuration sampled per minute.
+  let best = 0;
+  for (let min = 0; min < 180; min++) {
+    const e = solarAt(43.0, -8.0, new Date(Date.UTC(2026, 7, 12, 17, min)));
+    if (e.obsc > best) best = e.obsc;
+  }
+  check(
+    'Galicia 2026-08-12',
+    best > 0.95,
+    `max obscuration over 17:00-20:00 UT = ${(best * 100).toFixed(1)}% - the eclipse five weeks from this commit`
+  );
+}
+
+{
+  // 2026-03-03 total lunar eclipse (greatest ~11:33 UT).
+  let bestMag = 0;
+  let bestIn = 0;
+  for (let min = 0; min < 150; min++) {
+    const l = lunarAt(new Date(Date.UTC(2026, 2, 3, 10, 30 + min)));
+    if (l.umbraMag > bestMag) {
+      bestMag = l.umbraMag;
+      bestIn = l.inUmbra;
+    }
+  }
+  const quiet = lunarAt(new Date(Date.UTC(2026, 2, 17, 11, 33)));
+  const geom = lunarAt(new Date(Date.UTC(2026, 2, 3, 11, 33)));
+  check(
+    'lunar 2026-03-03',
+    bestMag >= 1 &&
+      bestIn >= 0.999 &&
+      quiet.umbraMag < 0 &&
+      geom.umbra / geom.rMoon > 2 &&
+      geom.umbra / geom.rMoon < 3.5 &&
+      DANJON === 1.02,
+    `umbral magnitude peaks at ${bestMag.toFixed(2)} (total, fully immersed); two weeks later ${quiet.umbraMag.toFixed(1)}; the Danjon-enlarged umbra spans ${(geom.umbra / geom.rMoon).toFixed(2)} moon radii (classical ~2.7)`
+  );
+}
+
+if (fail) {
+  console.log(`${fail} LANDMARK(S) FAILED`);
+  process.exit(1);
+}

--- a/themes/horizon/eclipses.js
+++ b/themes/horizon/eclipses.js
@@ -1,0 +1,119 @@
+/**
+ * Eclipses - the single source shared by the theme
+ * (Horizon.html) and the reference printer
+ * (eclipses-reference.mjs).
+ *
+ * Replaces the theme's first-pass eclipse code, which used the
+ * linear MAGNITUDE (fraction of the sun's DIAMETER covered) with
+ * a fixed 0.267-deg sun to dim the light. Both were
+ * approximations of exactly the kind this project exists to
+ * remove:
+ *  - illuminance follows the covered AREA (the two-disc lens
+ *    integral, closed form below): at magnitude 0.5 the true
+ *    obscuration is 0.391, not 0.5 - the old code over-darkened
+ *    every partial phase by up to ~30%
+ *  - the sun's angular radius swings +-1.7% over the year (959.63
+ *    arcsec at 1 AU - the IAU photospheric radius over the true
+ *    VSOP87 distance), and that swing is the entire difference
+ *    between a TOTAL and an ANNULAR eclipse
+ *
+ * Solar: topocentric separation (the theme already has it) against
+ * the two TRUE disc radii; discObscuration() gives the covered
+ * fraction of the photosphere with the exact circle-circle lens
+ * area, including the annular branch (fraction = (r_m/r_s)^2 when
+ * the moon sits inside the sun's disc).
+ *
+ * Lunar: the classical geocentric shadow construction (Chauvenet;
+ * the 2% shadow enlargement is Danjon's rule for the terrestrial
+ * atmosphere - the same rule the Astronomical Almanac applies):
+ *   umbra    = 1.02 (pi_moon + pi_sun - s_sun)
+ *   penumbra = 1.02 (pi_moon + pi_sun + s_sun)
+ * with the parallaxes and solar radius from the true distances,
+ * measured from the ANTISOLAR point. The umbral magnitude
+ * (u + r_m - sep) / (2 r_m) drives the copper darkening of the
+ * moon disc - during totality the moon glows with light refracted
+ * through every sunrise and sunset on Earth at once.
+ *
+ * The ephemerides are astronomy-engine (vendored; VSOP87/ELP) -
+ * the same instance the theme drives; reference-gated here
+ * against PUBLISHED history: the 2024-04-08 Dallas totality, the
+ * upcoming 2026-08-12 totality over Galicia, and the 2026-03-03
+ * total lunar eclipse.
+ */
+
+export const R_SUN_KM = 696000; // IAU photospheric radius
+export const R_MOON_KM = 1737.4;
+export const R_EARTH_EQ_KM = 6378.137;
+export const DANJON = 1.02; // shadow enlargement (Danjon's rule)
+
+// Fraction of disc 1 (the sun) covered by disc 2 (the moon):
+// exact two-circle lens area. All angles in radians (small-angle
+// safe: these are ~0.005 rad discs).
+export function discObscuration(sep, rSun, rMoon) {
+  if (sep >= rSun + rMoon) return 0;
+  if (sep <= rMoon - rSun) return 1; // total
+  if (sep <= rSun - rMoon) return (rMoon * rMoon) / (rSun * rSun); // annular
+  const d = Math.max(sep, 1e-12);
+  const a1 =
+    rSun *
+    rSun *
+    Math.acos((d * d + rSun * rSun - rMoon * rMoon) / (2 * d * rSun));
+  const a2 =
+    rMoon *
+    rMoon *
+    Math.acos((d * d + rMoon * rMoon - rSun * rSun) / (2 * d * rMoon));
+  const tri =
+    0.5 *
+    Math.sqrt(
+      Math.max(
+        (-d + rSun + rMoon) *
+          (d + rSun - rMoon) *
+          (d - rSun + rMoon) *
+          (d + rSun + rMoon),
+        0
+      )
+    );
+  return (a1 + a2 - tri) / (Math.PI * rSun * rSun);
+}
+
+// Solar eclipse at the observer: separation (rad, topocentric)
+// plus the TRUE distances (km) -> obscuration (area fraction,
+// what the light does) and magnitude (diameter fraction, what
+// the almanacs quote).
+export function solarEclipse(sepRad, distSunKm, distMoonKm) {
+  const rSun = Math.asin(R_SUN_KM / distSunKm);
+  const rMoon = Math.asin(R_MOON_KM / distMoonKm);
+  const obsc = discObscuration(sepRad, rSun, rMoon);
+  const mag = Math.max((rSun + rMoon - sepRad) / (2 * rSun), 0);
+  return {obsc, mag, rSun, rMoon, annular: rMoon < rSun && obsc > 0};
+}
+
+// Lunar eclipse circumstances from geocentric positions: the
+// moon's angular separation from the ANTISOLAR point (rad) and
+// the two true distances. Returns the penumbral and umbral
+// magnitudes (almanac convention) and the umbral IMMERSION
+// fraction (0..1 area, driving the copper darkening).
+export function lunarEclipse(sepAntisolarRad, distSunKm, distMoonKm) {
+  const piM = Math.asin(R_EARTH_EQ_KM / distMoonKm);
+  const piS = Math.asin(R_EARTH_EQ_KM / distSunKm);
+  const sS = Math.asin(R_SUN_KM / distSunKm);
+  const umbra = DANJON * (piM + piS - sS);
+  const penumbra = DANJON * (piM + piS + sS);
+  const rM = Math.asin(R_MOON_KM / distMoonKm);
+  const umbraMag = (umbra + rM - sepAntisolarRad) / (2 * rM);
+  const penMag = (penumbra + rM - sepAntisolarRad) / (2 * rM);
+  // area immersion in the umbra: the same lens integral with the
+  // umbra as the "sun" disc and the moon as the cover, read the
+  // other way round (fraction of the MOON inside the umbra)
+  const inUmbra =
+    (discObscuration(sepAntisolarRad, umbra, rM) * (Math.PI * umbra * umbra)) /
+    (Math.PI * rM * rM);
+  return {
+    umbraMag,
+    penMag,
+    umbra,
+    penumbra,
+    rMoon: rM,
+    inUmbra: Math.min(inUmbra, 1)
+  };
+}

--- a/themes/horizon/harness/validate.sh
+++ b/themes/horizon/harness/validate.sh
@@ -24,7 +24,7 @@ REFDIR=${REFDIR:-..} # where the *-reference.mjs live
 fail=0
 
 echo "== CPU references (double precision, ground truth) =="
-for name in ocean atmo moon optics surf glint aurora leadr radar igrf scintillation ross-li cn2 airglow zodiacal meteors contrails ships navlights lightning milkyway earthshine nlc sats worker server; do
+for name in ocean atmo moon optics surf glint aurora leadr radar igrf scintillation ross-li cn2 airglow zodiacal meteors contrails ships navlights lightning milkyway earthshine nlc sats eclipses worker server; do
   ref="$REFDIR/$name-reference.mjs"
   if [ ! -f "$ref" ]; then echo "[FAIL] $name-reference.mjs missing"; fail=1; continue; fi
   if out=$(node "$ref" 2>&1); then


### PR DESCRIPTION
The first-pass solar-eclipse code was precisely the kind of approximation this project exists to remove - and lunar eclipses did not exist at all.

Solar (eclipses.js):
- the old code dimmed light by the linear MAGNITUDE (diameter fraction) with a fixed 0.267-deg sun. Illuminance follows the covered AREA: the exact two-disc lens integral (closed forms landmarked, plus a deterministic grid integration to 1e-3). At magnitude 0.5 the true obscuration is 0.391 - every partial phase was over-darkened by up to ~28%.
- the sun's angular radius now comes from the true VSOP87 distance; its +-1.7% annual swing IS the total-vs-annular distinction, and the annular branch returns (r_m/r_s)^2.

Lunar (new): the classical geocentric shadow construction with Danjon's 2% enlargement (the Almanac's rule) - umbral and penumbral magnitudes plus the exact umbral AREA immersion, which drives a copper darkening of the Hapke moon disc (Danjon L2 tint as the documented display mapping; the penumbra dims gently, as it really does).

eclipses-reference.mjs (gate set 27) validates the EXACT chain the page runs - the vendored astronomy-engine in node - against published history:
- Dallas 2024-04-08: TOTAL at 18:42 UT, magnitude 1.013 (published 1.018), first contact bracketed to the published 17:23 UT (0% at 17:20, 3.2% at 17:30)
- Galicia 2026-08-12 - five weeks from this commit: max obscuration 100.0% over 17:00-20:00 UT; our own ephemeris confirms the upcoming totality
- 2026-03-03 total lunar eclipse: umbral magnitude peaks 1.16 fully immersed; the Danjon-enlarged umbra spans 2.70 moon radii (classical ~2.7)

Theme: the astro block feeds eclipses.js from the same AE.Equator results (sun distance now captured); the existing dimming plumbing consumes the new area obscuration unchanged; say() reports obscuration + magnitude + annular; ?eclipse=f harness override.

Gate: 27/27 reference sets pass.


Claude-Session: https://claude.ai/code/session_01NKKBen9kkD562HDVr7cXAx