### PR TITLE
METAR: aerodromes measure the sky, and measured beats modelled

### DIFF
--- a/themes/Horizon.html
+++ b/themes/Horizon.html
@@ -105,7 +105,8 @@
         weather code), quake (magnitude), kp (0-9), aurora (0-1),
         auroralat (deg), dem=0 (skip real terrain), demtiles=URL
         (terrarium tile endpoint override), roam=0 (pin the box),
-        space=URL (solar-wind endpoint override), debug=1
+        space=URL (solar-wind endpoint override), metar=URL (aerodrome
+        observation endpoint override), debug=1
     -->
     <style>
       html,
@@ -319,6 +320,7 @@
         yOfElev
       } from './horizon/roam.js';
       import {hpScale} from './horizon/solarwind.js';
+      import {etageCovers, pickStation, visibilityM} from './horizon/metar.js';
       import {lineStrengths} from './horizon/airglow.js';
       import {fR, ZL_OMEGA} from './horizon/zodiacal.js';
       import {
@@ -453,6 +455,7 @@
         auroraLat: 68,
         hpNow: null, // OVATION hemispheric power, GW (live, 5 min)
         hpAtGrid: null, // ...as it was when the oval grid was fetched
+        metar: null, // nearest fresh aerodrome observation (metar.js)
         sea: null, // measured wave partitions (marine model), null = wind sea
         shake: 0
       };
@@ -1329,6 +1332,65 @@
           applySpace(j);
         } catch {
           // Stream event or the next poll refreshes it.
+        }
+      }
+
+      // Aerodrome observations: the nearest fresh METAR is a
+      // MEASUREMENT of the sky - ceilometer cloud bases, layer
+      // covers, transmissometer visibility - and it outranks the
+      // model where it can see (the same rule the radar layer
+      // follows). Scope is deliberate: METAR governs the LOW
+      // etage (measured deck base + cover) and the visibility;
+      // automated ceilometers are blind above a few km, so the
+      // mid and high decks stay with the model. Via the daemon
+      // (/metar - aviationweather.gov sends no CORS header).
+      const METAR_PROXY = params.get('metar') ?? 'https://api.ndev.tk/metar';
+      async function syncMetar() {
+        if (overridden) return;
+        try {
+          const r = await (
+            await fetch(
+              METAR_PROXY +
+                '?lat=' +
+                state.lat.toFixed(3) +
+                '&lon=' +
+                state.lon.toFixed(3),
+              {credentials: 'omit'}
+            )
+          ).json();
+          const s = pickStation(
+            r.metars,
+            state.lat,
+            state.lon,
+            Date.now() / 1000
+          );
+          if (!s) {
+            state.metar = null;
+            return;
+          }
+          const e = etageCovers(s.clouds);
+          state.metar = {
+            at: Date.now(),
+            id: s.id,
+            km: s.km,
+            low: e.low,
+            baseM: e.baseM,
+            visM: visibilityM(s.visib),
+            wx: s.wx
+          };
+          record(
+            'METAR ' + s.id + ' (' + s.km.toFixed(0) + ' km)',
+            (s.cover ?? 'sky') +
+              (e.baseM !== null
+                ? ' · measured base ' + Math.round(e.baseM) + ' m'
+                : '') +
+              (state.metar.visM !== null
+                ? ' · vis ' + (state.metar.visM / 1000).toFixed(1) + ' km'
+                : '') +
+              (s.wx ? ' · ' + s.wx : '')
+          );
+        } catch {
+          // The model stands.
         }
       }
 
@@ -3874,6 +3936,7 @@
           state.lat = geo.lat;
           state.lon = geo.lon;
           state.place = '';
+          state.metar = null; // the old station no longer speaks for here
           pinnedLoc = true; // geolocation must not snap us home
           buildWorld(); // new centerElev, moments, water, trees
           freeCam.pos.x = 0;
@@ -3934,6 +3997,7 @@
         syncBrdf();
         syncShips();
         syncTraffic();
