### PR TITLE
Horizon: NOAA HMS wildfire smoke — the analyst-verified plume layer

### DIFF
--- a/themes/Horizon.html
+++ b/themes/Horizon.html
@@ -106,7 +106,8 @@
         auroralat (deg), dem=0 (skip real terrain), demtiles=URL
         (terrarium tile endpoint override), roam=0 (pin the box),
         space=URL (solar-wind endpoint override), metar=URL (aerodrome
-        observation endpoint override), debug=1
+        observation endpoint override), smoke=URL (HMS plume endpoint
+        override), debug=1
     -->
     <style>
       html,
@@ -464,6 +465,7 @@
         hpAtGrid: null, // ...as it was when the oval grid was fetched
         metar: null, // nearest fresh aerodrome observation (metar.js)
         profile: null, // measured refraction column (refraction.js)
+        smoke: null, // analyst-verified wildfire plume overhead (smoke.js)
         sea: null, // measured wave partitions (marine model), null = wind sea
         shake: 0
       };
@@ -1452,6 +1454,43 @@
           );
         } catch {
           // The model stands.
+        }
+      }
+
+      // Wildfire smoke: NOAA HMS analysts draw verified plume
+      // polygons from satellite imagery (North America - null
+      // elsewhere is the truthful answer). The daemon holds the
+      // daily file; the panel records the verdict and state.smoke
+      // carries the published class concentration (Ruminski et
+      // al. 2006: 5/16/27 ug/m^3). The CAMS AOD the sky already
+      // uses is quantitative and includes smoke - the absorbing-
+      // aerosol render hook waits on the Mie-absorption question
+      // logged in WEBGPU-PLAN.md.
+      const SMOKE_PROXY = params.get('smoke') ?? 'https://api.ndev.tk/smoke';
+      async function syncSmoke() {
+        try {
+          const j = await (
+            await fetch(
+              SMOKE_PROXY +
+                '?lat=' +
+                state.lat.toFixed(3) +
+                '&lon=' +
+                state.lon.toFixed(3),
+              {credentials: 'omit'}
+            )
+          ).json();
+          state.smoke = j.smoke ?? null;
+          if (state.smoke) {
+            record(
+              'NOAA HMS wildfire smoke',
+              state.smoke.density +
+                ' plume overhead (analyst-verified) · class ~' +
+                state.smoke.ugm3 +
+                ' µg/m³'
+            );
+          }
+        } catch {
+          // No verdict; the measured AOD stands alone.
         }
       }
 
@@ -4059,6 +4098,7 @@
         syncShips();
         syncTraffic();
         syncMetar();
