### PR TITLE
Mie SSA 0.9: the haze stops absorbing 10x the paper

### DIFF
--- a/themes/horizon/WEBGPU-PLAN.md
+++ b/themes/horizon/WEBGPU-PLAN.md
@@ -2135,19 +2135,31 @@ secret put AISSTREAM_KEY && npx wrangler deploy`.
   position through the same gated geoToScene - exact continuity.
   window.\_\_roam.workerUsed for the harness; verified in the
   browser smoke (hop through the worker path).
-- OPEN (radiative constants, needs GPU recertification):
-  atmosphere-tsl's MIE_A0 = 4.4e-6 reads as Mie ABSORPTION and
-  extinction is computed as MIE_S0 + MIE_A0 = 8.4e-6 - but
+- DONE (radiative constants): MIE_A0 corrected 4.4e-6 -> 4.44e-7.
   Hillaire (2020) gives Mie scattering 3.996e-6 and EXTINCTION
-  4.440e-6, i.e. absorption 4.44e-7: the code's absorption looks
-  10x the paper's (SSA 0.48 vs the paper's 0.9). It is
-  self-consistent with the certified GLSL reference (same
-  constant ported), so renders match each other - but the
-  constant should be re-derived against the paper and, if
-  corrected, the sky recertified against the pinned matrix with
-  a proper SHOOT_CHROME. The smoke SSA hook (analyst-verified
-  plume -> biomass-burning single-scattering albedo, AERONET
-  climatology) lands in the same edit once settled.
+  4.440e-6 = sigma_s / 0.9 (Bruneton's convention); the original
+  port read the extinction-minus-scattering as 4.4e-6 - a slipped
+  decimal carried self-consistently by every mirror, giving Mie
+  SSA 0.48 instead of the paper's 0.9 (haze absorbed 10x too
+  much). All three mirrors moved in the same edit - the TSL
+  extinction (atmosphere-tsl.js), the CPU sun-colour integral
+  (sun-transmittance.js), and the double-precision reference
+  (atmo-reference.mjs) - so the reference-vs-engine relationship
+  is unchanged and the gate re-derives every REF texel from the
+  corrected constant. New landmark in atmo-reference.mjs pins it:
+  sigma_s/(sigma_s+sigma_a) = 0.9 to 1e-12 and sigma_t = 4.440e-6
+  (exit 1 on drift), so the constant can never silently regress.
+  Measured effect on the sun's transmitted light (mieScale 1,
+  red channel): alt 1 deg 0.2132 -> 0.2482 (+16%), alt 0.2 deg
+  0.1144 -> 0.1511 (+32%) - the low sun and horizon sky brighten
+  toward the paper's intent, high sun barely moves (alt 30 deg
+  +0.6%). No pinned GPU texel matrix exists for the sky (the
+  fixture rig cannot shoot it - environment OPEN below), so
+  on-screen judgement is the owner's live browser; the numeric
+  chain is gated. The smoke SSA hook (analyst-verified plume ->
+  biomass-burning single-scattering albedo) stays deferred until
+  a citable climatology value is settled - published AERONET
+  spreads are wide and we do not invent constants.
 - OPEN (environment, not code) - UPDATE (roam smoke, Jul 7): the
   drift now also manifests as a PER-FRAME uncaught TypeError -
   GPUTexture.createView rejects the `swizzle` field three's

--- a/themes/horizon/atmo-reference.mjs
+++ b/themes/horizon/atmo-reference.mjs
@@ -5,9 +5,26 @@ const Rb = 6360e3,
   Rt = 6460e3;
 const rayS = [5.802e-6, 13.558e-6, 33.1e-6];
 const mieS0 = 3.996e-6,
-  mieA0 = 4.4e-6,
+  mieA0 = 4.44e-7,
   MIE = 1;
 const ozA = [0.65e-6, 1.881e-6, 0.085e-6];
+
+// Radiative-constant landmark (Hillaire 2020, table 1): Mie
+// scattering 3.996e-6 with EXTINCTION 4.440e-6 = sigma_s / 0.9
+// (Bruneton's convention), i.e. absorption 4.44e-7 and a
+// single-scattering albedo of exactly 0.9. The original port
+// carried 4.4e-6 as the ABSORPTION (SSA 0.48) - this pins every
+// mirror (shader, CPU transmittance, this reference) to the paper.
+{
+  const ssa = mieS0 / (mieS0 + mieA0);
+  const ok =
+    Math.abs(ssa - 0.9) < 1e-12 &&
+    Math.abs((mieS0 + mieA0) / 4.44e-6 - 1) < 1e-12;
+  console.log(
+    `${ok ? 'REF' : 'FAIL'} mie SSA: sigma_s ${mieS0.toExponential(4)} / sigma_t ${(mieS0 + mieA0).toExponential(4)} = ${ssa.toFixed(12)} (Hillaire 2020: 0.9 exactly)`
+  );
+  if (!ok) process.exit(1);
+}
 
 const dens = (h) => [
   Math.exp(-h / 8000),

--- a/themes/horizon/atmosphere-tsl.js
+++ b/themes/horizon/atmosphere-tsl.js
@@ -88,8 +88,11 @@ export function createAtmosphereTSL(renderer) {
 
   const rayleighS = vec3(5.802e-6, 13.558e-6, 33.1e-6);
   const ozoneA = vec3(0.65e-6, 1.881e-6, 0.085e-6);
+  // Hillaire (2020) Mie radiative constants: scattering 3.996e-6,
+  // extinction 4.440e-6 (= sigma_s / 0.9, Bruneton's convention), so
+  // absorption is 4.44e-7 and the single-scattering albedo is 0.9.
   const MIE_S0 = 3.996e-6;
-  const MIE_A0 = 4.4e-6;
+  const MIE_A0 = 4.44e-7;
 
   // x: rayleigh, y: mie, z: ozone (tent at 25 km).
   const densities = Fn(([h]) =>

--- a/themes/horizon/sun-transmittance.js
+++ b/themes/horizon/sun-transmittance.js
@@ -27,7 +27,9 @@ export function sunTransmittanceJS(cosZenith, mieScale) {
     tm += Math.exp(-h / 1200) * dt;
     to += Math.max(0, 1 - Math.abs(h - 25e3) / 15e3) * dt;
   }
-  const mie = (3.996e-6 + 4.4e-6) * mieScale * tm;
+  // Mie extinction 4.440e-6 = scattering 3.996e-6 + absorption
+  // 4.44e-7 (Hillaire 2020, SSA 0.9) - same split as the shader.
+  const mie = (3.996e-6 + 4.44e-7) * mieScale * tm;
   return [
     Math.exp(-(5.802e-6 * tr + mie + 0.65e-6 * to)),
     Math.exp(-(13.558e-6 * tr + mie + 1.881e-6 * to)),


### PR DESCRIPTION
Hillaire (2020) gives Mie scattering 3.996e-6 with **extinction** 4.440e-6 (= σs / 0.9, Bruneton's convention), so absorption is 4.44e-7. The original port carried 4.4e-6 as the absorption — a slipped decimal every mirror copied self-consistently, making the haze layer absorb ten times too much (single-scattering albedo 0.48 instead of the paper's 0.9).

All three mirrors move in one edit so the reference-vs-engine relationship never changes:
- `atmosphere-tsl.js` — the TSL extinction (`MIE_A0 = 4.44e-7`, with the citation)
- `sun-transmittance.js` — the CPU integral that colours the sun's light on the terrain
- `atmo-reference.mjs` — the double-precision reference, which re-derives every REF texel from the corrected constant

New landmark in `atmo-reference.mjs` pins the constant forever: σs/(σs+σa) = 0.9 to 1e-12 and σt = 4.440e-6, exit 1 on drift.

Measured effect (sun transmittance, mieScale 1, red channel): +16% at 1° altitude, +32% at 0.2° — the low sun and horizons brighten to the paper's intent; the high sun barely moves (+0.6% at 30°). Full gate: 39 reference sets PASS including the new landmark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKKBen9kkD562HDVr7cXAx

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKKBen9kkD562HDVr7cXAx)_