+        syncMetar();
       }
       function maybeRoam(now, moved) {
         if (moved) lastMoveMs = now;
@@ -4188,9 +4252,16 @@
         aerialU.uFogColor.value.copy(tmpB);
         // Koschmieder relation: extinction from the MEASURED visibility
         // (2% contrast at V). Fog codes need no special-casing - a foggy
-        // hour reports a short visibility by itself.
+        // hour reports a short visibility by itself. A fresh nearby
+        // METAR's transmissometer reading outranks the model value.
+        const visEff =
+          state.metar &&
+          Date.now() - state.metar.at < 90 * 60e3 &&
+          state.metar.visM !== null
+            ? state.metar.visM
+            : state.visibility;
         aerialU.uFogDensity.value =
-          1.98 / (Math.max(state.visibility, 400) / MPU) + cloudy * 0.001;
+          1.98 / (Math.max(visEff, 400) / MPU) + cloudy * 0.001;
 
         // A real solar eclipse dims the direct light by its obscuration.
         const ecl = astro.eclipse || 0;
@@ -4810,15 +4881,29 @@
           (state.lat < 0 ? Math.PI : 0) - (state.magD ?? 0) * RAD;
 
         // Three cloud layers from the model's real per-layer covers.
-        // Cumulus base at the real lifting condensation level (Espy:
-        // ~125m per degree of dew point spread), clamped above the
-        // camera because the asinh height compression squeezes low
-        // decks harder than the terrain they sit over.
-        const cLow = state.cloudLow ?? state.cloud * 0.7;
+        // A fresh nearby METAR outranks the model where it can see:
+        // its ceilometer MEASURED the low deck's base and cover, so
+        // those replace the Espy LCL estimate (~125m per degree of
+        // dew point spread) and the model's low cover; automated
+        // ceilometers are blind above a few km, so the mid and high
+        // decks stay with the model. Clamped above the camera
+        // because the asinh height compression squeezes low decks
+        // harder than the terrain they sit over.
+        const mzr =
+          state.metar && Date.now() - state.metar.at < 90 * 60e3
+            ? state.metar
+            : null;
+        const cLow = mzr ? mzr.low : (state.cloudLow ?? state.cloud * 0.7);
         const cMid = state.cloudMid ?? state.cloud * 0.5;
         const cHigh = state.cloudHigh ?? state.cloud * 0.3;
-        const lcl = Math.max(125 * (state.temp - state.dew), 150);
-        const yCloud = Math.max(16 * Math.asinh(lcl / 500) + 8, camBaseY + 26);
+        const baseAgl =
+          mzr && mzr.baseM !== null
+            ? mzr.baseM // ceilometer measurement
+            : Math.max(125 * (state.temp - state.dew), 150); // Espy LCL
+        const yCloud = Math.max(
+          16 * Math.asinh(baseAgl / 500) + 8,
+          camBaseY + 26
+        );
         // Each deck rides its own real wind: surface, 700hPa, 250hPa jet.
         const driftLayer = (arr, cover, y, wv, speed) => {
           const showN = Math.round((cover / 100) * arr.length);
@@ -5435,6 +5520,8 @@
         syncOvation();
         setInterval(syncOvation, 30 * 60 * 1000);
         syncSpace();
+        syncMetar();
+        setInterval(syncMetar, 10 * 60 * 1000);
         setInterval(syncSpace, 5 * 60 * 1000);
         syncISS();
         setInterval(syncISS, 6 * 60 * 60 * 1000);

--- a/themes/horizon/WEBGPU-PLAN.md
+++ b/themes/horizon/WEBGPU-PLAN.md
@@ -1144,7 +1144,7 @@ Scenes (all at Grindelwald unless noted):
       v = 21 m/s, A = 1.7e-14 (the first web-checked source that
       said v = 27 was wrong; the SPIE Field Guide's 21 lands both
       named values); the instantaneous Rytov point-receiver index
-      sigma_I^2 = 2.25 k^(7/6) sec(Z)^(11/6) mu_{5/6} sits in the
+      sigma*I^2 = 2.25 k^(7/6) sec(Z)^(11/6) mu*{5/6} sits in the
       weak regime at ~0.49, consistent with Young's 0.1 s-averaged
       0.255; the ITU RMS-wind integral is exact on analytic
       profiles and refuses profiles that do not span the slab;
@@ -1154,8 +1154,8 @@ Scenes (all at Grindelwald unless noted):
       crossing rate lands at ~500 Hz = the published milliseconds
       shadow lifetime (Dravins et al. 1997 II).
     - Display: sigZen (new star uniform) = Young's calibrated
-      zenith sigma x sigmaScale(v_RMS) = sqrt(mu_{5/6}(v)/
-      mu_{5/6}(21)) - a calm upper atmosphere steadies the stars, a
+      zenith sigma x sigmaScale(v*RMS) = sqrt(mu*{5/6}(v)/
+      mu\_{5/6}(21)) - a calm upper atmosphere steadies the stars, a
       screaming jet churns them - clamped 0.05..0.6; twRate now
       comes from the profile's Fresnel-shadow crossing rate
       (W-weighted wind over W-weighted altitude) divided by 50
@@ -1214,7 +1214,7 @@ Scenes (all at Grindelwald unless noted):
       the bathymetry bake stores SIGNED depth clamp(-e/40, -1, 1)
       (float texture - shoreline texels keep their real height
       above MSL instead of clamping to zero), and water-tsl
-      computes max(store*40 + tide, 0) before the surf LUT sample -
+      computes max(store\*40 + tide, 0) before the surf LUT sample -
       exactly max(tide - e, 0) for all |e| <= 40 m, held as a
       surf-reference landmark. High water drowns the breakpoint
       bars, low water exposes them, the McCowan/BJ criterion
@@ -1347,163 +1347,139 @@ Scenes (all at Grindelwald unless noted):
   - DONE (deployed at https://horizon-adsb.ndevtk.workers.dev):
     live ADS-B aircraft via a Cloudflare Worker
     (themes/horizon/worker). The owner green-lit workers, which
-    removes the CORS wall from the contrail item:
-    - horizon-adsb (src/index.js + wrangler.toml): an allowlisted
-      proxy - GET /adsb?lat&lon&dist only, numeric-validated,
-      dist <= 60 nm, coordinates rounded to ~110 m so nearby
-      visitors share a 15 s edge-cached upstream call. NOT an open
-      proxy. Verified end-to-end with `wrangler dev --local`: CORS
-      header added, live traffic flowing (a Condor A20N at FL360
-      over the test site, feed OAT -53 degC - consistent with the
-      measured 250 hPa air; 38 aircraft over Heathrow on the
-      OpenSky-era recheck), 404/400 on anything else.
-    - Upstream reality (measured on the DEPLOYED worker, not just
-      locally, over two rounds): api.adsb.lol AND opendata.adsb.fi
-      don't just refuse Cloudflare-egress requests - they TARPIT
-      them. Round 1 read as hard 429s; round 2 (after the failover
-      build deployed) measured 5 of 6 probes hanging past 15 s
-      with one sub-second 32-aircraft success - so ANY failover
-      chain through the readsb feeds stalls the whole request
-      before the next upstream gets a turn. The same queries
-      answer sub-second from a residential IP. Decision (owner:
-      "one good data source"): the readsb upstreams are DROPPED;
-      OpenSky became the single source for one round (SUPERSEDED
-      by the edge measurement below - OpenSky network-drops CF
-      ranges too, which only /probe could see). Its restrictive
-      CORS never
-      mattered behind a server-side proxy (the original objection
-      only applied to direct browser fetches - the owner called
-      this out). OpenSky takes a bounding box (1 nm latitude =
-      exactly 1/60 deg; longitude widened by 1/cos lat) and speaks
-      positional state vectors in SI units, so the worker
-      normalizes into the readsb shape with the exact
-      international foot and knot - the theme keeps ONE parser.
-      x-adsb-source names the mode per response.
-    - (SUPERSEDED, kept as history) Making the OpenSky source
-      good: OpenSky's anonymous tier buckets
-      400 daily credits per IP - Cloudflare's shared egress
-      exhausts that pool, which is the measured ~50% 503 shedding.
-      A registered API client gets 4000 credits/day on its OWN
-      account (docs: openskynetwork.github.io/opensky-api); the
-      15 nm box is far under the 25 sq deg 1-credit tier, and the
-      15 s edge cache spends the budget frugally. The worker does
-      OAuth2 client-credentials against the OpenSky Keycloak
-      (endpoint verified live: invalid_client 401 for bogus
-      creds), caches the 30-minute Bearer token per isolate,
-      refreshes once on a server-side 401, and falls back to
-      anonymous (with 2 shed-absorbing retries, 400 ms apart) when
-      the secrets are absent. Every upstream fetch carries a hard
-      4 s AbortSignal timeout - the tarpit measurement is exactly
-      why. Owner setup: create an API client on the OpenSky
-      account page, then `npx wrangler secret put
-OPENSKY_CLIENT_ID` + `OPENSKY_CLIENT_SECRET` and redeploy.
-    - worker-reference.mjs (gate set 18, airplanes.live build):
-      the worker module runs UNMODIFIED in node, so the gate
-      exercises the real handler offline - fetch stubbed with the
-      measured failure modes - asserting the /v2/point URL shape,
-      the strip to exactly the theme's seven fields with readsb
-      units UNTOUCHED, "ground"/incomplete vectors dropped, a 429
-      blip carried by the rate-respecting retry with the
-      User-Agent sent, CORS + x-adsb-source, the adsbToScene
-      round-trip, /probe mapping statuses and thrown timeouts
-      alike into inspectable rows, and the 404/400/OPTIONS
-      allowlist. Live checks: the real handler run in node served
-      14 aircraft over Heathrow / 3 alpine / 5 JFK from
-      airplanes.live; workerd (`wrangler dev --local`) 15 over
-      Heathrow with exactly the seven fields.
-    - Theme: syncTraffic polls the worker each minute (only while
-      Schmidt-Appleman says trails can exist), maps state vectors
-      with adsbToScene (contrails.js: exact international foot/knot
-      constants, the theme's own equirectangular + asinh mapping;
-      landmark set: origin/altitude/velocity exact, +8 km north =
-      half-world) and queues cruise aircraft (>= FL260, inside the
-      world, deduplicated by hex for 10 min). Free contrail slots
-      claim REAL aircraft first - real position, real altitude,
-      real track and ground speed, callsign in the provenance
-      record - with the ambient traffic as documented fallback
-      (worker not deployed, offline harness, no coverage).
-      ?adsb=URL overrides the proxy origin.
-    - DEPLOY (owner): cd themes/horizon/worker && npx wrangler
-      deploy (needs `wrangler login` or CLOUDFLARE_API_TOKEN). The
-      theme expects https://horizon-adsb.<subdomain>.workers.dev -
-      ADSB_PROXY in Horizon.html assumes subdomain `ndevtk`; update
-      it if the account's workers.dev subdomain differs. Each
-      upstream change needs a redeploy.
-    - RESOLVED by edge measurement (GET /probe on the deployed
-      worker, 2026-07-06, three consistent runs): control 200 in
-      389 ms (egress healthy); opensky-api AND opensky-auth
-      TimeoutError at 6 s even with an honest User-Agent -
-      OpenSky network-drops Cloudflare ranges, so credentials can
-      NEVER help (the owner's OPENSKY_* worker secrets are now
-      unused and can be deleted); adsb.lol 429 in 869 ms and
-      adsb.fi 403 in 139 ms - fast deliberate refusals; and
-      airplanes.live 200 with 30-32 aircraft in 126-232 ms every
-      time. airplanes.live is itself served through Cloudflare,
-      so worker-to-it traffic is first-class. THE one source:
-      airplanes.live /v2/point/lat/lon/radius - readsb v2
-      natively (feet, knots), so no unit conversion even exists
-      to get wrong; the worker strips vectors to the seven fields
-      the theme reads (an order of magnitude smaller payload) and
-      respects the documented 1 req/s: rounded coords + 15 s edge
-      cache + the single retry spaced a full 1.1 s. /probe stays
-      in the worker as a permanent regression instrument. History
-      of the hunt, all measured: OpenSky's anonymous per-IP 400
-      credits/day explained the 503 shedding; the readsb feeds
-      tarpit CF egress (5/6 probes hung >15 s); adsb.one serves a
-      bot-challenge page even to a residential probe. The
-      earlier OAuth2 client-credentials build (Keycloak token
-      endpoint, per-isolate 30-min cache, 401 refresh) is in git
-      history at cfffb36 should OpenSky ever unblock Cloudflare.
+    removes the CORS wall from the contrail item: - horizon-adsb (src/index.js + wrangler.toml): an allowlisted
+    proxy - GET /adsb?lat&lon&dist only, numeric-validated,
+    dist <= 60 nm, coordinates rounded to ~110 m so nearby
+    visitors share a 15 s edge-cached upstream call. NOT an open
+    proxy. Verified end-to-end with `wrangler dev --local`: CORS
+    header added, live traffic flowing (a Condor A20N at FL360
+    over the test site, feed OAT -53 degC - consistent with the
+    measured 250 hPa air; 38 aircraft over Heathrow on the
+    OpenSky-era recheck), 404/400 on anything else. - Upstream reality (measured on the DEPLOYED worker, not just
+    locally, over two rounds): api.adsb.lol AND opendata.adsb.fi
+    don't just refuse Cloudflare-egress requests - they TARPIT
+    them. Round 1 read as hard 429s; round 2 (after the failover
+    build deployed) measured 5 of 6 probes hanging past 15 s
+    with one sub-second 32-aircraft success - so ANY failover
+    chain through the readsb feeds stalls the whole request
+    before the next upstream gets a turn. The same queries
+    answer sub-second from a residential IP. Decision (owner:
+    "one good data source"): the readsb upstreams are DROPPED;
+    OpenSky became the single source for one round (SUPERSEDED
+    by the edge measurement below - OpenSky network-drops CF
+    ranges too, which only /probe could see). Its restrictive
+    CORS never
+    mattered behind a server-side proxy (the original objection
+    only applied to direct browser fetches - the owner called
+    this out). OpenSky takes a bounding box (1 nm latitude =
+    exactly 1/60 deg; longitude widened by 1/cos lat) and speaks
+    positional state vectors in SI units, so the worker
+    normalizes into the readsb shape with the exact
+    international foot and knot - the theme keeps ONE parser.
+    x-adsb-source names the mode per response. - (SUPERSEDED, kept as history) Making the OpenSky source
+    good: OpenSky's anonymous tier buckets
+    400 daily credits per IP - Cloudflare's shared egress
+    exhausts that pool, which is the measured ~50% 503 shedding.
+    A registered API client gets 4000 credits/day on its OWN
+    account (docs: openskynetwork.github.io/opensky-api); the
+    15 nm box is far under the 25 sq deg 1-credit tier, and the
+    15 s edge cache spends the budget frugally. The worker does
+    OAuth2 client-credentials against the OpenSky Keycloak
+    (endpoint verified live: invalid*client 401 for bogus
+    creds), caches the 30-minute Bearer token per isolate,
+    refreshes once on a server-side 401, and falls back to
+    anonymous (with 2 shed-absorbing retries, 400 ms apart) when
+    the secrets are absent. Every upstream fetch carries a hard
+    4 s AbortSignal timeout - the tarpit measurement is exactly
+    why. Owner setup: create an API client on the OpenSky
+    account page, then `npx wrangler secret put
+OPENSKY_CLIENT_ID` + `OPENSKY_CLIENT_SECRET` and redeploy. - worker-reference.mjs (gate set 18, airplanes.live build):
+    the worker module runs UNMODIFIED in node, so the gate
+    exercises the real handler offline - fetch stubbed with the
+    measured failure modes - asserting the /v2/point URL shape,
+    the strip to exactly the theme's seven fields with readsb
+    units UNTOUCHED, "ground"/incomplete vectors dropped, a 429
+    blip carried by the rate-respecting retry with the
+    User-Agent sent, CORS + x-adsb-source, the adsbToScene
+    round-trip, /probe mapping statuses and thrown timeouts
+    alike into inspectable rows, and the 404/400/OPTIONS
+    allowlist. Live checks: the real handler run in node served
+    14 aircraft over Heathrow / 3 alpine / 5 JFK from
+    airplanes.live; workerd (`wrangler dev --local`) 15 over
+    Heathrow with exactly the seven fields. - Theme: syncTraffic polls the worker each minute (only while
+    Schmidt-Appleman says trails can exist), maps state vectors
+    with adsbToScene (contrails.js: exact international foot/knot
+    constants, the theme's own equirectangular + asinh mapping;
+    landmark set: origin/altitude/velocity exact, +8 km north =
+    half-world) and queues cruise aircraft (>= FL260, inside the
+    world, deduplicated by hex for 10 min). Free contrail slots
+    claim REAL aircraft first - real position, real altitude,
+    real track and ground speed, callsign in the provenance
+    record - with the ambient traffic as documented fallback
+    (worker not deployed, offline harness, no coverage).
+    ?adsb=URL overrides the proxy origin. - DEPLOY (owner): cd themes/horizon/worker && npx wrangler
+    deploy (needs `wrangler login` or CLOUDFLARE_API_TOKEN). The
+    theme expects https://horizon-adsb.<subdomain>.workers.dev -
+    ADSB_PROXY in Horizon.html assumes subdomain `ndevtk`; update
+    it if the account's workers.dev subdomain differs. Each
+    upstream change needs a redeploy. - RESOLVED by edge measurement (GET /probe on the deployed
+    worker, 2026-07-06, three consistent runs): control 200 in
+    389 ms (egress healthy); opensky-api AND opensky-auth
+    TimeoutError at 6 s even with an honest User-Agent -
+    OpenSky network-drops Cloudflare ranges, so credentials can
+    NEVER help (the owner's OPENSKY*\* worker secrets are now
+    unused and can be deleted); adsb.lol 429 in 869 ms and
+    adsb.fi 403 in 139 ms - fast deliberate refusals; and
+    airplanes.live 200 with 30-32 aircraft in 126-232 ms every
+    time. airplanes.live is itself served through Cloudflare,
+    so worker-to-it traffic is first-class. THE one source:
+    airplanes.live /v2/point/lat/lon/radius - readsb v2
+    natively (feet, knots), so no unit conversion even exists
+    to get wrong; the worker strips vectors to the seven fields
+    the theme reads (an order of magnitude smaller payload) and
+    respects the documented 1 req/s: rounded coords + 15 s edge
+    cache + the single retry spaced a full 1.1 s. /probe stays
+    in the worker as a permanent regression instrument. History
+    of the hunt, all measured: OpenSky's anonymous per-IP 400
+    credits/day explained the 503 shedding; the readsb feeds
+    tarpit CF egress (5/6 probes hung >15 s); adsb.one serves a
+    bot-challenge page even to a residential probe. The
+    earlier OAuth2 client-credentials build (Keycloak token
+    endpoint, per-isolate 30-min cache, 401 refresh) is in git
+    history at cfffb36 should OpenSky ever unblock Cloudflare.
   - DONE (deploy + key pending): live AIS ships on the FFT ocean
     (ships.js + worker /ais route) - the worker pattern's second
     payoff, and the first use of its OTHER superpower: a static
-    GitHub Pages site can never hold a secret, but a worker can.
-    - Source: aisstream.io - global community AIS over WebSocket,
-      free API key, terms explicitly forbid browser exposure (so
-      the key lives in `npx wrangler secret put AISSTREAM_KEY`).
-      /ais opens an outbound socket, subscribes the visitor's
-      bounding box (subscription must arrive within 3 s - sent on
-      open), collects PositionReports for a 2.5 s window, closes,
-      answers plain JSON stripped to seven fields with ITU-R
-      M.1371 sentinels mapped (Sog 102.3 -> 0, Cog 360 / heading
-      511 -> null), 60 s manual edge cache per rounded coordinate
-      (few concurrent sockets on the free tier - the cache IS the
-      budget). Bad-key reality (measured): aisstream keeps the
-      socket open and sends NOTHING - indistinguishable from an
-      empty sea - so the documented error-frame path is handled
-      but verification needs a real key over a busy lane (Dover
-      Strait) after deploy. WS mechanics verified in node AND
-      workerd against the live server (connect + subscribe +
-      window + clean close, /adsb unaffected).
-    - Physics (ships.js): COLREGS 1972 verbatim - Rule 21 arcs
-      (masthead 225 deg, sidelights 112.5 each, sternlight 135;
-      side + stern tile the circle exactly), Rule 22 ranges for
-      > = 50 m vessels (6/3/3 nm), Annex I section 8 luminous
-      > intensity I = 3.43e6 T D^2 K^-D (reproduces the published
-      > table: 0.9 cd at 1 nm, 12 at 3, 94 at 6), Allard's law for
-      > apparent illuminance - and the Annex I constant 3.43e6 IS
-      > 1852^2 to three figures, so at the rated range the eye
-      > receives exactly the adopted 2e-7 lux threshold: the
-      > regulation is Allard's law solved for I (landmarked to
-      > 1e-12). Rule 20(b) lights from sunset to sunrise = solar
-      > altitude below -50 arcmin. ships-reference.mjs is gate set
-      > 18 (6 landmarks); the /ais route landmark joined set 19
-      > (worker): stubbed aisstream socket, subscription carries
-      > key + exact bbox, latest-per-MMSI, sentinels, 503 without a
-      > key.
-    - Theme: 8-slot ship pool on the tide-following water plane;
-      syncShips polls /ais every 120 s (only when the DEM has
-      sea), dead-reckons on SOG/COG between reports, hulls are
-      documented display furniture (90 m default - position
-      reports carry no dimensions); each nav light shows only
-      inside its Rule 21 arc for the camera's CURRENT relative
-      bearing, brightness Allard at actual distance (a 3 nm
-      sidelight dies at 3 nm exactly), provenance panel lists
-      callsigns + speeds. ?ais=URL overrides the proxy; ?ship=N
-      spawns deterministic synthetic vessels (no fetch, no
-      Math.random) for pinned shots.
-    - Owner setup: create the free key at aisstream.io (GitHub
-      sign-in), then `cd themes/horizon/worker && npx wrangler
+    GitHub Pages site can never hold a secret, but a worker can. - Source: aisstream.io - global community AIS over WebSocket,
+    free API key, terms explicitly forbid browser exposure (so
+    the key lives in `npx wrangler secret put AISSTREAM_KEY`).
+    /ais opens an outbound socket, subscribes the visitor's
+    bounding box (subscription must arrive within 3 s - sent on
+    open), collects PositionReports for a 2.5 s window, closes,
+    answers plain JSON stripped to seven fields with ITU-R
+    M.1371 sentinels mapped (Sog 102.3 -> 0, Cog 360 / heading
+    511 -> null), 60 s manual edge cache per rounded coordinate
+    (few concurrent sockets on the free tier - the cache IS the
+    budget). Bad-key reality (measured): aisstream keeps the
+    socket open and sends NOTHING - indistinguishable from an
+    empty sea - so the documented error-frame path is handled
+    but verification needs a real key over a busy lane (Dover
+    Strait) after deploy. WS mechanics verified in node AND
+    workerd against the live server (connect + subscribe +
+    window + clean close, /adsb unaffected). - Physics (ships.js): COLREGS 1972 verbatim - Rule 21 arcs
+    (masthead 225 deg, sidelights 112.5 each, sternlight 135;
+    side + stern tile the circle exactly), Rule 22 ranges for > = 50 m vessels (6/3/3 nm), Annex I section 8 luminous > intensity I = 3.43e6 T D^2 K^-D (reproduces the published > table: 0.9 cd at 1 nm, 12 at 3, 94 at 6), Allard's law for > apparent illuminance - and the Annex I constant 3.43e6 IS > 1852^2 to three figures, so at the rated range the eye > receives exactly the adopted 2e-7 lux threshold: the > regulation is Allard's law solved for I (landmarked to > 1e-12). Rule 20(b) lights from sunset to sunrise = solar > altitude below -50 arcmin. ships-reference.mjs is gate set > 18 (6 landmarks); the /ais route landmark joined set 19 > (worker): stubbed aisstream socket, subscription carries > key + exact bbox, latest-per-MMSI, sentinels, 503 without a > key. - Theme: 8-slot ship pool on the tide-following water plane;
+    syncShips polls /ais every 120 s (only when the DEM has
+    sea), dead-reckons on SOG/COG between reports, hulls are
+    documented display furniture (90 m default - position
+    reports carry no dimensions); each nav light shows only
+    inside its Rule 21 arc for the camera's CURRENT relative
+    bearing, brightness Allard at actual distance (a 3 nm
+    sidelight dies at 3 nm exactly), provenance panel lists
+    callsigns + speeds. ?ais=URL overrides the proxy; ?ship=N
+    spawns deterministic synthetic vessels (no fetch, no
+    Math.random) for pinned shots. - Owner setup: create the free key at aisstream.io (GitHub
+    sign-in), then `cd themes/horizon/worker && npx wrangler
 secret put AISSTREAM_KEY && npx wrangler deploy`.
   - DONE (owner provisioning): horizon-live, the dedicated-IP
     successor to the worker (themes/horizon/server) - the owner
@@ -1724,14 +1700,14 @@ secret put AISSTREAM_KEY && npx wrangler deploy`.
       Earth's phase from the Moon is the exact complement of the
       Moon's phase from Earth (new moon = FULL Earth over the
       thinnest crescent); the Earth's effective albedo is the Big
-      Bear programme's A* = 0.297 (Goode et al. 2001 - measured
+      Bear programme's A\* = 0.297 (Goode et al. 2001 - measured
       by watching precisely the glow this item draws); Lambertian
       sphere phase law at its exact nodes (f(pi/2) = 1/pi);
       geometry on the shared IUGG radius (imported from
       lightning.js - the model lives once)
     - landmarks (gate set 24): full Earth from the Moon V =
       -16.52 (published -17..-16.1), 33x the full Moon;