+        syncSmoke();
       }
       function maybeRoam(now, moved) {
         if (moved) lastMoveMs = now;
@@ -5687,6 +5727,8 @@
         syncSpace();
         syncMetar();
         setInterval(syncMetar, 10 * 60 * 1000);
+        syncSmoke();
+        setInterval(syncSmoke, 30 * 60 * 1000);
         setInterval(syncSpace, 5 * 60 * 1000);
         syncISS();
         setInterval(syncISS, 6 * 60 * 60 * 1000);

--- a/themes/horizon/WEBGPU-PLAN.md
+++ b/themes/horizon/WEBGPU-PLAN.md
@@ -2081,28 +2081,67 @@ secret put AISSTREAM_KEY && npx wrangler deploy`.
     are blind above a few km, and overriding cirrus with an AUTO
     station's silence would erase real measured-model cloud.
     Present weather (wxString) is recorded as provenance only.
-  - OPEN (environment, not code) - UPDATE (roam smoke, Jul 7): the
-    drift now also manifests as a PER-FRAME uncaught TypeError -
-    GPUTexture.createView rejects the `swizzle` field three's
-    texture views pass (the bundled chromium-1194's WebGPU
-    dictionary vs this three build) - which aborts frame() before
-    any scene logic runs in the fixture rig (event-driven UI
-    still works, which is why the explore smoke passed). The roam
-    smoke installs a fixture-side createView shim that strips the
-    field (identity swizzle, never shipped); a matching
-    SHOOT_CHROME remains the real fix for pixel work.
-    Original note: today's fixture rig drops the
-    volumetric cloud decks and spams "2D view of 3D texture" Dawn
-    validation errors from the Nubis noise volumes - bisect-shot
-    d202bb5 (the certified phase-5 build), 289ab7c, a466700,
-    ad2270c and HEAD all reproduce it, while the SAME d202bb5 code
-    rendered clouds in its Jul 5 certification shots. Same pinned
-    Chrome binary, same shoot.mjs, no system Vulkan ICDs (bundled
-    SwiftShader), so the trigger is environmental drift in the
-    container, not any commit. References + GPU probes (the actual
-    correctness gate) are unaffected and green. Revisit if cloud
-    scenes need pixel inspection; the errors first appear when the
-    cloud compute pipeline spins up (~frame 200).
+  - DONE: wildfire smoke - NOAA HMS, the analyst-verified plume
+    layer. New single source smoke.js (daemon + theme + reference;
+    shipped beside the daemon) + smoke-reference.mjs (gate set 37,
+    3 landmarks): the KML parser held to a VERBATIM fixture cut
+    from the live daily file (150 plumes parsed, density counts
+    49/46/55 matching the raw grep exactly), interior probes of the
+    real plumes hitting their published class concentrations
+    (Ruminski et al. 2006: light/medium/heavy = 5/16/27 ug/m^3),
+    and geometry discipline (heavy outranks light in overlaps; a
+    concave U-notch is OUTSIDE - the even-odd test; the development
+    probe that landed a concave plume's centroid outside its own
+    ring is why that landmark exists). Daemon: hourly fetch of the
+    ~200 KB daily KML (yesterday's file stands in early UTC),
+    parsed to RAM, GET /smoke?lat&lon answers with the plume class
+    or null (HMS is a North America product - null elsewhere is
+    the truthful answer); /health grows a smoke block. Theme:
+    syncSmoke every 30 min (?smoke=URL override, kept across
+    relocations, re-synced on roam settle); the provenance panel
+    reports "heavy plume overhead (analyst-verified) · class ~27
+    ug/m^3"; state.smoke carries the class for the render hook.
+    DELIBERATE SCOPE: no render change this item - the CAMS AOD
+    the sky already uses is quantitative and includes smoke; HMS
+    adds the analyst's TYPE verdict, whose honest render
+    consequence is the aerosol's single-scattering albedo (biomass
+    smoke absorbs more), and that hook waits on the OPEN question
+    below.
+- OPEN (radiative constants, needs GPU recertification):
+  atmosphere-tsl's MIE_A0 = 4.4e-6 reads as Mie ABSORPTION and
+  extinction is computed as MIE_S0 + MIE_A0 = 8.4e-6 - but
+  Hillaire (2020) gives Mie scattering 3.996e-6 and EXTINCTION
+  4.440e-6, i.e. absorption 4.44e-7: the code's absorption looks
+  10x the paper's (SSA 0.48 vs the paper's 0.9). It is
+  self-consistent with the certified GLSL reference (same
+  constant ported), so renders match each other - but the
+  constant should be re-derived against the paper and, if
+  corrected, the sky recertified against the pinned matrix with
+  a proper SHOOT_CHROME. The smoke SSA hook (analyst-verified
+  plume -> biomass-burning single-scattering albedo, AERONET
+  climatology) lands in the same edit once settled.
+- OPEN (environment, not code) - UPDATE (roam smoke, Jul 7): the
+  drift now also manifests as a PER-FRAME uncaught TypeError -
+  GPUTexture.createView rejects the `swizzle` field three's
+  texture views pass (the bundled chromium-1194's WebGPU
+  dictionary vs this three build) - which aborts frame() before
+  any scene logic runs in the fixture rig (event-driven UI
+  still works, which is why the explore smoke passed). The roam
+  smoke installs a fixture-side createView shim that strips the
+  field (identity swizzle, never shipped); a matching
+  SHOOT_CHROME remains the real fix for pixel work.
+  Original note: today's fixture rig drops the
+  volumetric cloud decks and spams "2D view of 3D texture" Dawn
+  validation errors from the Nubis noise volumes - bisect-shot
+  d202bb5 (the certified phase-5 build), 289ab7c, a466700,
+  ad2270c and HEAD all reproduce it, while the SAME d202bb5 code
+  rendered clouds in its Jul 5 certification shots. Same pinned
+  Chrome binary, same shoot.mjs, no system Vulkan ICDs (bundled
+  SwiftShader), so the trigger is environmental drift in the
+  container, not any commit. References + GPU probes (the actual
+  correctness gate) are unaffected and green. Revisit if cloud
+  scenes need pixel inspection; the errors first appear when the
+  cloud compute pipeline spins up (~frame 200).
   - Phase 5 FINAL CERTIFICATION - full pinned matrix with EVERYTHING
     (octave clouds, limb darkening, FFT ocean + filtering, cloud
     shadows, Hapke moon), real WebGPU vs WebGL2, mean abs /255:
@@ -2141,31 +2180,31 @@ secret put AISSTREAM_KEY && npx wrangler deploy`.
   landmarks. PHASE 2 (DONE): the drawn sun and moon are refracted
   through the MEASURED column. syncAloft also fetches the low
   pressure levels (temperature/relative_humidity at 1000..200 hPa
-  + low geopotentials, still one request) and builds
-  state.profile via the gated buildProfile, closed at the ground
-  by the surface temperature and the exact dew-point rh (Murphy &
-  Koop). Frame loop: a paced CPU ray trace (N = 400, pinned
-  within 0.5" of N = 1600 by the new 'node-count convergence'
-  landmark; recompute every 0.02 deg of true altitude when low,
-  0.5 deg high - ~10 ms per update, sunsets only) yields the
-  green-channel apparent altitude that now drives sunVec (sky,
-  water, aerial - the whole scene sees the LIFTED sun: sunset
-  genuinely happens minutes later, from geometry), plus
-  per-channel apparent directions + the flattening ratio into new
-  atmosphere-tsl uniforms (sunDisc: dirR/dirB/flatten). The
-  shader draws three monochrome Hestroffer-Magnan discs, each
-  squashed vertically about its own centre - the green rim IS the
-  gap between them, widening whenever the measured profile
-  magnifies it: the green flash, when the real atmosphere serves
-  one. The moon takes the same lift and squash (its rim
-  dispersion sits below the eye's threshold at lunar brightness -
-  documented scope), and the paraselenic optics dome anchors on
-  the DRAWN moon. Below the grazing ray the displacement holds
-  its limit so twilight geometry stays continuous; the ICAO
-  standard atmosphere stands in offline; the -50 arcmin EVENT
-  conventions (ships.js etc.) deliberately stay - this is the
-  drawn sun, not the almanac. Also absorbed: atmosphere-tsl's
-  aerialMaxUnits used the 57.14 literal - now exact 400/7. A new
-  'measured profile builder' landmark holds the surface
-  hydrostatic closure to its closed form. Gate 36 sets,
-  refraction at 6 landmarks.
+  - low geopotentials, still one request) and builds
+    state.profile via the gated buildProfile, closed at the ground
+    by the surface temperature and the exact dew-point rh (Murphy &
+    Koop). Frame loop: a paced CPU ray trace (N = 400, pinned
+    within 0.5" of N = 1600 by the new 'node-count convergence'
+    landmark; recompute every 0.02 deg of true altitude when low,
+    0.5 deg high - ~10 ms per update, sunsets only) yields the
+    green-channel apparent altitude that now drives sunVec (sky,
+    water, aerial - the whole scene sees the LIFTED sun: sunset
+    genuinely happens minutes later, from geometry), plus
+    per-channel apparent directions + the flattening ratio into new
+    atmosphere-tsl uniforms (sunDisc: dirR/dirB/flatten). The
+    shader draws three monochrome Hestroffer-Magnan discs, each
+    squashed vertically about its own centre - the green rim IS the
+    gap between them, widening whenever the measured profile
+    magnifies it: the green flash, when the real atmosphere serves
+    one. The moon takes the same lift and squash (its rim
+    dispersion sits below the eye's threshold at lunar brightness -
+    documented scope), and the paraselenic optics dome anchors on
+    the DRAWN moon. Below the grazing ray the displacement holds
+    its limit so twilight geometry stays continuous; the ICAO
+    standard atmosphere stands in offline; the -50 arcmin EVENT
+    conventions (ships.js etc.) deliberately stay - this is the
+    drawn sun, not the almanac. Also absorbed: atmosphere-tsl's
+    aerialMaxUnits used the 57.14 literal - now exact 400/7. A new
+    'measured profile builder' landmark holds the surface
+    hydrostatic closure to its closed form. Gate 36 sets,
+    refraction at 6 landmarks.

