### PR TITLE
Crepuscular rays phase 2: the sky dome joins

### DIFF
--- a/themes/Horizon.html
+++ b/themes/Horizon.html
@@ -4602,14 +4602,16 @@
           // compression) feeds the sky and aerial LUTs, so flying up
           // physically lowers the horizon and thins the haze.
           const eCam = centerElev + 500 * Math.sinh(camera.position.y / 16);
-          // Crepuscular rays: the aerial march places its cloud
-          // shadow samples from the camera's scene position and the
-          // sun azimuth (set BEFORE update - fillAerial runs there).
+          // Crepuscular rays: the sky and aerial marches place
+          // their cloud shadow samples from the camera's scene
+          // position, the sun azimuth and the box's elevation
+          // datum (set BEFORE update - the fills run there).
           atmo.aerialShadow.camXZ.value.set(
             camera.position.x,
             camera.position.z
           );
           atmo.aerialShadow.sunAz.value.set(sunVec.x, sunVec.z).normalize();
+          atmo.aerialShadow.elev0.value = centerElev;
           atmo.update(sunVec, mieRad, Math.max(eCam, 50), skyExposure);
           // Aerial perspective shares the dome's exposure so inscattered
           // light on the terrain matches the sky it comes from.

--- a/themes/horizon/WEBGPU-PLAN.md
+++ b/themes/horizon/WEBGPU-PLAN.md
@@ -2252,6 +2252,34 @@ secret put AISSTREAM_KEY && npx wrangler deploy`.
   under heavy cloud reproduces IDENTICALLY on a clean HEAD
   worktree (156 vs 158 messages), i.e. the documented
   environmental drift below, not this change.
+- DONE: crepuscular rays phase 2 - the sky dome joins (Jul 9).
+  The follow-up queued in the phase-1 entry: the SKY-VIEW march
+  now carries the same volumetric shadow as the aerial one, so
+  the beams fan across the sky from cloud gaps, not only through
+  the terrain haze. One march factory serves both LUTs (the
+  aerial march was the special case se=0, ce=1 all along - the
+  unification is a deletion, not a fork). Sky-view LUT went
+  192x108 half-circle -> 384x108 FULL signed circle (the old
+  texel pitch kept; the seam at the anti-sun azimuth); the dome
+  sampler reads the signed angle with the same gated
+  atan(cross, dot); the irradiance integral's 8 azimuth samples
+  now span the full circle, so the shadowed sky darkens the
+  hemisphere ambient correctly. Shadow samples are HEIGHT-AWARE
+  everywhere now: scene y from the theme's exact asinh altitude
+  datum (identity landmark against roam.yOfElev - one datum, one
+  model), so a ray above the decks reads full sun and a camera
+  flying over the clouds sees no ground shafts (this supersedes
+  phase 1's ground-datum sampling for the aerial march too).
+  Landmarks (atmo set 16 -> 19 lines): full-circle back-compat -
+  the six old half-circle sky pins and their MIRRORS reproduce to
+  2.2e-16 (the remap provably changes nothing for a symmetric
+  sky; REF pins re-indexed 192+i, same values to the digit); sky
+  shadow bounds (chi=1 IS unshadowed, chi=0 IS ambient-only,
+  exact); the datum identity. Cost: fillSky doubles its texels
+  (384 wide) - per frame like before, fine on real GPUs. Scope
+  note: the shadow map still covers the 16 km world box, so
+  dome beams come from the clouds overhead - which is where
+  crepuscular rays live.
 - OPEN (environment, not code) - UPDATE (roam smoke, Jul 7): the
   drift now also manifests as a PER-FRAME uncaught TypeError -
   GPUTexture.createView rejects the `swizzle` field three's

--- a/themes/horizon/atmo-reference.mjs
+++ b/themes/horizon/atmo-reference.mjs
@@ -1,6 +1,8 @@
 // Double-precision JS reference of the Hillaire chain (node atmo-reference.mjs).
 // Mirrors the GLSL/TSL exactly (LUT sizes, bilinear sampling) - the ground
 // truth every GPU port is validated against. See WEBGPU-PLAN.md.
+import {yOfElev} from './roam.js';
+
 const Rb = 6360e3,
   Rt = 6460e3;
 const rayS = [5.802e-6, 13.558e-6, 33.1e-6];
@@ -173,13 +175,15 @@ for (let j = 0; j < MW; j++)
 const psiMS = (r, mu) =>
   bilinear(msLut, MW, MW, mu * 0.5 + 0.5, (r - Rb) / (Rt - Rb));
 
-// sky-view at selected texels, 192x108, camH=300, sunMu given
+// sky-view at selected texels - 384x108 (full SIGNED azimuth
+// circle, u = 0.5 faces the sun), camH=300, sunMu given. chi(ti)
+// is the cloud shadow's sun visibility on the DIRECT term
+// (Hillaire's volumetric shadow); mode as in aer() below.
 const sunMu = 0.28 / Math.hypot(0.94, 0.28); // matches the A/B pages' normalize
-const SW = 192,
+const SW = 384,
   SH = 108;
-const sky = (i, j) => {
-  const ux = (i + 0.5) / SW,
-    uyv = (j + 0.5) / SH;
+const skyElev = (j) => {
+  const uyv = (j + 0.5) / SH;
   const r = Rb + 300;
   const horizon = -Math.sqrt(Math.max(r * r - Rb * Rb, 0)) / r;
   const hA = Math.asin(Math.min(Math.max(horizon, -1), 1));
@@ -187,21 +191,21 @@ const sky = (i, j) => {
   // half-texel guards at the v=0.5 horizon seam, ray class by half.
   const guard = 0.5 / SH,
     span = 0.5 - 1 / SH;
-  let elev;
   if (uyv < 0.5) {
     const s = Math.min(Math.max((0.5 - guard - uyv) / span, 0), 1);
-    elev = hA - s * s * (hA + Math.PI / 2);
-  } else {
-    const s = Math.min(Math.max((uyv - 0.5 - guard) / span, 0), 1);
-    elev = hA + s * s * (Math.PI / 2 - hA);
+    return hA - s * s * (hA + Math.PI / 2);
   }
-  const relAz = ux * Math.PI;
+  const s = Math.min(Math.max((uyv - 0.5 - guard) / span, 0), 1);
+  return hA + s * s * (Math.PI / 2 - hA);
+};
+const skyAt = (az, j, chi, mode) => {
+  const uyv = (j + 0.5) / SH;
+  const r = Rb + 300;
+  const elev = skyElev(j);
   const se = Math.sin(elev),
     ce = Math.cos(elev);
-  const dir = [ce * Math.cos(relAz), se, ce * Math.sin(relAz)];
   const sunS = Math.sqrt(Math.max(1 - sunMu * sunMu, 0));
-  const sd = [sunS, sunMu, 0];
-  const mu = dir[1];
+  const mu = se;
   const dG = raySphere(r, mu, Rb),
     dT = raySphere(r, mu, Rt);
   const dTan = Math.sqrt(Math.max(r * r - Rb * Rb, 0));
@@ -209,7 +213,7 @@ const sky = (i, j) => {
   const dt = dEnd / 32;
   const T = [1, 1, 1],
     L = [0, 0, 0];
-  const cSun = dir[0] * sd[0] + dir[1] * sd[1] + dir[2] * sd[2];
+  const cSun = ce * Math.cos(az) * sunS + se * sunMu;
   for (let s = 0; s < 32; s++) {
     const ti = (s + 0.5) * dt;
     const ri = Math.sqrt(r * r + ti * ti + 2 * r * ti * mu);
@@ -221,10 +225,11 @@ const sky = (i, j) => {
     const muSi = Math.min(Math.max((r * sunMu + ti * cSun) / ri, -1), 1);
     const Ts = sunT(ri, muSi);
     const psi = psiMS(ri, muSi);
+    const x = chi ? chi(ti) : 1;
     for (let c = 0; c < 3; c++) {
-      const S =
-        (sR[c] * phaseR(cSun) + sM[c] * phaseM(cSun)) * Ts[c] +
-        (sR[c] + sM[c]) * psi[c];
+      const dir = (sR[c] * phaseR(cSun) + sM[c] * phaseM(cSun)) * Ts[c];
+      const amb = (sR[c] + sM[c]) * psi[c];
+      const S = mode === 'nodirect' ? amb : dir * x + amb;
       const st = Math.exp(-e[c] * dt);
       L[c] += (T[c] * (S - S * st)) / Math.max(e[c], 1e-9);
       T[c] *= st;
@@ -232,6 +237,8 @@ const sky = (i, j) => {
   }
   return L;
 };
+const sky = (i, j, chi, mode) =>
+  skyAt(((i + 0.5) / SW - 0.5) * 2 * Math.PI, j, chi, mode);
 
 const fmt = (a) => a.map((v) => v.toExponential(4)).join();
 console.log('REF ms(16,8):', fmt(bilinearAt(16, 8)));
@@ -240,14 +247,88 @@ function bilinearAt(i, j) {
 }
 console.log('REF ms(20,0):', fmt(bilinearAt(20, 0)));
 console.log('REF ms(28,16):', fmt(bilinearAt(28, 16)));
-console.log('REF sky(30,80):', fmt(sky(30, 80)));
-console.log('REF sky(96,60):', fmt(sky(96, 60)));
-console.log('REF sky(5,90):', fmt(sky(5, 90)));
-console.log('REF sky(30,20):', fmt(sky(30, 20)));
+
+{
+  // Full-circle back-compat: the new signed mapping at the old
+  // half-circle pins. i_new = 192 + i_old lands on the SAME
+  // physical azimuth ((i_old + 0.5)/192 * pi), so the six pinned
+  // texels must reproduce the old-mapping march (recomputed here
+  // with the old arithmetic) to fp; and the unshadowed sky is
+  // even in azimuth, so the mirror texel i = 191 - i_old must
+  // match too - a broken signed mapping shows up immediately.
+  let worst = 0;
+  for (const [io, j] of [
+    [30, 80],
+    [96, 60],
+    [5, 90],
+    [30, 20],
+    [30, 53],
+    [30, 54]
+  ]) {
+    const neu = sky(192 + io, j);
+    const old = skyAt(((io + 0.5) / 192) * Math.PI, j);
+    const mir = sky(191 - io, j);
+    for (let c = 0; c < 3; c++)
+      worst = Math.max(
+        worst,
+        Math.abs(neu[c] / old[c] - 1),
+        Math.abs(mir[c] / neu[c] - 1)
+      );
+  }
+  const ok = worst < 1e-12;
+  console.log(
+    `${ok ? 'REF' : 'FAIL'} sky full circle: signed-azimuth texels reproduce the half-circle pins and their mirrors to ${worst.toExponential(1)} (6 texels x 3 channels)`
+  );
+  if (!ok) process.exit(1);
+}
+
+{
+  // The sky march carries the same volumetric shadow as the
+  // aerial one: chi=1 IS the unshadowed march (exact) and chi=0
+  // IS the ambient-only march - on a sky texel near the horizon
+  // where the direct term dominates.
+  const one = sky(222, 56, () => 1);
+  const un = sky(222, 56);
+  const dark = sky(222, 56, () => 0);
+  const amb = sky(222, 56, null, 'nodirect');
+  const ok =
+    one.every((v, c) => v === un[c]) && dark.every((v, c) => v === amb[c]);
+  console.log(
+    `${ok ? 'REF' : 'FAIL'} sky shadow bounds: chi=1 IS the unshadowed march and chi=0 IS the ambient-only march (exact) - the dome's beams are the direct term`
+  );
+  if (!ok) process.exit(1);
+}
+
+{
+  // The kernel's altitude-datum mapping for shadow samples is the
+  // THEME's exact asinh compression (roam.js yOfElev, gated
+  // there): 16 * asinh((h - elev0)/500) - one datum, one model.
+  let worst = 0;
+  for (const [h, e0] of [
+    [300, 0],
+    [1720, 1034],
+    [8000, 46],
+    [0, 300]
+  ])
+    worst = Math.max(
+      worst,
+      Math.abs(16 * Math.asinh((h - e0) / 500) - yOfElev(h, e0))
+    );
+  const ok = worst === 0;
+  console.log(
+    `${ok ? 'REF' : 'FAIL'} shadow altitude datum: the march's y formula IS roam.yOfElev (identity at 4 altitudes)`
+  );
+  if (!ok) process.exit(1);
+}
+
+console.log('REF sky(222,80):', fmt(sky(222, 80)));
+console.log('REF sky(288,60):', fmt(sky(288, 60)));
+console.log('REF sky(197,90):', fmt(sky(197, 90)));
+console.log('REF sky(222,20):', fmt(sky(222, 20)));
 // The guard rows either side of the horizon seam: the one-sided
 // limits (below: ground at the tangent distance; above: full path).