-      earthlight/sunlight = 8.16e-5 at new moon = A*(R_E/d)^2
+      earthlight/sunlight = 8.16e-5 at new moon = A\*(R_E/d)^2
       exactly - the ashen side 10.2 mag below the sunlit surface
       (the classical Danjon contrast); quarter = new/pi exactly;
       full moon -> 0
@@ -1988,8 +1964,8 @@ secret put AISSTREAM_KEY && npx wrangler deploy`.
     ?demtiles=URL endpoint override (infrastructure param, kept
     across relocations) lets the offline harness serve
     deterministic terrarium tiles; ?roam=0 pins the box.
-    window.__roam harness introspection (same precedent as
-    __meteors). Verified in real Chromium (WebGPU/Xvfb) with a
+    window.**roam harness introspection (same precedent as
+    **meteors). Verified in real Chromium (WebGPU/Xvfb) with a
     local synthetic-tile server: flew the free camera past the
     4 km ring - fetch, buildWorld swap, camera rewrite to origin,
     URL rewrite and panel provenance all firing (smoke needed a
@@ -2006,7 +1982,7 @@ secret put AISSTREAM_KEY && npx wrangler deploy`.
        value noise ON THE EARTH SPHERE at the historic 400 m base
        wavelength (MICRO_M === 7*MPU exactly). 3D-on-the-sphere
        because any 2D unrolling shears somewhere (lon*cos(lat)
-       drifts lonRad*sin(lat) metres of texture per metre walked
+       drifts lonRad\*sin(lat) metres of texture per metre walked
        north - 21:1 streaks at 170E). Trees moved from a
        scene-space RNG to roam.treeCandidates: fixed geodetic
        cells (150 m), one hash-deterministic candidate each