--- a/themes/horizon/explore.js
+++ b/themes/horizon/explore.js
@@ -55,6 +55,7 @@ export const KEEP_PARAMS = [
   'tles',
   'space',
   'metar',
+  'smoke',
   'roam'
 ];
 

--- a/themes/horizon/harness/validate.sh
+++ b/themes/horizon/harness/validate.sh
@@ -24,7 +24,7 @@ REFDIR=${REFDIR:-..} # where the *-reference.mjs live
 fail=0
 
 echo "== CPU references (double precision, ground truth) =="
-for name in ocean atmo moon optics surf glint aurora leadr radar igrf scintillation ross-li cn2 airglow zodiacal meteors contrails ships navlights lightning milkyway earthshine nlc sats eclipses skyglow explore roam solarwind metar refraction server; do
+for name in ocean atmo moon optics surf glint aurora leadr radar igrf scintillation ross-li cn2 airglow zodiacal meteors contrails ships navlights lightning milkyway earthshine nlc sats eclipses skyglow explore roam solarwind metar refraction smoke server; do
   ref="$REFDIR/$name-reference.mjs"
   if [ ! -f "$ref" ]; then echo "[FAIL] $name-reference.mjs missing"; fail=1; continue; fi
   if out=$(node "$ref" 2>&1); then