-console.log('REF sky(30,53):', fmt(sky(30, 53)));
-console.log('REF sky(30,54):', fmt(sky(30, 54)));
+console.log('REF sky(222,53):', fmt(sky(222, 53)));
+console.log('REF sky(222,54):', fmt(sky(222, 54)));
 
 // ---- aerial march with volumetric shadow (crepuscular rays) ----
 // Mirrors atmosphere-tsl's marchAerial20: a horizontal 20-step

--- a/themes/horizon/atmosphere-tsl.js
+++ b/themes/horizon/atmosphere-tsl.js
@@ -18,6 +18,8 @@ import {
   If,
   Loop,
   abs,
+  asinh,
+  atan,
   clamp,
   cos,
   dot,
@@ -52,17 +54,19 @@ import {
  *  - transmittance LUT 256x64, built once (40-step optical depth)
  *  - multiple-scattering LUT 32x32: 64 spherical-Fibonacci directions,
  *    20-step marches, ground bounce, Psi_ms = L2 / (1 - f_ms)
- *  - sky-view LUT 192x108 per frame (32 steps, sqrt-warped elevation
- *    split at the true horizon)
+ *  - sky-view LUT 384x108 per frame (32 steps, sqrt-warped elevation
+ *    split at the true horizon; full SIGNED azimuth circle)
  *  - aerial-perspective LUT 128x32 (SIGNED relative azimuth over the
- *    full circle x distance, 20 steps) for the per-material fog
- *    hook, with Hillaire's volumetric shadow: the DIRECT
- *    single-scatter term is multiplied per step by the cloud shadow
- *    map's Beer-Lambert transmittance at the marched point
- *    (crepuscular rays; multiple scattering stays unshadowed). The
- *    full circle exists BECAUSE of the shadow - clouds are not
- *    azimuthally symmetric; the seam sits at the anti-sun azimuth
- *    where in-scatter varies slowest.
+ *    full circle x distance, 20 steps) for the per-material fog hook
+ *  - BOTH per-frame marches carry Hillaire's volumetric shadow: the
+ *    DIRECT single-scatter term is multiplied per step by the cloud
+ *    shadow map's Beer-Lambert transmittance at the marched point
+ *    (crepuscular rays in the sky AND in the terrain haze; multiple
+ *    scattering stays unshadowed). The full circles exist BECAUSE
+ *    of the shadow - clouds are not azimuthally symmetric; the
+ *    seams sit at the anti-sun azimuth where in-scatter varies
+ *    slowest. Shadow samples map to the scene through the exact
+ *    asinh altitude datum, so rays above the decks read full sun.
  *  - 1x1 cosine-weighted sky irradiance for the hemisphere ambient
  *    (read back asynchronously - no pipeline stall)
  *  - the dome samples the sky-view LUT and adds the sun disc through
@@ -222,7 +226,12 @@ export function createAtmosphereTSL(renderer, cloudShadow) {
 
   const tLut = makeLut(256, 64);
   const msLut = makeLut(32, 32);
-  const skyLut = makeLut(192, SKY_H);
+  // Full SIGNED azimuth circle (384 = the old 192 half-circle
+  // texel pitch kept): the volumetric cloud shadow is not
+  // azimuthally symmetric, so the sky-view LUT carries both sides
+  // of the sun line. u = 0.5 faces the sun; the clamp seam sits at
+  // the anti-sun azimuth.
+  const skyLut = makeLut(384, SKY_H);
   const aerialLut = makeLut(128, 32);
   // The irradiance readback needs a RenderTarget on both backends
   // (readRenderTargetPixelsAsync is the async staging read); it is a
@@ -346,17 +355,38 @@ export function createAtmosphereTSL(renderer, cloudShadow) {
     return vec4(psi, 1.0);
   });
 
-  // Shared single-scattering march used by sky-view and aerial (step
-  // count is a compile-time constant, hence the factory).
-  const makeMarchSky = (steps) =>
-    Fn(([r, dir, dEnd]) => {
+  // ---------- shared march with volumetric shadow ----------
+  // ONE single-scattering march serves the sky-view and aerial LUTs
+  // (step count is the compile-time constant): a ray from camera
+  // height at SIGNED azimuth az from the sun and elevation
+  // (se, ce), where chi(t) - the cloud shadow map's Beer-Lambert
+  // transmittance at the marched point - multiplies the DIRECT
+  // single-scatter term only (Hillaire 2020's volumetric shadow;
+  // multiple scattering stays unshadowed). The marched point maps
+  // to the scene through the sun-azimuth rotation (roundtrip
+  // gated), the horizontal arc ti*ce (curvature over the 16 km
+  // shadow range is metres - far under the map texel), and the
+  // theme's exact asinh altitude datum (roam.js yOfElev, gated).
+  // Mirrored in atmo-reference.mjs.
+  const aerialCamXZ = uniform(new Vector2(0, 0));
+  const aerialSunAz = uniform(new Vector2(1, 0));
+  const shadowElev0 = uniform(0); // the box's elevation datum (m)
+  const makeMarch = (steps) =>
+    Fn(([r, az, se, ce, dEnd]) => {
       const dt = dEnd.div(steps);
       const T = vec3(1).toVar();
       const L = vec3(0).toVar();
-      const mu = dir.y;
+      const mu = se;
       const sunS = sqrt(max(sunMu.mul(sunMu).oneMinus(), 0.0));
-      const sunDir = vec3(sunS, sunMu, 0.0);
-      const cSun = dot(dir, sunDir);
+      const cSun = ce.mul(cos(az)).mul(sunS).add(se.mul(sunMu));
+      // Scene-plane direction of this azimuth: the sun's azimuth
+      // vector rotated by az (counterclockwise in the xz basis -
+      // the same convention aerial-tsl's atan(cross, dot) reads
+      // back; roundtrip gated).
+      const sceneDir = vec2(
+        aerialSunAz.x.mul(cos(az)).sub(aerialSunAz.y.mul(sin(az))),
+        aerialSunAz.x.mul(sin(az)).add(aerialSunAz.y.mul(cos(az)))
+      );
       Loop(steps, ({i: s}) => {
         const ti = float(s).add(0.5).mul(dt);
         const ri = sqrt(
@@ -369,10 +399,24 @@ export function createAtmosphereTSL(renderer, cloudShadow) {
         const ext = extinction(h);
         const muSi = clamp(r.mul(sunMu).add(ti.mul(cSun)).div(ri), -1.0, 1.0);
         const Ts = sunT(ri, muSi);
+        // chi: sun visibility through the cloud decks at the
+        // marched point - scene xz from the horizontal arc, scene
+        // y from the altitude datum (a ray above the decks reads
+        // full sun; the hook's mid-plane projection handles any y).
+        const chi = cloudShadow
+          ? (() => {
+              const p = aerialCamXZ.add(
+                sceneDir.mul(ti.mul(ce).mul(SCENE_PER_M))
+              );
+              const y = asinh(h.sub(shadowElev0).div(500)).mul(16);
+              return cloudShadow.transmittance(vec3(p.x, y, p.y));
+            })()
+          : float(1);
         const S = scatR
           .mul(phaseR(cSun))
           .add(scatM.mul(phaseM(cSun)))
           .mul(Ts)
+          .mul(chi)
           .add(scatR.add(scatM).mul(psiMS(ri, muSi)));
         const stepT = exp(ext.mul(dt).negate());
         L.addAssign(T.mul(S.sub(S.mul(stepT))).div(max(ext, vec3(1e-9))));
@@ -380,62 +424,8 @@ export function createAtmosphereTSL(renderer, cloudShadow) {
       });
       return vec4(L, dot(T, vec3(1 / 3, 1 / 3, 1 / 3)));
     });
-  const marchSky32 = makeMarchSky(32);
-
-  // ---------- aerial march with volumetric shadow ----------
-  // The horizontal march at camera height along the SIGNED azimuth
-  // from the sun: identical physics to makeMarchSky with dir.y = 0,
-  // plus chi(t) - the cloud shadow map's Beer-Lambert transmittance
-  // at the marched point - on the DIRECT single-scatter term only
-  // (Hillaire 2020's aerial perspective with volumetric shadow;
-  // multiple scattering stays unshadowed). Mirrored and gated in
-  // atmo-reference.mjs.
-  const aerialCamXZ = uniform(new Vector2(0, 0));
-  const aerialSunAz = uniform(new Vector2(1, 0));
-  const marchAerial20 = Fn(([r, az, dEnd]) => {
-    const steps = 20;
-    const dt = dEnd.div(steps);
-    const T = vec3(1).toVar();
-    const L = vec3(0).toVar();
-    const sunS = sqrt(max(sunMu.mul(sunMu).oneMinus(), 0.0));
-    const cSun = cos(az).mul(sunS);
-    // Scene-plane direction of this azimuth: the sun's azimuth
-    // vector rotated by az (counterclockwise in the xz basis - the
-    // same convention aerial-tsl's atan(cross, dot) reads back;
-    // roundtrip gated).
-    const sceneDir = vec2(
-      aerialSunAz.x.mul(cos(az)).sub(aerialSunAz.y.mul(sin(az))),
-      aerialSunAz.x.mul(sin(az)).add(aerialSunAz.y.mul(cos(az)))
-    );
-    Loop(steps, ({i: s}) => {
-      const ti = float(s).add(0.5).mul(dt);
-      const ri = sqrt(r.mul(r).add(ti.mul(ti)));
-      const h = ri.sub(RB);
-      const dens = densities(h);
-      const scatR = rayleighS.mul(dens.x);
-      const scatM = mieScat.mul(dens.y);
-      const ext = extinction(h);
-      const muSi = clamp(r.mul(sunMu).add(ti.mul(cSun)).div(ri), -1.0, 1.0);
-      const Ts = sunT(ri, muSi);
-      // chi: sun visibility through the cloud decks at the marched
-      // point (ground datum - the 2D LUT collapses elevation; the
-      // shafts line up with the terrain's own per-pixel shadow).
-      const p = aerialCamXZ.add(sceneDir.mul(ti.mul(SCENE_PER_M)));
-      const chi = cloudShadow
-        ? cloudShadow.transmittance(vec3(p.x, 0.0, p.y))
-        : float(1);
-      const S = scatR
-        .mul(phaseR(cSun))
-        .add(scatM.mul(phaseM(cSun)))
-        .mul(Ts)
-        .mul(chi)
-        .add(scatR.add(scatM).mul(psiMS(ri, muSi)));
-      const stepT = exp(ext.mul(dt).negate());
-      L.addAssign(T.mul(S.sub(S.mul(stepT))).div(max(ext, vec3(1e-9))));
-      T.mulAssign(stepT);
-    });
-    return vec4(L, dot(T, vec3(1 / 3, 1 / 3, 1 / 3)));
-  });
+  const marchSky32 = makeMarch(32);
+  const marchAerial20 = makeMarch(20);
 
   // Sky-view vertical mapping, Bruneton-style guarded split (phase 4
   // horizon-band fix). Sky radiance is DISCONTINUOUS at the horizon
@@ -493,12 +483,14 @@ export function createAtmosphereTSL(renderer, cloudShadow) {
       .negate();
     const hAngle = horizon.clamp(-1, 1).asin();
     const elev = elevFromSkyV(vUv.y, hAngle);
-    const relAz = vUv.x.mul(3.14159265);
+    // Full-circle SIGNED azimuth: u = 0.5 faces the sun, the seam
+    // (u = 0/1) is the anti-sun azimuth (same convention as the
+    // aerial LUT - the cloud shadow is not azimuthally symmetric).
+    const az = vUv.x.sub(0.5).mul(2.0 * 3.14159265);
     const se = sin(elev);
     const ce = cos(elev);
-    const dir = vec3(ce.mul(cos(relAz)), se, ce.mul(sin(relAz)));
-    const dGround = raySphere(r, dir.y, float(RB));
-    const dTop = raySphere(r, dir.y, float(RT));
+    const dGround = raySphere(r, se, float(RB));
+    const dTop = raySphere(r, se, float(RT));
     // Ray class by texture half; the tangent distance is the exact
     // disc==0 fallback for the below-boundary row.
     const dTangent = sqrt(max(r.mul(r).sub(RB * RB), 0.0));
@@ -510,17 +502,18 @@ export function createAtmosphereTSL(renderer, cloudShadow) {
       ),
       0.0
     );
-    return marchSky32(r, dir, dEnd);
+    return marchSky32(r, az, se, ce, dEnd);
   });
 
   // ---------- aerial perspective (per frame) ----------
   const aerialNode = Fn(([vUv]) => {
     // Full-circle SIGNED azimuth: u = 0.5 faces the sun, the seam
-    // (u = 0/1) is the anti-sun azimuth.
+    // (u = 0/1) is the anti-sun azimuth. A horizontal ray:
+    // se = 0, ce = 1.
     const az = vUv.x.sub(0.5).mul(2.0 * 3.14159265);
     const dist = vUv.y.mul(MAX_DIST_M);
     const r = float(RB).add(max(camH, 1.0));
-    return marchAerial20(r, az, dist);
+    return marchAerial20(r, az, float(0), float(1), dist);
   });
 
   // ---------- cosine-weighted sky irradiance (per frame, 1x1) ----------
@@ -543,6 +536,9 @@ export function createAtmosphereTSL(renderer, cloudShadow) {
       // cos(theta_zenith) = sin(elev); d-omega = cos(elev) d-elev d-az
       const w = sin(elev).mul(cos(elev)).toVar();
       Loop(8, ({i: ia}) => {
+        // ax spans the FULL signed circle now (u = 0.5 faces the
+        // sun) - the mean over 8 azimuths is the same integral,
+        // and the shadowed sky darkens the ambient correctly.
         const ax = float(ia)
           .add(0.5)
           .mul(1 / 8);
@@ -564,8 +560,11 @@ export function createAtmosphereTSL(renderer, cloudShadow) {
     const elev = v.y.clamp(-1, 1).asin();
     const sunH = normalize(sunDirW.xz.add(vec2(1e-6, 1e-6)));
     const vH = normalize(v.xz.add(vec2(1e-6, 1e-6)));
-    const relAz = dot(sunH, vH).clamp(-1, 1).acos();
-    const ux = relAz.div(3.14159265);
+    // SIGNED azimuth over the full circle - atan(cross, dot), the
+    // same convention the LUT fill rotates by (roundtrip gated).
+    const ux = atan(sunH.x.mul(vH.y).sub(sunH.y.mul(vH.x)), dot(sunH, vH))
+      .div(2.0 * 3.14159265)
+      .add(0.5);
     // The horizon is a true radiance discontinuity (the guarded LUT
     // split stores its one-sided limits in the two seam rows). A
     // pixel straddling it should show the box-filter integral of
@@ -698,10 +697,11 @@ export function createAtmosphereTSL(renderer, cloudShadow) {
     // Exact metres-per-scene-unit (roam.js MPU = 16000/280): the
     // old 57.14 literal was 50 ppm off the mapping's own constant.
     aerialMaxUnits: MAX_DIST_M / (400 / 7),
-    // Crepuscular rays: the aerial march needs the camera's scene
-    // position and the sun's azimuth vector to place its shadow
-    // samples (set per frame next to the fog hook's uSunAzV).
-    aerialShadow: {camXZ: aerialCamXZ, sunAz: aerialSunAz},
+    // Crepuscular rays: the shadowed marches need the camera's
+    // scene position, the sun's azimuth vector and the box's
+    // elevation datum to place their shadow samples (set per frame
+    // next to the fog hook's uSunAzV).
+    aerialShadow: {camXZ: aerialCamXZ, sunAz: aerialSunAz, elev0: shadowElev0},
     // Refraction of the drawn disc: per-channel apparent
     // directions + vertical flattening (set from refraction.js).
     sunDisc: {dirR: sunDirR, dirB: sunDirB, flatten: sunFlat},


### PR DESCRIPTION
Phase 1 put the beams in the terrain haze; this puts them in the **sky** — the sky-view march now carries the same Hillaire volumetric shadow as the aerial one, so crepuscular rays fan across the dome from cloud gaps.

- **One march factory serves both LUTs** — the aerial march turned out to be the sky march's special case (se=0, ce=1), so the unification deletes code rather than forking it. The shared math was already gated by phase 1's landmarks.
- **Sky-view LUT goes 192×108 half-circle → 384×108 full signed circle** (old texel pitch kept; seam at the anti-sun azimuth). The dome reads the signed angle via the gated `atan(cross, dot)`; the hemisphere-irradiance integral's azimuth samples now span the full circle, so a shadowed sky correctly darkens the ambient light too.
- **Height-aware shadow samples everywhere**: scene y through the theme's exact asinh altitude datum, with an identity landmark against `roam.yOfElev` — one datum, one model. Rays above the decks read full sun; a camera flying over the clouds sees no ground shafts. This supersedes phase 1's ground-datum sampling for the aerial march as well.

**Landmarks** (atmo set 16 → 19 lines): the six old half-circle sky pins *and their mirrors* reproduce under the new mapping to 2.2e-16 — the remap provably changes nothing for a symmetric sky (REF pins re-indexed 192+i with values identical to the digit); sky shadow bounds (χ=1 **is** the unshadowed march, χ=0 **is** the ambient-only march, exact); the altitude-datum identity.

Cost: fillSky doubles its texels (384 wide), still per-frame comfortable on real GPUs. Browser smoke with the cloud system active: kernels compile, frame loop alive, no new shader errors. Full `validate.sh`: 41 sets PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKKBen9kkD562HDVr7cXAx

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKKBen9kkD562HDVr7cXAx)_