@@ -2037,17 +2013,17 @@ secret put AISSTREAM_KEY && npx wrangler deploy`.
        relocateURL) and only moves the coordinates, dropping the
        stale place label. Landmarked; reload mid-walk now
        reproduces the session exactly.
-    SERVER (same pass): SSE backpressure - a stalled client
-    (zero TCP window) used to buffer events in daemon RAM without
-    bound for its 30-minute lifetime, and one broken client's
-    write throw ABORTED the strike fanout loop for every client
-    after it (real bug). Now: per-client write isolation in the
-    fanout + overBackpressure(SSE_BUFFER_MAX = 256 KiB) drops
-    slow readers on every write path (strike/ais/adsb/heartbeat);
-    EventSource reconnects healthy clients. New 'SSE backpressure'
-    landmark (boundary exact, 36x the largest real ais frame,
-    6.6 MB worst case across SSE_MAX). Gate now 30 sets: roam 9
-    landmarks, server 12.
+       SERVER (same pass): SSE backpressure - a stalled client
+       (zero TCP window) used to buffer events in daemon RAM without
+       bound for its 30-minute lifetime, and one broken client's
+       write throw ABORTED the strike fanout loop for every client
+       after it (real bug). Now: per-client write isolation in the
+       fanout + overBackpressure(SSE_BUFFER_MAX = 256 KiB) drops
+       slow readers on every write path (strike/ais/adsb/heartbeat);
+       EventSource reconnects healthy clients. New 'SSE backpressure'
+       landmark (boundary exact, 36x the largest real ais frame,
+       6.6 MB worst case across SSE_MAX). Gate now 30 sets: roam 9
+       landmarks, server 12.
   - DONE: solar-wind aurora - the curtain's driver becomes a
     MEASUREMENT taken 1.5 million km upwind. New single source
     solarwind.js (daemon + theme + reference; install.sh ships it
@@ -2078,6 +2054,33 @@ secret put AISSTREAM_KEY && npx wrangler deploy`.
     clamped at the designed full-curtain level. The provenance
     panel now says "strikes the magnetosphere in N min" - the
     wallpaper knows before the sky does.