--- a/themes/horizon/server/README.md
+++ b/themes/horizon/server/README.md
@@ -73,6 +73,10 @@ are gated by `../server-reference.mjs` — the `server` set in
   measured cloud-layer bases, covers, visibility and present
   weather, stripped to the fields the theme reads
   (`normalizeMetars`, gated) with a 10-minute per-area cache.
+- `GET /smoke?lat&lon` — the analyst-verified wildfire plume over
+  the point: NOAA HMS daily polygons (North America), fetched
+  hourly, decoded by the gated `smoke.js`, answered from RAM with
+  the published class concentration.
 - `GET /solarwind` — the aurora's measured driver: DSCOVR/ACE
   solar wind at L1, already propagated to the bow shock by SWPC
   (the `propagated_time_tag` is a real physical lead time of tens

--- a/themes/horizon/server/install.sh
+++ b/themes/horizon/server/install.sh
@@ -35,10 +35,11 @@ install -m 644 src/index.mjs /opt/horizon-live/index.mjs
 install -m 644 ../lightning.js /opt/horizon-live/lightning.js
 install -m 644 ../solarwind.js /opt/horizon-live/solarwind.js
 install -m 644 ../metar.js /opt/horizon-live/metar.js
+install -m 644 ../smoke.js /opt/horizon-live/smoke.js
 # The '../../' import paths must keep resolving from
 # /opt/horizon-live/index.mjs - rewrite them for the flat deploy
 # (metar.js's own './lightning.js' import already resolves there).
-sed -i "s#'../../lightning.js'#'./lightning.js'#; s#'../../solarwind.js'#'./solarwind.js'#; s#'../../metar.js'#'./metar.js'#" /opt/horizon-live/index.mjs
+sed -i "s#'../../lightning.js'#'./lightning.js'#; s#'../../solarwind.js'#'./solarwind.js'#; s#'../../metar.js'#'./metar.js'#; s#'../../smoke.js'#'./smoke.js'#" /opt/horizon-live/index.mjs
 
 # Environment (created once; never overwritten - your key lives here).
 if [ ! -f /etc/horizon-live.env ]; then

--- a/themes/horizon/server/src/index.mjs
+++ b/themes/horizon/server/src/index.mjs
@@ -59,6 +59,7 @@ import http from 'node:http';
 import {haversineKm} from '../../lightning.js';
 import {parseHemiPower, parsePropagated} from '../../solarwind.js';
 import {normalizeMetars} from '../../metar.js';
+import {parseHmsKml, smokeAt} from '../../smoke.js';
 
 // Schema normalizers - moved here when the Cloudflare worker was
 // retired and deleted (the daemon superseded it; git history
@@ -705,6 +706,46 @@ function main() {
       ? {wind: space.wind, hp: space.hp, at: space.at}
       : null;
 
+  // Wildfire smoke: NOAA HMS - analysts drawing verified plumes
+  // from satellite imagery, one daily KML (~200 KB in season).
+  // Fetched hourly, parsed by the gated smoke.js, answered from
+  // RAM; early in the UTC day today's file may not exist yet, so
+  // yesterday's stands in.
+  const smokeState = {at: 0, day: '', polys: [], fetches: 0, errors: 0};
+  async function pollSmoke() {
+    for (const back of [0, 1]) {
+      const t = new Date(Date.now() - back * 86400e3);
+      const y = t.getUTCFullYear();
+      const mo = String(t.getUTCMonth() + 1).padStart(2, '0');
+      const da = String(t.getUTCDate()).padStart(2, '0');
+      const day = '' + y + mo + da;
+      try {
+        const r = await fetch(
+          'https://satepsanone.nesdis.noaa.gov/pub/FIRE/web/HMS/Smoke_Polygons/KML/' +
+            y +
+            '/' +
+            mo +
+            '/hms_smoke' +
+            day +
+            '.kml',
+          {signal: AbortSignal.timeout(FETCH_MS), headers: {'user-agent': UA}}
+        );
+        if (!r.ok) throw new Error('hms ' + r.status);
+        const polys = parseHmsKml(await r.text());
+        if (!polys.length && back === 0) continue; // too early UTC
+        smokeState.polys = polys;
+        smokeState.day = day;
+        smokeState.at = Date.now();
+        smokeState.fetches++;
+        return;
+      } catch {
+        smokeState.errors++;
+      }
+    }
+  }
+  pollSmoke();
+  setInterval(pollSmoke, 3600e3).unref();
+
   let tlesCache = {t: 0, body: null}; // CelesTrak visual group
   const adsbCache = new Map(); // area key -> {t, body, src}
   const metarCache = new Map(); // area key -> {t, body}
@@ -853,6 +894,13 @@ function main() {
         connects: blitz.connects,
         streams: sseClients.size
       };
+      const smokeHealth = {
+        plumes: smokeState.polys.length,
+        day: smokeState.day,
+        ageMs: smokeState.at ? Date.now() - smokeState.at : null,
+        fetches: smokeState.fetches,
+        errors: smokeState.errors
+      };
       const spaceHealth = {
         haveWind: !!space.wind,
         haveHp: !!space.hp,
@@ -864,12 +912,18 @@ function main() {
       if (url.pathname === '/health')
         return json(
           200,
-          {ais, lightning, space: spaceHealth},
+          {ais, lightning, space: spaceHealth, smoke: smokeHealth},
           {'cache-control': 'no-store'}
         );
       return json(
         200,
-        {ais, lightning, space: spaceHealth, probe: await probeAll()},
+        {
+          ais,
+          lightning,
+          space: spaceHealth,
+          smoke: smokeHealth,
+          probe: await probeAll()
+        },
         {'cache-control': 'no-store'}
       );
     }
@@ -905,6 +959,23 @@ function main() {
         {
           'cache-control': 'public, max-age=30',
           'x-lightning-source': 'blitzortung.org'
+        }
+      );
+    }
+
+    if (url.pathname === '/smoke') {
+      // The analyst-verified plume over the point (HMS is a North
+      // America product - null elsewhere is the truthful answer).
+      return json(
+        200,
+        {
+          smoke: smokeAt(smokeState.polys, lat, lon),
+          plumes: smokeState.polys.length,
+          day: smokeState.day
+        },
+        {
+          'cache-control': 'public, max-age=600',
+          'x-smoke-source': 'NOAA HMS (analyst-verified)'
         }
       );
     }

--- a/themes/horizon/server/update.sh
+++ b/themes/horizon/server/update.sh
@@ -36,7 +36,7 @@ CUR=$(git rev-parse HEAD)
 CHANGED=$(git diff --name-only "$CUR" "$NEW" -- \
   themes/horizon/server \
   themes/horizon/lightning.js themes/horizon/solarwind.js \
-  themes/horizon/metar.js \
+  themes/horizon/metar.js themes/horizon/smoke.js \
   themes/horizon/'*-reference.mjs' \
   themes/horizon/harness/validate.sh 2>/dev/null || echo forced)
 git checkout --quiet "$NEW"

--- a/themes/horizon/smoke-reference.mjs
+++ b/themes/horizon/smoke-reference.mjs
@@ -1,0 +1,110 @@
+// Reference printer for the wildfire-smoke layer (node
+// smoke-reference.mjs). Every HMS plume is an analyst's verified
+// observation, so the gate holds the decoding of their product to
+// a VERBATIM fixture captured live from the real daily KML
+// (2026-07-06 file, fetched 2026-07-09):
+//  - the parser recovers exactly the placemarks in the file -
+//    densities from styleUrl, rings from the coordinate lines
+//  - point-in-polygon: interior points of each real plume hit
+//    with the right class, heavy outranks light in overlaps, a
+//    concave notch is OUTSIDE (the even-odd test, not a bbox)
+//  - the published class concentrations (Ruminski et al. 2006:
+//    light/medium/heavy = 5/16/27 ug/m^3)
+import {HMS_UGM3, inRing, parseHmsKml, smokeAt} from './smoke.js';
+
+let fail = 0;
+const check = (name, ok, detail) => {
+  console.log(`${ok ? 'REF' : 'FAIL'} ${name}: ${detail}`);
+  if (!ok) fail++;
+};
+
+// Three placemarks copied VERBATIM from the live daily file (one
+// per density; the shortest ring of each class).
+const FIXTURE =
+  '<kml><Document><Placemark><description><![CDATA[<div style="width:170px;">Start Time: 2026187 1700UTC<br>End Time: 2026187 2000UTC<br>Density: Light<br>Satellite: GOES-WEST</div>]]></description>\n<styleUrl>#Smoke_Light_style</styleUrl>\n<Polygon>\n  <tessellate>1</tessellate>\n  <gx:drawOrder>0</gx:drawOrder>\n  <outerBoundaryIs>\n    <LinearRing>\n      <coordinates>\n        -77.487670,47.716114,0\n        -77.487670,47.874222,0\n        -77.608575,48.078831,0\n        -77.738781,48.255539,0\n        -77.999193,48.385745,0\n        -78.203802,48.404346,0\n        -78.454914,48.329942,0\n        -78.547918,48.209037,0\n        -78.566519,48.041629,0\n        -78.436313,47.688213,0\n        -78.250304,47.595209,0\n        -77.980592,47.502205,0\n        -77.748082,47.474304,0\n        -77.571374,47.567308,0\n        -77.487670,47.716114,0\n      </coordinates>\n    </LinearRing>\n  </outerBoundaryIs>\n</Polygon>\n</Placemark>\n<Placemark><description><![CDATA[<div style="width:170px;">Start Time: 2026187 1500UTC<br>End Time: 2026187 1700UTC<br>Density: Medium<br>Satellite: GOES-WEST</div>]]></description>\n<styleUrl>#Smoke_Medium_style</styleUrl>\n<Polygon>\n  <tessellate>1</tessellate>\n  <gx:drawOrder>1</gx:drawOrder>\n  <outerBoundaryIs>\n    <LinearRing>\n      <coordinates>\n        -75.136055,54.050601,0\n        -75.136055,54.156006,0\n        -75.136055,54.255210,0\n        -75.098853,54.311012,0\n        -75.030650,54.342014,0\n        -74.974848,54.342014,0\n        -74.919045,54.292412,0\n        -74.956247,54.156006,0\n        -75.012049,54.100203,0\n        -75.067852,54.044401,0\n        -75.136055,54.050601,0\n      </coordinates>\n    </LinearRing>\n  </outerBoundaryIs>\n</Polygon>\n</Placemark>\n<Placemark><description><![CDATA[<div style="width:170px;">Start Time: 2026187 1200UTC<br>End Time: 2026187 1500UTC<br>Density: Heavy<br>Satellite: GOES-EAST</div>]]></description>\n<styleUrl>#Smoke_Heavy_style</styleUrl>\n<Polygon>\n  <tessellate>1</tessellate>\n  <gx:drawOrder>2</gx:drawOrder>\n  <outerBoundaryIs>\n    <LinearRing>\n      <coordinates>\n        -78.735066,50.227056,0\n        -78.747041,50.228145,0\n        -78.759651,50.221522,0\n        -78.764550,50.205601,0\n        -78.755977,50.183555,0\n        -78.742505,50.170083,0\n        -78.719235,50.160285,0\n        -78.706398,50.168631,0\n        -78.703857,50.191856,0\n        -78.713655,50.209638,0\n        -78.722909,50.221522,0\n        -78.735066,50.227056,0\n      </coordinates>\n    </LinearRing>\n  </outerBoundaryIs>\n</Polygon>\n</Placemark></Document></kml>';
+
+{
+  const polys = parseHmsKml(FIXTURE);
+  const sig = polys.map((p) => p.density + ':' + p.ring.length).join(' ');
+  check(
+    'HMS parser',
+    polys.length === 3 &&
+      sig === 'light:15 medium:11 heavy:12' &&
+      parseHmsKml('<kml>junk</kml>').length === 0 &&
+      parseHmsKml(null).length === 0,
+    `verbatim fixture -> ${sig}; junk and null -> empty`
+  );
+}
+
+{
+  // Interior probes of the real plumes (mean of three adjacent
+  // vertices - locally convex) hit with the right class; a point
+  // an ocean away misses everything.
+  const polys = parseHmsKml(FIXTURE);
+  const probe = (p) => {
+    const c = [0, 1, 2].reduce(
+      (a, i) => [a[0] + p.ring[i][0] / 3, a[1] + p.ring[i][1] / 3],
+      [0, 0]
+    );
+    return smokeAt(polys, c[0], c[1]);
+  };
+  const hits = polys.map(probe);
+  check(
+    'plume lookup',
+    hits[0].ugm3 === 5 &&
+      hits[1].ugm3 === 16 &&
+      hits[2].ugm3 === 27 &&
+      smokeAt(polys, 51.48, 0) === null &&
+      HMS_UGM3.light === 5 &&
+      HMS_UGM3.medium === 16 &&
+      HMS_UGM3.heavy === 27,
+    `real-plume interiors -> 5/16/27 ug/m^3 (Ruminski et al. 2006 classes); Greenwich -> null`
+  );
+}
+
+{
+  // Geometry discipline: heavy outranks light where plumes
+  // overlap, and a concave notch is genuinely outside - the
+  // even-odd test, not a bounding box (a centroid can lie outside
+  // its own concave plume; the lookup must not).
+  const light = {
+    density: 'light',
+    ring: [
+      [0, 0],
+      [0, 10],
+      [10, 10],
+      [10, 0]
+    ]
+  };
+  const heavy = {
+    density: 'heavy',
+    ring: [
+      [4, 4],
+      [4, 6],
+      [6, 6],
+      [6, 4]
+    ]
+  };
+  // A "U" in lat/lon: the notch (5, 5) is outside the smoke.
+  const u = [
+    [0, 0],
+    [10, 0],
+    [10, 4],
+    [2, 4],
+    [2, 6],
+    [10, 6],
+    [10, 10],
+    [0, 10]
+  ];
+  check(
+    'overlap and concavity',
+    smokeAt([light, heavy], 5, 5).density === 'heavy' &&
+      smokeAt([light], 5, 5).density === 'light' &&
+      inRing(u, 5, 5) === false &&
+      inRing(u, 1, 5) === true &&
+      smokeAt([light], 11, 5) === null,
+    `heavy outranks light in the overlap; the U-notch is outside (even-odd), its arm inside; beyond the edge -> null`
+  );
+}
+
+process.exit(fail ? 1 : 0);

--- a/themes/horizon/smoke.js
+++ b/themes/horizon/smoke.js
@@ -1,0 +1,82 @@
+/**
+ * Wildfire smoke - the single source shared by the horizon-live
+ * daemon (server/src/index.mjs; install.sh ships this file beside
+ * it), the theme (Horizon.html) and the reference printer
+ * (smoke-reference.mjs).
+ *
+ * NOAA's Hazard Mapping System is ANALYSTS drawing what they see
+ * in the satellite imagery: every plume polygon is a human-
+ * verified observation of smoke, classified light/medium/heavy -
+ * published class concentrations ~5/16/27 ug/m^3 of surface-level
+ * smoke (Ruminski et al. 2006, the HMS product description).
+ * Coverage is North America (the product's own scope). The daemon
+ * fetches the daily KML once per hour and answers point queries
+ * from RAM; the theme records the verified plume overhead in the
+ * provenance panel and exposes it as state.smoke for the aerosol
+ * layer (the CAMS AOD the sky already uses is quantitative and
+ * includes smoke - HMS adds the analyst's TYPE verdict; the
+ * absorbing-aerosol render hook is deferred until the Mie
+ * absorption constant question in WEBGPU-PLAN.md is settled with
+ * GPU recertification).
+ *
+ * Wire format captured live 2026-07-09: KML Placemarks with the
+ * density in styleUrl (#Smoke_{Light,Medium,Heavy}_style) and one
+ * outer ring of "lon,lat,alt" lines per polygon.
+ */
+
+// Published HMS class concentrations, ug/m^3 (Ruminski et al.
+// 2006). Exported for the future aerosol hook.
+export const HMS_UGM3 = {light: 5, medium: 16, heavy: 27};
+
+// Parse the daily HMS smoke KML: [{density, ring: [[lat, lon]..]}].
+// Regex-scoped per Placemark - the files are machine-written with
+// one styleUrl and one outer ring each; malformed placemarks are
+// dropped, never guessed at.
+export function parseHmsKml(kml) {
+  const out = [];
+  if (typeof kml !== 'string') return out;
+  const marks = kml.split('<Placemark>').slice(1);
+  for (const m of marks) {
+    const style = m.match(/styleUrl>#Smoke_(Light|Medium|Heavy)/);
+    const coords = m.match(/<coordinates>([\s\S]*?)<\/coordinates>/);
+    if (!style || !coords) continue;
+    const ring = [];
+    for (const line of coords[1].trim().split(/\s+/)) {
+      const [lon, lat] = line.split(',').map(Number);
+      if (Number.isFinite(lat) && Number.isFinite(lon)) ring.push([lat, lon]);
+    }
+    if (ring.length >= 4) {
+      out.push({density: style[1].toLowerCase(), ring});
+    }
+  }
+  return out;
+}
+
+// Even-odd point-in-polygon (the same test the theme's forests
+// use), in geodetic coordinates.
+export function inRing(ring, lat, lon) {
+  let inside = false;
+  for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+    const [lai, loi] = ring[i];
+    const [laj, loj] = ring[j];
+    if (
+      loi > lon !== loj > lon &&
+      lat < ((laj - lai) * (lon - loi)) / (loj - loi) + lai
+    ) {
+      inside = !inside;
+    }
+  }
+  return inside;
+}
+
+// The densest analyst-verified plume covering the point, or null.
+// Heavy outranks medium outranks light when plumes overlap.
+const RANK = {heavy: 3, medium: 2, light: 1};
+export function smokeAt(polys, lat, lon) {
+  let best = null;
+  for (const p of Array.isArray(polys) ? polys : []) {
+    if (best && RANK[p.density] <= RANK[best.density]) continue;
+    if (inRing(p.ring, lat, lon)) best = p;
+  }
+  return best ? {density: best.density, ugm3: HMS_UGM3[best.density]} : null;
+}


### PR DESCRIPTION
Every HMS polygon is a human analyst's verified observation of smoke in satellite imagery. The daemon now carries the daily product and the theme reports the verdict over the visitor. Reference-gated (`smoke-reference.mjs`, gate set 37).

- **`smoke.js`** (single source): KML parser, even-odd point-in-polygon, densest-plume lookup, and the published class concentrations (Ruminski et al. 2006: light/medium/heavy = 5/16/27 µg/m³).
- **Gate**: parser held to a *verbatim* fixture cut from the live daily file; interior probes of real plumes hit their classes; heavy outranks light in overlaps; a concave U-notch is genuinely outside (a development probe put a concave plume's centroid outside its own ring — that lesson is now a landmark).
- **Daemon**: hourly fetch of the ~200 KB daily KML (yesterday stands in early UTC), parsed to RAM; `GET /smoke?lat&lon` answers the plume class or null (HMS covers North America — null elsewhere is the truthful answer); `/health` grows a smoke block. Verified live through the route against today's file.
- **Theme**: `syncSmoke` every 30 min (`?smoke=` override, kept across relocations, re-synced on roam settle); the provenance panel reports e.g. "heavy plume overhead (analyst-verified) · class ~27 µg/m³".
- **Deliberate scope**: no render change — the CAMS AOD the sky uses is quantitative and already includes smoke. HMS adds the analyst's *type* verdict; its honest render consequence (biomass smoke's lower single-scattering albedo) waits on a newly logged OPEN item: `atmosphere-tsl`'s `MIE_A0 = 4.4e-6` reads 10× Hillaire's published Mie absorption — self-consistent with the certified reference, but it should be re-derived and recertified on a proper GPU rig before the smoke SSA hook lands.

The box self-deploys via the gated update timer after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKKBen9kkD562HDVr7cXAx

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKKBen9kkD562HDVr7cXAx)_