### PR TITLE
Crepuscular rays: volumetric cloud shadow in the aerial in-scatter

### DIFF
--- a/themes/Horizon.html
+++ b/themes/Horizon.html
@@ -1847,12 +1847,24 @@
       const ambient = new THREE.HemisphereLight(0xffffff, 0x404038, 0.5);
       scene.add(ambient);
 
+      // Cloud shadows (phase 5): Beer-Lambert through the SAME Nubis
+      // density the sky renders, multiplied into every sunlit
+      // material's received shadow AND into the aerial march's
+      // direct term (crepuscular rays). Created BEFORE the
+      // atmosphere so its transmittance node can compile into the
+      // aerial LUT kernel; until the lazy cloud system attaches, the
+      // hook is a zero map - full sun.
+      const cloudShadow = createCloudShadowHook();
+      cloudShadow.uniforms.uWorldSize.value = WORLD;
+
       // The sky: Hillaire (2020) multiple-scattering atmosphere -
       // transmittance, multiple-scattering and per-frame sky-view LUTs
       // with Rayleigh, measured-aerosol Mie and ozone profiles.
       // Twilight arch and the Belt of Venus emerge from the raymarch
-      // instead of being painted.
-      const atmo = createAtmosphereTSL(renderer);
+      // instead of being painted. The aerial-perspective march
+      // carries Hillaire's volumetric shadow through the cloud
+      // shadow hook - the haze itself shows the beams.
+      const atmo = createAtmosphereTSL(renderer, cloudShadow);
       if (atmo.ok) {
         scene.add(atmo.mesh);
         record(
@@ -2073,12 +2085,6 @@
       const terrainMat = terrainObj.material;
       const terrainUniforms = terrainObj.uniforms;
       terrainUniforms.uWorldSize.value = WORLD;
-      // Cloud shadows (phase 5): Beer-Lambert through the SAME Nubis
-      // density the sky renders, multiplied into every sunlit
-      // material's received shadow. Until the lazy cloud system
-      // attaches, the hook is a zero map - full sun.
-      const cloudShadow = createCloudShadowHook();
-      cloudShadow.uniforms.uWorldSize.value = WORLD;
       cloudShadow.applyTo(terrainMat);
       record(
         'GGX microfacet BRDF (Karis 2013)',
@@ -2087,6 +2093,10 @@
       record(
         'Cloud shadow map',
         'Beer-Lambert through the cloud decks (Schneider 2015)'
+      );
+      record(
+        'Crepuscular rays',
+        'volumetric cloud shadow in the aerial in-scatter (Hillaire 2020)'
       );
       record('Lommel-Seeliger moon', 'lunar regolith photometry');
 
@@ -4592,6 +4602,14 @@
           // compression) feeds the sky and aerial LUTs, so flying up
           // physically lowers the horizon and thins the haze.
           const eCam = centerElev + 500 * Math.sinh(camera.position.y / 16);
+          // Crepuscular rays: the aerial march places its cloud
+          // shadow samples from the camera's scene position and the
+          // sun azimuth (set BEFORE update - fillAerial runs there).
+          atmo.aerialShadow.camXZ.value.set(
+            camera.position.x,
+            camera.position.z
+          );
+          atmo.aerialShadow.sunAz.value.set(sunVec.x, sunVec.z).normalize();
           atmo.update(sunVec, mieRad, Math.max(eCam, 50), skyExposure);
           // Aerial perspective shares the dome's exposure so inscattered
           // light on the terrain matches the sky it comes from.

--- a/themes/horizon/WEBGPU-PLAN.md
+++ b/themes/horizon/WEBGPU-PLAN.md
@@ -2211,6 +2211,47 @@ secret put AISSTREAM_KEY && npx wrangler deploy`.
     sky): expect hazier, warmer horizons under real air - measured
     tau is 5-30x the paper default - and dust/smoke events to
     read as coloured, absorbing skies.
+- DONE: crepuscular rays - Hillaire's volumetric shadow in the
+  aerial perspective (Jul 9). The cloud shadow map (Schneider
+  2015 Beer-Lambert through the decks, shipped in phase 5) so far
+  shadowed only SURFACES; the haze between the camera and the
+  terrain ignored it, so cloud banks never threw visible beams.
+  Now the aerial-perspective march multiplies its DIRECT
+  single-scatter term per step by the shadow map's transmittance
+  at the marched point (chi(t)) - exactly Hillaire (2020)'s
+  aerial perspective with volumetric shadow; multiple scattering
+  stays unshadowed per the paper. Structural change the shadow
+  forced: the aerial LUT went 64x32 half-circle -> 128x32 FULL
+  circle with SIGNED azimuth (clouds are not azimuthally
+  symmetric - the old |relAz| fold would have mirrored every
+  shaft across the sun line); the seam sits at the anti-sun
+  azimuth where in-scatter varies slowest, and aerial-tsl's
+  sampler reads the signed angle back via atan(cross, dot).
+  Gated in atmo-reference.mjs (atmo set grew 10 -> 16 lines):
+  (1) chi=1 IS the unshadowed march and chi=0 IS the
+  ambient-only march, exact - the shadow touches only the direct
+  term; (2) linearity restatement - a half-lit ray equals
+  ambient + the lit steps' direct contributions harvested from
+  an independent pass (1.8e-15); (3) fill-rotation vs sampler
+  atan(cross, dot) roundtrip over the full signed circle
+  (2.2e-16) - a sign slip would mirror every shaft; plus three
+  REF aerial texel pins. Scope, stated honestly: the 2D LUT
+  collapses elevation, so chi is sampled at the ground datum
+  along the ray - the shafts line up with the terrain's own
+  per-pixel cloud shadow by construction; the sky DOME march
+  stays unshadowed (a shaft's shadow covers only the first 16 km
+  of a dome ray, which converges to unshadowed at the dome's
+  distances - and dome shafts would need the same full-circle
+  treatment on the 192x108 sky LUT, a possible follow-up).
+  Wiring: the cloud shadow hook is created BEFORE the atmosphere
+  so its transmittance node compiles into the aerial compute
+  kernel; camera scene position + sun azimuth uniforms feed the
+  march (set before update()). Browser smoke with the cloud
+  system ACTIVE (cloud=60): kernel compiles, frame loop alive,
+  no new shader errors - the "2D view of 3D texture" Dawn spam
+  under heavy cloud reproduces IDENTICALLY on a clean HEAD
+  worktree (156 vs 158 messages), i.e. the documented
+  environmental drift below, not this change.
 - OPEN (environment, not code) - UPDATE (roam smoke, Jul 7): the
   drift now also manifests as a PER-FRAME uncaught TypeError -
   GPUTexture.createView rejects the `swizzle` field three's

--- a/themes/horizon/aerial-tsl.js
+++ b/themes/horizon/aerial-tsl.js
@@ -1,6 +1,7 @@
 import {AgXToneMapping, Color, SRGBColorSpace, Vector2} from 'three/webgpu';
 import {
   Fn,
+  atan,
   cameraPosition,
   color,
   dot,
@@ -78,7 +79,18 @@ export function createAerialFog(aerialLutTex) {
     const dir = positionWorld.sub(cameraPosition);
     const d = dir.length();
     const aerH = normalize(dir.xz.add(vec2(1e-6, 1e-6)));
-    const aerAz = dot(aerH, u.uSunAzV).clamp(-1, 1).acos().div(3.14159265);
+    // SIGNED relative azimuth over the full circle (the LUT carries
+    // the cloud volumetric shadow, which is not azimuthally
+    // symmetric): atan(cross, dot) is the counterclockwise angle
+    // from the sun azimuth - the same convention the LUT fill
+    // rotates by (roundtrip gated in atmo-reference.mjs). u = 0.5
+    // faces the sun; the clamp seam sits at the anti-sun azimuth.
+    const aerAz = atan(
+      u.uSunAzV.x.mul(aerH.y).sub(u.uSunAzV.y.mul(aerH.x)),
+      dot(aerH, u.uSunAzV)
+    )
+      .div(2.0 * 3.14159265)
+      .add(0.5);
     const aer = aerialTexNode.sample(
       vec2(aerAz, min(d.div(u.uAerialMaxU), 1.0))
     );

--- a/themes/horizon/atmo-reference.mjs
+++ b/themes/horizon/atmo-reference.mjs
@@ -248,3 +248,150 @@ console.log('REF sky(30,20):', fmt(sky(30, 20)));
 // limits (below: ground at the tangent distance; above: full path).
 console.log('REF sky(30,53):', fmt(sky(30, 53)));
 console.log('REF sky(30,54):', fmt(sky(30, 54)));
+
+// ---- aerial march with volumetric shadow (crepuscular rays) ----
+// Mirrors atmosphere-tsl's marchAerial20: a horizontal 20-step
+// march at camera height over the full SIGNED azimuth circle,
+// where chi(t) - the cloud shadow map's sun visibility at the
+// marched point - multiplies the DIRECT single-scatter term only
+// (Hillaire 2020's aerial perspective with volumetric shadow;
+// multiple scattering stays unshadowed).
+const AER_MAX = 25700;
+const aer = (uAz, uDist, chi, mode) => {
+  // mode: 'full' (the engine), 'nodirect' (ambient only),
+  // 'directonly' (per-step direct contributions, for linearity)
+  const az = (uAz - 0.5) * 2 * Math.PI;
+  const dEnd = uDist * AER_MAX;
+  const r = Rb + 300;
+  const steps = 20;
+  const dt = dEnd / steps;
+  const sunS = Math.sqrt(Math.max(1 - sunMu * sunMu, 0));
+  const cSun = Math.cos(az) * sunS;
+  const T = [1, 1, 1];
+  const L = [0, 0, 0];
+  const D = []; // per-step direct contributions (directonly)
+  for (let s = 0; s < steps; s++) {
+    const ti = (s + 0.5) * dt;
+    const ri = Math.sqrt(r * r + ti * ti);
+    const h = ri - Rb;
+    const dd = dens(h);
+    const sR = rayS.map((rr) => rr * dd[0]);
+    const sM = mieS.map((ss) => ss * dd[1]);
+    const e = ext(h);
+    const muSi = Math.min(Math.max((r * sunMu + ti * cSun) / ri, -1), 1);
+    const Ts = sunT(ri, muSi);
+    const psi = psiMS(ri, muSi);
+    const x = chi ? chi(ti) : 1;
+    const Ds = [0, 0, 0];
+    for (let c = 0; c < 3; c++) {
+      const dir = (sR[c] * phaseR(cSun) + sM[c] * phaseM(cSun)) * Ts[c];
+      const amb = (sR[c] + sM[c]) * psi[c];
+      const S =
+        mode === 'nodirect' ? amb : mode === 'directonly' ? dir : dir * x + amb;
+      const st = Math.exp(-e[c] * dt);
+      const add = (T[c] * (S - S * st)) / Math.max(e[c], 1e-9);
+      if (mode === 'directonly') Ds[c] = add;
+      else L[c] += add;
+      T[c] *= st;
+    }
+    if (mode === 'directonly') D.push(Ds);
+  }
+  return mode === 'directonly' ? D : L;
+};
+
+let aerFail = 0;
+const aerCheck = (name, ok, detail) => {
+  console.log(`${ok ? 'REF' : 'FAIL'} ${name}: ${detail}`);
+  if (!ok) aerFail++;
+};
+
+{
+  // chi = 1 must be EXACTLY the unshadowed march, chi = 0 exactly
+  // the ambient-only march - together they pin that the shadow
+  // multiplies the direct term and nothing else.
+  let worst = 0;
+  for (const [u, v] of [
+    [0.5, 1],
+    [0.25, 0.5],
+    [0.9, 0.75]
+  ]) {
+    const lit = aer(u, v, () => 1, 'full');
+    const un = aer(u, v, null, 'full');
+    const dark = aer(u, v, () => 0, 'full');
+    const amb = aer(u, v, null, 'nodirect');
+    for (let c = 0; c < 3; c++)
+      worst = Math.max(
+        worst,
+        Math.abs(lit[c] - un[c]),
+        Math.abs(dark[c] - amb[c])
+      );
+  }
+  aerCheck(
+    'aerial shadow bounds',
+    worst === 0,
+    `chi=1 IS the unshadowed march and chi=0 IS the ambient-only march (exact, 3 texels x 3 channels): the shadow touches only the direct term`
+  );
+}
+
+{
+  // Linearity restatement: the march is linear in per-step chi, so
+  // for ANY chi, L(chi) = L(0) + sum_s chi_s * D_s with D_s
+  // harvested from an independent direct-only pass. Check a hard
+  // half-lit chi (a cloud bank covering the near half of the ray).
+  const u = 0.35;
+  const v = 0.8;
+  const half = AER_MAX * v * 0.5;
+  const chi = (t) => (t < half ? 0 : 1);
+  const got = aer(u, v, chi, 'full');
+  const amb = aer(u, v, null, 'nodirect');
+  const D = aer(u, v, null, 'directonly');
+  const dt = (v * AER_MAX) / 20;
+  const want = [0, 1, 2].map(
+    (c) =>
+      amb[c] + D.reduce((a, Ds, s) => a + (chi((s + 0.5) * dt) ? Ds[c] : 0), 0)
+  );
+  const worst = Math.max(
+    ...[0, 1, 2].map(
+      (c) => Math.abs(got[c] - want[c]) / Math.max(want[c], 1e-12)
+    )
+  );
+  aerCheck(
+    'aerial shadow linearity',
+    worst < 1e-12,
+    `half-lit ray equals ambient + the lit steps' direct contributions (independent pass) to ${worst.toExponential(1)}`
+  );
+}
+
+{
+  // Azimuth convention roundtrip: the LUT fill rotates the sun
+  // azimuth vector by az (counterclockwise in the xz basis); the
+  // sampler reads az back as atan(cross, dot). Mirrors of both
+  // formulas must invert each other over the full circle for any
+  // sun azimuth - a sign slip here would mirror every shaft.
+  let worst = 0;
+  for (let k = 0; k < 24; k++) {
+    const az = -Math.PI + ((k + 0.5) / 24) * 2 * Math.PI;
+    for (const t of [0.3, 2.1, 4.4]) {
+      const s = [Math.cos(t), Math.sin(t)];
+      const d = [
+        s[0] * Math.cos(az) - s[1] * Math.sin(az),
+        s[0] * Math.sin(az) + s[1] * Math.cos(az)
+      ];
+      const back = Math.atan2(
+        s[0] * d[1] - s[1] * d[0],
+        s[0] * d[0] + s[1] * d[1]
+      );
+      worst = Math.max(worst, Math.abs(back - az));
+    }
+  }
+  aerCheck(
+    'aerial azimuth roundtrip',
+    worst < 1e-12,
+    `fill rotation and sampler atan(cross, dot) invert each other to ${worst.toExponential(1)} over the full signed circle (72 cases)`
+  );
+}
+
+console.log('REF aerial(0.5,1.0):', fmt(aer(0.5, 1, null, 'full')));
+console.log('REF aerial(0.25,0.5):', fmt(aer(0.25, 0.5, null, 'full')));
+console.log('REF aerial(0.0,1.0):', fmt(aer(0, 1, null, 'full')));
+if (aerFail) process.exit(1);

--- a/themes/horizon/atmosphere-tsl.js
+++ b/themes/horizon/atmosphere-tsl.js
@@ -10,6 +10,7 @@ import {
   RenderTarget,
   SphereGeometry,
   StorageTexture,
+  Vector2,
   Vector3
 } from 'three/webgpu';
 import {
@@ -53,8 +54,15 @@ import {
  *    20-step marches, ground bounce, Psi_ms = L2 / (1 - f_ms)
  *  - sky-view LUT 192x108 per frame (32 steps, sqrt-warped elevation
  *    split at the true horizon)
- *  - aerial-perspective LUT 64x32 (relative azimuth x distance, 20
- *    steps) for the per-material fog hook
+ *  - aerial-perspective LUT 128x32 (SIGNED relative azimuth over the
+ *    full circle x distance, 20 steps) for the per-material fog
+ *    hook, with Hillaire's volumetric shadow: the DIRECT
+ *    single-scatter term is multiplied per step by the cloud shadow
+ *    map's Beer-Lambert transmittance at the marched point
+ *    (crepuscular rays; multiple scattering stays unshadowed). The
+ *    full circle exists BECAUSE of the shadow - clouds are not
+ *    azimuthally symmetric; the seam sits at the anti-sun azimuth
+ *    where in-scatter varies slowest.
  *  - 1x1 cosine-weighted sky irradiance for the hemisphere ambient
  *    (read back asynchronously - no pipeline stall)
  *  - the dome samples the sky-view LUT and adds the sun disc through
@@ -71,9 +79,13 @@ import {
 const RB = 6360e3;
 const RT = 6460e3;
 const MAX_DIST_M = 25700; // 450 scene units at 57.14 m/unit
+const SCENE_PER_M = 7 / 400; // roam.js MPU inverted (exact)
 const SKY_H = 108; // sky-view LUT rows; the guarded split needs it
 
-export function createAtmosphereTSL(renderer) {
+// `cloudShadow` (optional) is the theme's cloud shadow hook
+// (clouds-tsl.js createCloudShadowHook): its Beer-Lambert
+// transmittance(worldPos) shadows the aerial march's direct term.
+export function createAtmosphereTSL(renderer, cloudShadow) {
   // Mie radiative properties as uniforms (aerosol.js): per-channel
   // scattering and absorption coefficients at profile h = 0 (1/m)
   // and the phase asymmetry. Defaults are Hillaire (2020)'s exact
@@ -211,7 +223,7 @@ export function createAtmosphereTSL(renderer) {
   const tLut = makeLut(256, 64);
   const msLut = makeLut(32, 32);
   const skyLut = makeLut(192, SKY_H);
-  const aerialLut = makeLut(64, 32);
+  const aerialLut = makeLut(128, 32);
   // The irradiance readback needs a RenderTarget on both backends
   // (readRenderTargetPixelsAsync is the async staging read); it is a
   // single texel - nothing for compute to win.
@@ -369,7 +381,61 @@ export function createAtmosphereTSL(renderer) {
       return vec4(L, dot(T, vec3(1 / 3, 1 / 3, 1 / 3)));
     });
   const marchSky32 = makeMarchSky(32);
-  const marchSky20 = makeMarchSky(20);
+
+  // ---------- aerial march with volumetric shadow ----------
+  // The horizontal march at camera height along the SIGNED azimuth
+  // from the sun: identical physics to makeMarchSky with dir.y = 0,
+  // plus chi(t) - the cloud shadow map's Beer-Lambert transmittance
+  // at the marched point - on the DIRECT single-scatter term only
+  // (Hillaire 2020's aerial perspective with volumetric shadow;
+  // multiple scattering stays unshadowed). Mirrored and gated in
+  // atmo-reference.mjs.
+  const aerialCamXZ = uniform(new Vector2(0, 0));
+  const aerialSunAz = uniform(new Vector2(1, 0));
+  const marchAerial20 = Fn(([r, az, dEnd]) => {
+    const steps = 20;
+    const dt = dEnd.div(steps);
+    const T = vec3(1).toVar();
+    const L = vec3(0).toVar();
+    const sunS = sqrt(max(sunMu.mul(sunMu).oneMinus(), 0.0));
+    const cSun = cos(az).mul(sunS);
+    // Scene-plane direction of this azimuth: the sun's azimuth
+    // vector rotated by az (counterclockwise in the xz basis - the
+    // same convention aerial-tsl's atan(cross, dot) reads back;
+    // roundtrip gated).
+    const sceneDir = vec2(
+      aerialSunAz.x.mul(cos(az)).sub(aerialSunAz.y.mul(sin(az))),
+      aerialSunAz.x.mul(sin(az)).add(aerialSunAz.y.mul(cos(az)))
+    );
+    Loop(steps, ({i: s}) => {
+      const ti = float(s).add(0.5).mul(dt);
+      const ri = sqrt(r.mul(r).add(ti.mul(ti)));
+      const h = ri.sub(RB);
+      const dens = densities(h);
+      const scatR = rayleighS.mul(dens.x);
+      const scatM = mieScat.mul(dens.y);
+      const ext = extinction(h);
+      const muSi = clamp(r.mul(sunMu).add(ti.mul(cSun)).div(ri), -1.0, 1.0);
+      const Ts = sunT(ri, muSi);
+      // chi: sun visibility through the cloud decks at the marched
+      // point (ground datum - the 2D LUT collapses elevation; the
+      // shafts line up with the terrain's own per-pixel shadow).
+      const p = aerialCamXZ.add(sceneDir.mul(ti.mul(SCENE_PER_M)));
+      const chi = cloudShadow
+        ? cloudShadow.transmittance(vec3(p.x, 0.0, p.y))
+        : float(1);
+      const S = scatR
+        .mul(phaseR(cSun))
+        .add(scatM.mul(phaseM(cSun)))
+        .mul(Ts)
+        .mul(chi)
+        .add(scatR.add(scatM).mul(psiMS(ri, muSi)));
+      const stepT = exp(ext.mul(dt).negate());
+      L.addAssign(T.mul(S.sub(S.mul(stepT))).div(max(ext, vec3(1e-9))));
+      T.mulAssign(stepT);
+    });
+    return vec4(L, dot(T, vec3(1 / 3, 1 / 3, 1 / 3)));
+  });
 
   // Sky-view vertical mapping, Bruneton-style guarded split (phase 4
   // horizon-band fix). Sky radiance is DISCONTINUOUS at the horizon
@@ -449,11 +515,12 @@ export function createAtmosphereTSL(renderer) {
 
   // ---------- aerial perspective (per frame) ----------
   const aerialNode = Fn(([vUv]) => {
-    const relAz = vUv.x.mul(3.14159265);
+    // Full-circle SIGNED azimuth: u = 0.5 faces the sun, the seam
+    // (u = 0/1) is the anti-sun azimuth.
+    const az = vUv.x.sub(0.5).mul(2.0 * 3.14159265);
     const dist = vUv.y.mul(MAX_DIST_M);
     const r = float(RB).add(max(camH, 1.0));
-    const dir = vec3(cos(relAz), 0.0, sin(relAz));
-    return marchSky20(r, dir, dist);
+    return marchAerial20(r, az, dist);
   });
 
   // ---------- cosine-weighted sky irradiance (per frame, 1x1) ----------
@@ -631,6 +698,10 @@ export function createAtmosphereTSL(renderer) {
     // Exact metres-per-scene-unit (roam.js MPU = 16000/280): the
     // old 57.14 literal was 50 ppm off the mapping's own constant.
     aerialMaxUnits: MAX_DIST_M / (400 / 7),
+    // Crepuscular rays: the aerial march needs the camera's scene
+    // position and the sun's azimuth vector to place its shadow
+    // samples (set per frame next to the fog hook's uSunAzV).
+    aerialShadow: {camXZ: aerialCamXZ, sunAz: aerialSunAz},
     // Refraction of the drawn disc: per-channel apparent
     // directions + vertical flattening (set from refraction.js).
     sunDisc: {dirR: sunDirR, dirB: sunDirB, flatten: sunFlat},


### PR DESCRIPTION
The cloud shadow map (Schneider 2015 Beer-Lambert through the decks, shipped in phase 5) so far shadowed only **surfaces** — the haze between the camera and the terrain ignored it, so cloud banks never threw visible beams. The aerial-perspective march now multiplies its direct single-scatter term per step by the shadow map's transmittance at the marched point — exactly **Hillaire (2020)'s aerial perspective with volumetric shadow**; multiple scattering stays unshadowed per the paper. Golden-hour cloud gaps now put the beams in the air itself, aligned with the terrain's own per-pixel cloud shadow by construction.

**Structural change the shadow forced:** the aerial LUT goes 64×32 half-circle → 128×32 **full circle with signed azimuth**. Clouds are not azimuthally symmetric — the old `|relAz|` fold would have mirrored every shaft across the sun line. The seam sits at the anti-sun azimuth (where in-scatter varies slowest); `aerial-tsl.js` reads the signed angle back via `atan(cross, dot)`.

**Gated** in `atmo-reference.mjs` (atmo set 10 → 16 landmark lines):
- χ=1 **is** the unshadowed march and χ=0 **is** the ambient-only march, exact — the shadow touches only the direct term
- linearity restatement: a half-lit ray equals ambient + the lit steps' direct contributions harvested from an independent pass (1.8e-15)
- fill-rotation vs sampler `atan(cross, dot)` roundtrip over the full signed circle (2.2e-16) — a sign slip would mirror every shaft
- three new REF aerial texel pins

Scope, stated honestly in the plan: the 2D LUT collapses elevation, so χ samples at the ground datum along the ray; the sky dome march stays unshadowed (a local shadow covers only the first 16 km of a dome ray — dome shafts are a possible follow-up needing the same full-circle treatment on the sky LUT).

Wiring: the cloud shadow hook is created before the atmosphere so its transmittance node compiles into the aerial compute kernel; camera scene position + sun azimuth uniforms feed the march. Browser smoke with the cloud system active: kernel compiles, frame loop alive, **no new shader errors** — the "2D view of 3D texture" Dawn spam under heavy cloud reproduces identically on a clean HEAD worktree (the documented environmental drift, not this change). Full `validate.sh`: 41 sets PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKKBen9kkD562HDVr7cXAx

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKKBen9kkD562HDVr7cXAx)_