+  - DONE: METAR - aerodromes MEASURE the sky, and the nearest
+    fresh report now outranks the model where it can see. New
+    single source metar.js (daemon + theme + reference; shipped
+    beside the daemon like lightning.js/solarwind.js) +
+    metar-reference.mjs (gate set 32, 4 landmarks): FMH-1 okta
+    band midpoints (sky-clear codes exactly 0, VV exactly 8/8),
+    WMO etage split at 2/7 km with the exact international foot -
+    the live-captured Glasgow fixture (FEW013 BKN025 OVC030)
+    decodes to 100% low cover with a 396.24 m measured base -
+    visibility by the exact statute mile with the API's "N+"
+    documented as an at-least floor, nearest-FRESH station
+    selection (staleness disqualifies before distance ranks), and
+    the readsb-style normalizer. Daemon: GET /metar?lat&lon -
+    aviationweather.gov decodes reports but sends no CORS header,
+    so the daemon proxies with a 10-min per-area cache; VERIFIED
+    LIVE in this container (Glasgow's layered ob served through
+    the route). Theme: syncMetar every 10 min (?metar=URL
+    override, kept across relocations; roam clears the station on
+    re-anchor and re-syncs on settle); a fresh (<90 min) nearby
+    (<60 km) station replaces the Espy LCL ESTIMATE with the
+    ceilometer's MEASURED deck base, the model's low cover with
+    the measured okta fraction, and the model visibility with the
+    transmissometer reading (Koschmieder haze). DELIBERATE SCOPE:
+    mid/high decks stay with the model - automated ceilometers
+    are blind above a few km, and overriding cirrus with an AUTO
+    station's silence would erase real measured-model cloud.
+    Present weather (wxString) is recorded as provenance only.
   - OPEN (environment, not code) - UPDATE (roam smoke, Jul 7): the
     drift now also manifests as a PER-FRAME uncaught TypeError -
     GPUTexture.createView rejects the `swizzle` field three's

--- a/themes/horizon/explore.js
+++ b/themes/horizon/explore.js
@@ -54,6 +54,7 @@ export const KEEP_PARAMS = [
   'live',
   'tles',
   'space',
+  'metar',
   'roam'
 ];
 

--- a/themes/horizon/harness/validate.sh
+++ b/themes/horizon/harness/validate.sh
@@ -24,7 +24,7 @@ REFDIR=${REFDIR:-..} # where the *-reference.mjs live
 fail=0
 
 echo "== CPU references (double precision, ground truth) =="
-for name in ocean atmo moon optics surf glint aurora leadr radar igrf scintillation ross-li cn2 airglow zodiacal meteors contrails ships navlights lightning milkyway earthshine nlc sats eclipses skyglow explore roam solarwind server; do
+for name in ocean atmo moon optics surf glint aurora leadr radar igrf scintillation ross-li cn2 airglow zodiacal meteors contrails ships navlights lightning milkyway earthshine nlc sats eclipses skyglow explore roam solarwind metar server; do
   ref="$REFDIR/$name-reference.mjs"
   if [ ! -f "$ref" ]; then echo "[FAIL] $name-reference.mjs missing"; fail=1; continue; fi
   if out=$(node "$ref" 2>&1); then

--- a/themes/horizon/metar-reference.mjs
+++ b/themes/horizon/metar-reference.mjs
@@ -1,0 +1,157 @@
+// Reference printer for the METAR layer (node metar-reference.mjs).
+// Aerodromes measure the sky, so the gate holds the conversion of
+// their report into the theme's cloud model to the published
+// conventions, against fixtures captured LIVE from
+// aviationweather.gov (2026-07-07):
+//  - FMH-1 okta bands (band midpoints; sky-clear codes exactly 0,
+//    indefinite ceiling exactly 8)
+//  - WMO etage boundaries with exact foot/mile conversions
+//  - the Glasgow fixture (FEW013 BKN025 OVC030) decodes to the
+//    exact measured deck: 100% low cover, base 396.24 m
+//  - nearest-fresh station selection: staleness disqualifies
+//    before distance ranks
+import {
+  ETAGE_LOW_M,
+  ETAGE_MID_M,
+  FT_M,
+  METAR_MAX_AGE_S,
+  SM_M,
+  coverFraction,
+  etageCovers,
+  normalizeMetars,
+  pickStation,
+  visibilityM
+} from './metar.js';
+
+let fail = 0;
+const check = (name, ok, detail) => {
+  console.log(`${ok ? 'REF' : 'FAIL'} ${name}: ${detail}`);
+  if (!ok) fail++;
+};
+
+{
+  // FMH-1 ch. 9: FEW 1-2, SCT 3-4, BKN 5-7, OVC 8 oktas - band
+  // midpoints as fractions; every sky-clear code exactly 0; VV
+  // (indefinite ceiling) exactly 8/8; unknown code -> null.
+  check(
+    'okta convention',
+    coverFraction('FEW') === 1.5 / 8 &&
+      coverFraction('SCT') === 3.5 / 8 &&
+      coverFraction('BKN') === 6 / 8 &&
+      coverFraction('OVC') === 1 &&
+      coverFraction('VV') === 1 &&
+      ['CAVOK', 'CLR', 'SKC', 'NCD', 'NSC'].every(
+        (c) => coverFraction(c) === 0
+      ) &&
+      coverFraction('???') === null,
+    `FEW ${(1.5 / 8) * 100}% · SCT ${(3.5 / 8) * 100}% · BKN 75% · OVC/VV 100% · five clear codes 0 · unknown null`
+  );
+}
+
+{
+  // Visibility: exact statute mile; the API's "N+" floor; junk null.
+  check(
+    'visibility',
+    visibilityM(2.5) === 2.5 * 1609.344 &&
+      visibilityM('6+') === 6 * 1609.344 &&
+      visibilityM('10+') === 16093.44 &&
+      SM_M === 1609.344 &&
+      visibilityM(null) === null &&
+      visibilityM('fog') === null,
+    `2.5 SM -> ${2.5 * SM_M} m; "6+" -> ${6 * SM_M} m (documented at-least floor); mile exact; junk -> null`
+  );
+}
+
+{
+  // The Glasgow fixture, captured live 2026-07-07 02:00Z:
+  // FEW013 BKN025 OVC030. All three bases sit under the WMO low
+  // etage (2000 m), so low cover is the MAX layer (OVC = 100%)
+  // and the measured deck base is 1300 ft = 396.24 m exactly.
+  const egpf = [
+    {cover: 'FEW', base: 1300},
+    {cover: 'BKN', base: 2500},
+    {cover: 'OVC', base: 3000}
+  ];
+  const e = etageCovers(egpf);
+  // Synthetic three-etage sky: SCT080 is middle (2438.4 m), a
+  // BKN250 cirrus deck is high (7620 m); low stays clear so
+  // baseM stays null.
+  const split = etageCovers([
+    {cover: 'SCT', base: 8000},
+    {cover: 'BKN', base: 25000}
+  ]);
+  const cavok = etageCovers([]);
+  check(
+    'etage split',
+    e.low === 100 &&
+      e.mid === 0 &&
+      e.high === 0 &&
+      e.baseM === 1300 * FT_M &&
+      Math.abs(e.baseM - 396.24) < 1e-9 &&
+      split.low === 0 &&
+      split.mid === 43.75 &&
+      split.high === 75 &&
+      split.baseM === null &&
+      8000 * FT_M > ETAGE_LOW_M &&
+      25000 * FT_M > ETAGE_MID_M &&
+      cavok.low === 0 &&
+      cavok.baseM === null,
+    `Glasgow FEW013 BKN025 OVC030 -> low 100% (max of layers), measured base ${e.baseM} m exactly; SCT080/BKN250 -> mid 43.75% high 75% (WMO 2/7 km etages); CAVOK -> clear`
+  );
+}
+
+{
+  // Live-captured API shape through the normalizer, then station
+  // selection: the nearest station is STALE (2 h old) and must
+  // lose to the fresh one further out; out-of-range fresh loses
+  // too; everything stale -> null.
+  const NOW = 1783390800 + 600; // 10 min after the fixture obs
+  const api = [
+    {
+      icaoId: 'EGPF',
+      obsTime: 1783390800,
+      visib: '6+',
+      temp: 15,
+      dewp: 13,
+      lat: 55.867,
+      lon: -4.433,
+      elev: 8,
+      cover: 'OVC',
+      clouds: [
+        {cover: 'FEW', base: 1300},
+        {cover: 'BKN', base: 2500},
+        {cover: 'OVC', base: 3000}
+      ],
+      name: 'Glasgow Arpt, SC, GB'
+    },
+    {
+      icaoId: 'EGPK',
+      obsTime: NOW - 7200, // stale: two hours old
+      visib: '6+',
+      temp: 15,
+      dewp: 13,
+      lat: 55.869,
+      lon: -4.43,
+      elev: 14,
+      cover: 'BKN',
+      clouds: [{cover: 'BKN', base: 1600}]
+    },
+    {icaoId: 'JUNK', clouds: []} // no position/time: dropped
+  ];
+  const metars = normalizeMetars(api);
+  const near = pickStation(metars, 55.87, -4.44, NOW);
+  const none = pickStation(metars, 40.0, -4.44, NOW); // out of range
+  const allStale = pickStation(metars, 55.87, -4.44, NOW + 2 * METAR_MAX_AGE_S);
+  check(
+    'nearest fresh station',
+    metars.length === 2 &&
+      near.id === 'EGPF' &&
+      near.km < 1 &&
+      near.visib === '6+' &&
+      none === null &&
+      allStale === null,
+    `junk entry dropped by the normalizer; stale-but-nearer EGPK loses to fresh EGPF ${near.km.toFixed(2)} km away; out of range -> null; all stale -> null`
+  );
+}
+
+process.exit(fail ? 1 : 0);

--- a/themes/horizon/metar.js
+++ b/themes/horizon/metar.js
@@ -1,0 +1,150 @@
+/**
+ * METAR - the single source shared by the horizon-live daemon
+ * (server/src/index.mjs; install.sh ships this file beside it,
+ * the same pattern as lightning.js/solarwind.js), the theme
+ * (Horizon.html) and the reference printer (metar-reference.mjs).
+ *
+ * Aerodromes MEASURE the sky: a ceilometer reads each cloud
+ * layer's base off a laser return, visibility comes off a
+ * transmissometer or a trained observer, and the report is the
+ * aviation-legal record of what the sky is actually doing. The
+ * theme has modelled cloud-base height with Espy's LCL estimate
+ * (125 m per degree of dewpoint spread) - a nearby fresh METAR
+ * replaces that estimate with the measurement, and its layer
+ * covers replace the model's low/mid/high percentages (the same
+ * measured-beats-model rule the radar layer already follows).
+ * Source: aviationweather.gov's data API (decoded JSON; no CORS,
+ * so the daemon proxies with a per-area cache). Wire fixtures
+ * captured live 2026-07-07.
+ *
+ *  - Cover fractions: FMH-1 (Federal Meteorological Handbook
+ *    No. 1, ch. 9) defines the okta bands - FEW 1-2, SCT 3-4,
+ *    BKN 5-7, OVC 8. A band maps to its midpoint (documented
+ *    convention); sky-clear codes and CAVOK are exactly 0, VV
+ *    (indefinite ceiling) is exactly 8.
+ *  - Etages: WMO International Cloud Atlas mid-latitude levels -
+ *    low below 2000 m, middle 2000-7000 m, high above. Each
+ *    layer joins its etage by MEASURED base (feet -> metres by
+ *    the exact international foot); an etage's cover is the MAX
+ *    of its layers (cover is a ceiling fraction, not a sum).
+ *  - Visibility: statute miles -> metres by the exact 1609.344;
+ *    the API's "N+" strings mean "at least N" and map to N
+ *    (a documented floor - the haze model can only be told what
+ *    was measured).
+ *  - Station choice: nearest FRESH report wins - a closer but
+ *    stale station never beats a fresh one within range.
+ */
+
+import {haversineKm} from './lightning.js';
+
+export const FT_M = 0.3048; // exact international foot
+export const SM_M = 1609.344; // exact statute mile
+export const ETAGE_LOW_M = 2000; // WMO low/middle boundary
+export const ETAGE_MID_M = 7000; // WMO middle/high boundary
+export const METAR_MAX_KM = 60; // a report speaks for ~this far
+export const METAR_MAX_AGE_S = 5400; // 90 min: two report cycles
+
+// FMH-1 okta band midpoints, eighths of sky.
+export const OKTAS = {
+  CAVOK: 0,
+  CLR: 0,
+  SKC: 0,
+  NCD: 0,
+  NSC: 0,
+  FEW: 1.5,
+  SCT: 3.5,
+  BKN: 6,
+  OVC: 8,
+  VV: 8
+};
+
+export function coverFraction(cover) {
+  const o = OKTAS[cover];
+  return o === undefined ? null : o / 8;
+}
+
+// Decoded-API visibility (statute miles, number or "N+") -> m.
+export function visibilityM(visib) {
+  if (visib === null || visib === undefined) return null;
+  const n = typeof visib === 'number' ? visib : parseFloat(String(visib));
+  if (!Number.isFinite(n) || n < 0) return null;
+  return n * SM_M;
+}
+
+// Layer list [{cover, base(ft AGL)}] -> etage covers (%) plus the
+// lowest measured LOW-etage base in metres AGL (the deck the
+// theme raymarches; null when no low layer reports a base).
+export function etageCovers(clouds) {
+  let low = 0;
+  let mid = 0;
+  let high = 0;
+  let baseM = null;
+  for (const c of Array.isArray(clouds) ? clouds : []) {
+    const f = coverFraction(c.cover);
+    if (f === null || f === 0) continue;
+    const b = Number.isFinite(+c.base) ? +c.base * FT_M : null;
+    if (b === null) continue;
+    if (b < ETAGE_LOW_M) {
+      low = Math.max(low, f);
+      baseM = baseM === null ? b : Math.min(baseM, b);
+    } else if (b < ETAGE_MID_M) {
+      mid = Math.max(mid, f);
+    } else {
+      high = Math.max(high, f);
+    }
+  }
+  return {low: low * 100, mid: mid * 100, high: high * 100, baseM};
+}
+
+// Strip a decoded-API response to the fields the model reads
+// (the same frugality rule as the readsb normalizer): entries
+// without a position or observation time are dropped.
+export function normalizeMetars(list) {
+  return (Array.isArray(list) ? list : [])
+    .filter(
+      (m) =>
+        typeof m.lat === 'number' &&
+        typeof m.lon === 'number' &&
+        typeof m.obsTime === 'number'
+    )
+    .map((m) => ({
+      id: m.icaoId,
+      name: m.name,
+      lat: m.lat,
+      lon: m.lon,
+      elev: m.elev,
+      obsTime: m.obsTime,
+      temp: m.temp,
+      dewp: m.dewp,
+      visib: m.visib ?? null,
+      cover: m.cover ?? null,
+      clouds: Array.isArray(m.clouds)
+        ? m.clouds.map((c) => ({cover: c.cover, base: c.base}))
+        : [],
+      wx: m.wxString ?? null
+    }));
+}
+
+// Nearest FRESH station to the visitor: staleness disqualifies
+// before distance ranks - a closer but expired report never
+// beats a fresh one in range. nowSec explicit (nothing here
+// reads the wall clock).
+export function pickStation(
+  metars,
+  lat,
+  lon,
+  nowSec,
+  maxKm = METAR_MAX_KM,
+  maxAgeS = METAR_MAX_AGE_S
+) {
+  let best = null;
+  let bestKm = Infinity;
+  for (const m of Array.isArray(metars) ? metars : []) {
+    if (!(nowSec - m.obsTime >= 0 && nowSec - m.obsTime <= maxAgeS)) continue;
+    const km = haversineKm(lat, lon, m.lat, m.lon);
+    if (km > maxKm || km >= bestKm) continue;
+    best = m;
+    bestKm = km;
+  }
+  return best ? {...best, km: bestKm} : null;
+}

--- a/themes/horizon/server/README.md
+++ b/themes/horizon/server/README.md
@@ -68,6 +68,11 @@ are gated by `../server-reference.mjs` — the `server` set in
   bypasses CORS, so the Origin allowlist gate IS the protection
   here — foreign origins get 403 before the stream opens. Capped
   concurrent streams (`SSE_MAX`, default 25).
+- `GET /metar?lat&lon` — aerodrome observations near the point
+  (aviationweather.gov decodes them but sends no CORS header):
+  measured cloud-layer bases, covers, visibility and present
+  weather, stripped to the fields the theme reads
+  (`normalizeMetars`, gated) with a 10-minute per-area cache.
 - `GET /solarwind` — the aurora's measured driver: DSCOVR/ACE
   solar wind at L1, already propagated to the bow shock by SWPC
   (the `propagated_time_tag` is a real physical lead time of tens

--- a/themes/horizon/server/install.sh
+++ b/themes/horizon/server/install.sh
@@ -34,9 +34,11 @@ rm -rf /opt/horizon-live/worker
 install -m 644 src/index.mjs /opt/horizon-live/index.mjs
 install -m 644 ../lightning.js /opt/horizon-live/lightning.js
 install -m 644 ../solarwind.js /opt/horizon-live/solarwind.js
+install -m 644 ../metar.js /opt/horizon-live/metar.js
 # The '../../' import paths must keep resolving from
-# /opt/horizon-live/index.mjs - rewrite them for the flat deploy.
-sed -i "s#'../../lightning.js'#'./lightning.js'#; s#'../../solarwind.js'#'./solarwind.js'#" /opt/horizon-live/index.mjs
+# /opt/horizon-live/index.mjs - rewrite them for the flat deploy
+# (metar.js's own './lightning.js' import already resolves there).
+sed -i "s#'../../lightning.js'#'./lightning.js'#; s#'../../solarwind.js'#'./solarwind.js'#; s#'../../metar.js'#'./metar.js'#" /opt/horizon-live/index.mjs
 
 # Environment (created once; never overwritten - your key lives here).
 if [ ! -f /etc/horizon-live.env ]; then

--- a/themes/horizon/server/src/index.mjs
+++ b/themes/horizon/server/src/index.mjs
@@ -58,6 +58,7 @@
 import http from 'node:http';
 import {haversineKm} from '../../lightning.js';
 import {parseHemiPower, parsePropagated} from '../../solarwind.js';
+import {normalizeMetars} from '../../metar.js';
 
 // Schema normalizers - moved here when the Cloudflare worker was
 // retired and deleted (the daemon superseded it; git history
@@ -706,9 +707,12 @@ function main() {
 
   let tlesCache = {t: 0, body: null}; // CelesTrak visual group
   const adsbCache = new Map(); // area key -> {t, body, src}
+  const metarCache = new Map(); // area key -> {t, body}
   setInterval(() => {
     const now = Date.now();
     for (const [k, v] of adsbCache) if (now - v.t > 30e3) adsbCache.delete(k);
+    for (const [k, v] of metarCache)
+      if (now - v.t > 20 * 60e3) metarCache.delete(k);
   }, 30e3).unref();
   // Aircraft near a point via the readsb failover chain, shared
   // by GET /adsb and the /stream pushes - the 15 s per-area cache
@@ -903,6 +907,48 @@ function main() {
           'x-lightning-source': 'blitzortung.org'
         }
       );
+    }
+
+    if (url.pathname === '/metar') {
+      // Aerodrome observations near the point: aviationweather.gov
+      // decodes the reports but sends no CORS header, so the
+      // daemon proxies - stripped to the fields the theme reads
+      // (normalizeMetars, gated) with a 10-minute per-area cache
+      // (reports refresh half-hourly; many viewers in one place
+      // cost one upstream request).
+      const ck = lat.toFixed(1) + '/' + lon.toFixed(1);
+      const hit = metarCache.get(ck);
+      if (hit && Date.now() - hit.t < 10 * 60e3) {
+        return json(200, hit.body, {
+          'cache-control': 'public, max-age=300',
+          'x-metar-source': 'aviationweather.gov (cached)'
+        });
+      }
+      try {
+        const d = 0.6;
+        const u =
+          'https://aviationweather.gov/api/data/metar?format=json&bbox=' +
+          (lat - d).toFixed(2) +
+          ',' +
+          (lon - d).toFixed(2) +
+          ',' +
+          (lat + d).toFixed(2) +
+          ',' +
+          (lon + d).toFixed(2);
+        const r = await fetch(u, {
+          signal: AbortSignal.timeout(FETCH_MS),
+          headers: {'user-agent': UA}
+        });
+        if (!r.ok) throw new Error(r.status);
+        const body = {metars: normalizeMetars(await r.json())};
+        metarCache.set(ck, {t: Date.now(), body});
+        return json(200, body, {
+          'cache-control': 'public, max-age=300',
+          'x-metar-source': 'aviationweather.gov'
+        });
+      } catch {
+        return json(502, {metars: [], upstream: 'unavailable'});
+      }
     }
 
     if (url.pathname === '/adsb') {

--- a/themes/horizon/server/update.sh
+++ b/themes/horizon/server/update.sh
@@ -36,6 +36,7 @@ CUR=$(git rev-parse HEAD)
 CHANGED=$(git diff --name-only "$CUR" "$NEW" -- \
   themes/horizon/server \
   themes/horizon/lightning.js themes/horizon/solarwind.js \
+  themes/horizon/metar.js \
   themes/horizon/'*-reference.mjs' \
   themes/horizon/harness/validate.sh 2>/dev/null || echo forced)
 git checkout --quiet "$NEW"


### PR DESCRIPTION
The nearest fresh aerodrome observation now outranks the model where it can see - the same rule the radar layer follows.

- metar.js (single source: daemon + theme + reference; shipped beside the daemon like lightning.js/solarwind.js): FMH-1 okta band midpoints (sky-clear codes exactly 0, VV exactly 8/8); WMO etage split at 2/7 km with the exact international foot; visibility by the exact statute mile with the API's "N+" documented as an at-least floor; nearest-FRESH station selection (staleness disqualifies before distance ranks); readsb-style normalizer.
- metar-reference.mjs (gate set 32): held to fixtures captured live from aviationweather.gov - the Glasgow observation (FEW013 BKN025 OVC030) decodes to 100% low cover with a 396.24 m measured base, exactly.
- Daemon: GET /metar?lat&lon - aviationweather.gov decodes reports but sends no CORS header, so the daemon proxies with a 10-minute per-area cache. Verified live through the route.
- Theme: syncMetar every 10 min (?metar=URL override, kept across relocations; roam clears the station on re-anchor and re-syncs on settle). A fresh (<90 min) nearby (<60 km) station replaces the Espy LCL ESTIMATE with the ceilometer's MEASURED deck base, the model's low cover with the measured okta fraction, and the model visibility with the transmissometer reading (Koschmieder haze). Deliberate scope: mid/high decks stay with the model - automated ceilometers are blind above a few km, and an AUTO station's silence must not erase real cirrus. Present weather is recorded as provenance.

Also: WEBGPU-PLAN.md is now formatted with the repo's Prettier (one-time reflow) so the post-merge Prettier runs on main become no-ops and the recurring merge conflicts end.

Full gate 32/32.


Claude-Session: https://claude.ai/code/session_01NKKBen9kkD562HDVr7cXAx