### PR TITLE
Measured vessels + lamp light sources (owner feedback round)

### DIFF
--- a/themes/Horizon.html
+++ b/themes/Horizon.html
@@ -288,10 +288,11 @@
         aisToScene,
         apparentLux,
         lightArcs,
+        lightPlan,
         luminousIntensity,
-        RANGE_NM,
         relBearing,
-        SUNSET_ELEV
+        SUNSET_ELEV,
+        typeClass
       } from './horizon/ships.js';
       import {
         apparentFlash,
@@ -348,12 +349,18 @@
         TAU_MIN
       } from './horizon/aerosol.js';
       import {
+        LAMP_FULL,
         LAMP_TINT,
+        lampCandidates,
         NL_LAYER,
         NL_Z,
         lightsField,
         pixelOf
       } from './horizon/nightlights.js';
+      import {
+        attribute as tslAttribute,
+        uniform as tslUniform
+      } from 'three/tsl';
       import {lineStrengths} from './horizon/airglow.js';
       import {fR, ZL_OMEGA} from './horizon/zodiacal.js';
       import {
@@ -1554,6 +1561,9 @@
           NL_LAYER +
           '/default/{d}/GoogleMapsCompatible_Level8/{z}/{r}/{c}.png';
       let lightsSeq = 0;
+      let lampPts = null;
+      let lampMat = null;
+      let lampNightU = null;
       async function syncLights() {
         if (params.get('lights') === '0' || !terrainObj) return;
         const seq = ++lightsSeq; // a roam hop restarts the fetch
@@ -1607,14 +1617,14 @@
             cx.drawImage(img, 0, 0);
             px.set(k, cx.getImageData(0, 0, 256, 256).data);
           }
-          const sample = (ix, iy) => {
+          const pxAt = (ix, iy) => {
             const d = px.get(Math.floor(iy / 256) + '/' + Math.floor(ix / 256));
             if (!d) return null;
             const o = ((iy & 255) * 256 + (ix & 255)) * 4;
             return [d[o], d[o + 1], d[o + 2], d[o + 3]];
           };
           const N = 96;
-          const f = lightsField(sample, anchor, WORLD, N);
+          const f = lightsField(pxAt, anchor, WORLD, N);
           const tex = new THREE.DataTexture(
             f.data,
             N,
@@ -1628,16 +1638,74 @@
           terrainObj.lightsTexNode.value = tex;
           if (old && old.image && old.image.width > 1) old.dispose();
           terrainUniforms.uLightsOn.value = 1;
+          // The SOURCES, not just the glow: Earth-anchored lamp
+          // points (nightlights.js, gated - roam's shared hash on
+          // geodetic cells, density linear in measured radiance),
+          // dropped onto the terrain surface, never on water.
+          const radAtGeo = (lat, lon) => {
+            const s = geoToScene(lat, lon, anchor);
+            const gi = Math.round((s.x / WORLD + 0.5) * N - 0.5);
+            const gj = Math.round((0.5 - s.z / WORLD) * N - 0.5);
+            return gi < 0 || gi >= N || gj < 0 || gj >= N
+              ? 0
+              : f.data[gj * N + gi];
+          };
+          const lamps = lampCandidates(radAtGeo, anchor, WORLD).filter(
+            (L) => !sample(L.x, L.z).water
+          );
+          const pos = new Float32Array(lamps.length * 3);
+          const col = new Float32Array(lamps.length * 3);
+          lamps.forEach((L, k) => {
+            pos[3 * k] = L.x;
+            pos[3 * k + 1] = sample(L.x, L.z).y + 0.12;
+            pos[3 * k + 2] = L.z;
+            // Brightness follows the measured radiance (sqrt for
+            // the eye's crushed response to point sources).
+            const b = 0.35 + 0.65 * Math.sqrt(Math.min(L.rad / LAMP_FULL, 1));
+            col[3 * k] = LAMP_TINT[0] * b;
+            col[3 * k + 1] = LAMP_TINT[1] * b;
+            col[3 * k + 2] = LAMP_TINT[2] * b;
+          });
+          const lg = new THREE.BufferGeometry();
+          lg.setAttribute('position', new THREE.BufferAttribute(pos, 3));
+          lg.setAttribute('color', new THREE.BufferAttribute(col, 3));
+          if (!lampMat) {
+            // Additive warm points through the shared AgX + fog
+            // encode - lamps dim with distance haze like every
+            // other emitter; at day the night gate multiplies them
+            // to black, which adds nothing.
+            lampNightU = tslUniform(0);
+            lampMat = new THREE.PointsNodeMaterial({
+              transparent: true,
+              depthWrite: false,
+              blending: THREE.AdditiveBlending
+            });
+            lampMat.size = 2.2;
+            lampMat.sizeAttenuation = false;
+            lampMat.colorNode = aerial.encodeFog(
+              tslAttribute('color').mul(lampNightU)
+            );
+          }
+          if (lampPts) {
+            scene.remove(lampPts);
+            lampPts.geometry.dispose();
+          }
+          lampPts = new THREE.Points(lg, lampMat);
+          lampPts.frustumCulled = false;
+          scene.add(lampPts);
           record(
             'VIIRS Black Marble ' + day,
             'max ' +
               f.max.toFixed(1) +
               ' · mean ' +
               f.mean.toFixed(2) +
-              ' nW/cm²/sr over the box'
+              ' nW/cm²/sr · ' +
+              lamps.length +
+              ' lamps'
           );
-        } catch {
+        } catch (e) {
           // The ground stays dark - the truthful default.
+          if (params.has('debug')) console.warn('lights: ' + e.message);
         }
       }
 
@@ -2899,68 +2967,211 @@
       // Annex I candela through Allard's law - beyond a light's
       // rated range the eye receives less than the adopted 2e-7
       // lux threshold and the light goes out, exactly as the
-      // regulation is constructed). The hull itself is display
-      // furniture (reports carry no dimensions - a 90 m default);
-      // the lights and kinematics are the physics. ?ais=URL
-      // overrides the proxy; ?ship=N spawns N deterministic
-      // synthetic vessels for the offline harness.
+      // regulation is constructed). The hulls are MEASURED too:
+      // the daemon merges AIS message 5 (real length/beam from
+      // the A/B/C/D antenna offsets, M.1371 type, draught), the
+      // silhouette follows the type class and the light plan
+      // follows the dimensions (Rule 23's second masthead at
+      // >= 50 m, Rule 25(b)'s no-masthead sailing rig, Annex I
+      // heights - ships.js, gated). ?ais=URL overrides the proxy;
+      // ?ship=N spawns N deterministic vessels (one per class)
+      // for the offline harness.
       const AIS_PROXY = params.get('ais') ?? 'https://api.ndev.tk/ais';
       const SHIP_N = 8;
-      const SHIP_LOA = 90 / MPU; // scene units (90 m)
       const NAV_COLOR = {
         masthead: '#ffffff',
         stern: '#ffffff',
         port: '#ff2418',
         starboard: '#19e34d'
       };
-      const NAV_RANGE = {
-        masthead: 'masthead',
-        stern: 'stern',
-        port: 'side',
-        starboard: 'side'
-      };
       const shipPool = [];
+      const shipMats = {};
+      const dotGeo = new THREE.SphereGeometry(0.085, 8, 6);
       {
-        const hullGeo = new THREE.BoxGeometry(0.25, 0.14, SHIP_LOA);
-        const supGeo = new THREE.BoxGeometry(0.21, 0.21, 0.32);
-        const dotGeo = new THREE.SphereGeometry(0.085, 8, 6);
-        const hullMat = new THREE.MeshStandardNodeMaterial({
-          color: '#252b30',
-          roughness: 0.9
-        });
-        const supMat = new THREE.MeshStandardNodeMaterial({
-          color: '#77828c',
-          roughness: 0.9
-        });
-        applyAerial(hullMat);
-        applyAerial(supMat);
+        const mk = (color) => {
+          const m = new THREE.MeshStandardNodeMaterial({
+            color,
+            roughness: 0.9
+          });
+          applyAerial(m);
+          return m;
+        };
+        shipMats.hullA = mk('#252b30');
+        shipMats.hullB = mk('#4a2320'); // oxide red, the other paint
+        shipMats.sup = mk('#77828c');
+        shipMats.white = mk('#c9cdd2'); // passenger superstructure
+        shipMats.deck = mk('#5c6066'); // hatches / trunk / gantries
+      }
+      // Build one vessel from its MEASURED identity: AIS message 5
+      // length/beam scale the hull exactly, the M.1371 type picks
+      // the silhouette, and the COLREGS light plan (ships.js,
+      // gated) places the lights - two mastheads on >= 50 m power
+      // vessels (Rule 23), none on sailing vessels (Rule 25(b)),
+      // Annex I heights/separations from the real dimensions.
+      // Without a static report yet: a 90 x 14 m 'other'.
+      function buildShip(slot, lenM, beamM, cls) {
+        const key = cls + '/' + lenM + '/' + beamM + '/' + (slot.mmsi % 2);
+        if (slot.dims === key) return;
+        slot.dims = key;
+        for (const c of [...slot.g.children]) {
+          slot.g.remove(c);
+          if (c.geometry && c.geometry !== dotGeo) c.geometry.dispose();
+          if (c.userData.dotMat) c.material.dispose();
+        }
+        const U = 1 / MPU; // metres -> scene units
+        const L = lenM * U;
+        const B = Math.max(beamM, 3) * U;
+        const hM = (m) => m * U;
+        const box = (w, h, len, mat, x, y, z) => {
+          const m = new THREE.Mesh(new THREE.BoxGeometry(w, h, len), mat);
+          m.position.set(x, y, z);
+          slot.g.add(m);
+          return m;
+        };
+        // Above-water hull: freeboard scales with length.
+        const hullH = hM(Math.min(Math.max(0.045 * lenM, 1.5), 12));
+        box(
+          B,
+          hullH,
+          L,
+          slot.mmsi % 2 ? shipMats.hullB : shipMats.hullA,
+          0,
+          hullH * 0.35,
+          0
+        );
+        const deckY = hullH * 0.85;
+        if (cls === 'cargo' || cls === 'hsc') {
+          const hH = hM(Math.min(Math.max(0.1 * lenM, 5), 25));
+          box(B * 0.9, hH, L * 0.12, shipMats.sup, 0, deckY + hH / 2, L * 0.36);
+          const bH = hM(Math.min(Math.max(0.06 * lenM, 2.5), 14));
+          for (const zc of [-0.3, -0.08, 0.14])
+            box(
+              B * 0.82,
+              bH,
+              L * 0.18,
+              shipMats.deck,
+              0,
+              deckY + bH / 2,
+              L * zc
+            );
+        } else if (cls === 'tanker') {
+          const hH = hM(Math.min(Math.max(0.09 * lenM, 5), 22));
+          box(B * 0.9, hH, L * 0.12, shipMats.sup, 0, deckY + hH / 2, L * 0.36);
+          box(
+            B * 0.45,
+            hM(2),
+            L * 0.6,
+            shipMats.deck,
+            0,
+            deckY + hM(1),
+            -L * 0.05
+          );
+          box(B * 0.6, hM(4), L * 0.05, shipMats.deck, 0, deckY + hM(2), 0);
+        } else if (cls === 'passenger') {
+          const hH = hM(Math.min(Math.max(0.13 * lenM, 6), 32));
+          box(
+            B * 0.86,
+            hH,
+            L * 0.68,
+            shipMats.white,
+            0,
+            deckY + hH / 2,
+            L * 0.02
+          );
+          box(
+            B * 0.6,
+            hH * 0.4,
+            L * 0.3,
+            shipMats.white,
+            0,
+            deckY + hH * 1.2,
+            0
+          );
+        } else if (cls === 'fishing') {
+          box(
+            B * 0.8,
+            hM(4),
+            L * 0.22,
+            shipMats.sup,
+            0,
+            deckY + hM(2),
+            -L * 0.18
+          );
+          box(
+            B * 0.12,
+            hM(6),
+            B * 0.12,
+            shipMats.deck,
+            0,
+            deckY + hM(3),
+            L * 0.3
+          );
+        } else if (cls === 'sailing') {
+          box(
+            B * 0.1,
+            hM(1.3 * lenM),
+            B * 0.1,
+            shipMats.deck,
+            0,
+            deckY + hM(0.65 * lenM),
+            -L * 0.1
+          );
+        } else {
+          const hH = hM(Math.min(Math.max(0.09 * lenM, 3), 12));
+          box(B * 0.75, hH, L * 0.3, shipMats.sup, 0, deckY + hH / 2, L * 0.15);
+        }
+        // COLREGS lights from the measured plan (metres -> units).
+        const plan = lightPlan(lenM, beamM, cls);
+        slot.lightList = [];
+        const addDot = (arc, range, x, y, z) => {
+          const mat = new THREE.MeshBasicNodeMaterial({color: NAV_COLOR[arc]});
+          aerial.applyTone(mat);
+          const dot = new THREE.Mesh(dotGeo, mat);
+          dot.userData.dotMat = true;
+          dot.position.set(x, y, z);
+          dot.visible = false;
+          slot.g.add(dot);
+          slot.lightList.push({arc, range, dot});
+        };
+        for (const mh of plan.mastheads)
+          addDot(
+            'masthead',
+            plan.ranges.masthead,
+            0,
+            deckY + hM(mh.y),
+            hM(mh.z)
+          );
+        addDot(
+          'port',
+          plan.ranges.side,
+          -B / 2,
+          deckY + hM(plan.sideY),
+          -L * 0.1
+        );
+        addDot(
+          'starboard',
+          plan.ranges.side,
+          B / 2,
+          deckY + hM(plan.sideY),
+          -L * 0.1
+        );
+        addDot(
+          'stern',
+          plan.ranges.stern,
+          0,
+          deckY + hM(plan.sternY),
+          L * 0.49
+        );
+      }
+      {
         for (let i = 0; i < SHIP_N; i++) {
           const g = new THREE.Group(); // bow points local -z
-          const hull = new THREE.Mesh(hullGeo, hullMat);
-          hull.position.y = 0.05;
-          const sup = new THREE.Mesh(supGeo, supMat);
-          sup.position.set(0, 0.2, SHIP_LOA * 0.32); // aft house
-          g.add(hull, sup);
-          const lights = {};
-          for (const [k, px, py, pz] of [
-            ['masthead', 0, 0.42, -SHIP_LOA * 0.2],
-            ['port', -0.15, 0.2, -SHIP_LOA * 0.1],
-            ['starboard', 0.15, 0.2, -SHIP_LOA * 0.1],
-            ['stern', 0, 0.18, SHIP_LOA * 0.49]
-          ]) {
-            const m = new THREE.MeshBasicNodeMaterial({color: NAV_COLOR[k]});
-            aerial.applyTone(m);
-            const dot = new THREE.Mesh(dotGeo, m);
-            dot.position.set(px, py, pz);
-            dot.visible = false;
-            lights[k] = dot;
-            g.add(dot);
-          }
           g.visible = false;
           scene.add(g);
           shipPool.push({
             g,
-            lights,
+            lightList: [],
+            dims: '',
             mmsi: null,
             name: '',
             x: 0,
@@ -2974,7 +3185,11 @@
         }
         record(
           'COLREGS navigation lights',
-          'Rule 21 arcs · Annex I candela · Allard visibility'
+          'Rule 21 arcs · Rule 23/25 by measured length · Annex I heights · Allard visibility'
+        );
+        record(
+          'Measured vessels',
+          'AIS message 5 · real length/beam hulls · M.1371 type silhouettes'
         );
       }
       const shipOv = params.has('ship') ? +params.get('ship') : null;
@@ -2989,6 +3204,18 @@
           shipCamDir.normalize();
           const px = -shipCamDir.z;
           const pz = shipCamDir.x;
+          // One of each silhouette class, measured-sized: the
+          // harness fleet exercises every hull the types produce.
+          const FLEET = [
+            [70, 240, 32], // cargo
+            [80, 180, 28], // tanker
+            [60, 140, 22], // passenger
+            [30, 24, 7], // fishing
+            [36, 14, 4], // sailing
+            [52, 30, 10], // tug
+            [0, 90, 14], // unknown -> other
+            [71, 160, 24] // cargo again, odd mmsi paint
+          ];
           for (let i = 0; i < Math.min(shipOv, SHIP_N); i++) {
             const s = shipPool[i];
             const ahead = 55 + i * 20;
@@ -3002,6 +3229,8 @@
               seen: Date.now(),
               active: true
             });
+            const [ft, fl, fb] = FLEET[i % FLEET.length];
+            buildShip(s, fl, fb, typeClass(ft));
             const tr = s.hdg * RAD;
             const sp = (12 * 0.514444) / MPU; // 12 kt
             s.vx = sp * Math.sin(tr);
@@ -3059,8 +3288,24 @@
             seen: now_,
             active: true
           });
+          // The measured vessel: message-5 dimensions scale the
+          // hull; the type picks the silhouette. Before a static
+          // report arrives the defaults are class-sized.
+          const cls = ship.type ? typeClass(ship.type) : 'other';
+          const small = cls === 'sailing' || cls === 'pleasure';
+          buildShip(
+            slot,
+            ship.len || (small ? 12 : 90),
+            ship.beam || (small ? 4 : 14),
+            cls
+          );
           names.push(
-            (ship.name || ship.mmsi) + ' ' + Math.round(ship.sog) + ' kt'
+            (ship.name || ship.mmsi) +
+              (ship.len ? ' ' + ship.len + 'm' : '') +
+              (ship.type ? ' ' + typeClass(ship.type) : '') +
+              ' ' +
+              Math.round(ship.sog) +
+              ' kt'
           );
         }
         for (const s of shipPool)
@@ -4362,6 +4607,13 @@
         syncMetar();
         syncSmoke();
         syncAerosol();
+        // The lamp cloud is anchored to the OLD box - drop it now,
+        // syncLights rebuilds it Earth-anchored on the new one.
+        if (lampPts) {
+          scene.remove(lampPts);
+          lampPts.geometry.dispose();
+          lampPts = null;
+        }
         syncLights();
       }
       function maybeRoam(now, moved) {
@@ -5065,16 +5317,15 @@
             const dM =
               Math.hypot(camera.position.x - s.x, camera.position.z - s.z) *
               MPU;
-            for (const k in s.lights) {
-              const dot = s.lights[k];
-              if (!shipLightsOn || !arcs[k]) {
+            // Each light carries ITS OWN Rule 22 range now (from
+            // the measured length via lightPlan) - a 15 m boat's
+            // 3 nm masthead fades sooner than a freighter's 6 nm.
+            for (const {arc, range, dot} of s.lightList) {
+              if (!shipLightsOn || !arcs[arc]) {
                 dot.visible = false;
                 continue;
               }
-              const E = apparentLux(
-                luminousIntensity(RANGE_NM[NAV_RANGE[k]]),
-                Math.max(dM, 30)
-              );
+              const E = apparentLux(luminousIntensity(range), Math.max(dM, 30));
               const amp = THREE.MathUtils.clamp(
                 Math.log10(E / 2e-7) / 2.5,
                 0,
@@ -5083,7 +5334,7 @@
               dot.visible = amp > 0;
               if (dot.visible)
                 dot.material.color
-                  .set(NAV_COLOR[k])
+                  .set(NAV_COLOR[arc])
                   .multiplyScalar(0.4 + 3.6 * amp);
             }
           }
@@ -5292,12 +5543,16 @@
         terrainUniforms.uWindMs.value = state.wind / 3.6;
         // Night lights fade in through civil twilight (streetlights
         // lead the stars); the camera sits under the decks with
-        // them, so no cloud dimming applies.
-        terrainUniforms.uLightsNight.value = THREE.MathUtils.clamp(
+        // them, so no cloud dimming applies. The lamp points share
+        // the gate.
+        const lightsNight = THREE.MathUtils.clamp(
           -(sun.alt / RAD + 0.5) / 5,
           0,
           1
         );
+        terrainUniforms.uLightsNight.value = lightsNight;
+        if (lampNightU) lampNightU.value = lightsNight;
+        if (lampPts) lampPts.visible = lightsNight > 0;
         terrainUniforms.uWindVec.value.set(windV.x, windV.z);
         terrainUniforms.uSunDirW.value.copy(sunVec);
         terrainUniforms.uSunCol.value

--- a/themes/horizon/WEBGPU-PLAN.md
+++ b/themes/horizon/WEBGPU-PLAN.md
@@ -2320,6 +2320,53 @@ secret put AISSTREAM_KEY && npx wrangler deploy`.
   single-lit-pixel weight through the Earth-anchor roundtrip; the
   lamp locus vs published CIE coordinates. ?lights=0 disables;
   ?lights=URL overrides the tile endpoint ({d}/{z}/{r}/{c}).
+- DONE: owner feedback round - "boats are generic" and "no light
+  sources" (Jul 9). Two fixes, one PR.
+  MEASURED VESSELS: the hull comment admitted it ("display
+  furniture... reports carry no dimensions") - but AIS message 5
+  carries them; the daemon just never subscribed. Now
+  ShipStaticData joins the aisstream subscription; normalizeStatic
+  (gated) reads the M.1371 type and the REAL dimensions (A+B
+  length, C+D beam from the antenna offsets, draught in metres),
+  a statics table rides the resident picture (6-min repeats,
+  24 h own-clock prune) and query() merges type/len/beam/draught
+  into /ais and the stream events. The theme scales each hull to
+  its measured length/beam, picks the silhouette by type class
+  (cargo hatches, tanker trunk, white passenger decks, fishing
+  wheelhouse+gantry, sailing mast, tug house - typeClass, gated)
+  and rebuilds only when identity changes. The COLREGS lights got
+  EXACTER with real lengths: lightPlan (gated) implements Rule 23
+  (second masthead abaft and higher on >= 50 m power vessels),
+  Rule 25(b) (sailing = NO masthead), Rule 22 in full (ranges by
+  length band - a 15 m boat's masthead is 3 nm, not 6) and
+  Annex I 2(a)/3(a) heights and separations from the measured
+  beam/length; each light now carries its own range through the
+  Allard fade. Landmarks: server set +1 (static merge fixture),
+  ships set +2 (type table; the 240 m/30 m/8 m/sailing plans
+  against the regulation text). The ?ship=N harness fleet is one
+  vessel of each class, measured-sized.
+  LIGHT SOURCES: Black Marble gave the glow; now it gives the
+  LAMPS. nightlights.js lampCandidates seeds Earth-anchored point
+  sources exactly like roam's trees (the shared hash3 - exported
+  - on absolute geodetic cells, cos(lat) acceptance for uniform
+    areal density, hash-sorted display budget), with acceptance
+    LINEAR in the measured radiance (LAMP_FULL 15 nW/(cm^2 sr) =
+    every 120 m cell lit) and none below ~3x the airglow floor.
+    The theme drops them on the terrain surface (never on water -
+    the 500 m data bleeds over shorelines), warm additive points
+    through the shared AgX+fog encode, brightness following
+    measured radiance, gated by the same civil-twilight ramp as
+    the emissive glow, rebuilt on roam re-anchor. Landmark:
+    deterministic twice; every overlap lamp from a second anchor
+    geodetically identical; count matches the areal-density
+    binomial expectation; dark field -> no lamps. Browser smoke
+    with the captured tile served locally through ?lights=: the
+    full pipeline (fetch -> decode -> field -> lamps -> compiled
+    point cloud) runs with the panel recording the lamp count -
+    which also live-verified the previous entry's texture path.
+    (Bug found by the smoke: a local variable named `sample`
+    shadowed the terrain sampler - renamed, and the sync's catch
+    now logs to console under ?debug=1 instead of swallowing.)
 - OPEN (environment, not code) - UPDATE (roam smoke, Jul 7): the
   drift now also manifests as a PER-FRAME uncaught TypeError -
   GPUTexture.createView rejects the `swizzle` field three's

--- a/themes/horizon/nightlights-reference.mjs
+++ b/themes/horizon/nightlights-reference.mjs
@@ -14,7 +14,10 @@
 import {inflateSync} from 'node:zlib';
 import {
   DNB_BINS,
+  LAMP_FULL,
+  LAMP_MIN,
   LAMP_TINT,
+  lampCandidates,
   lightsField,
   pixelOf,
   planckianXY,
@@ -264,6 +267,52 @@ const tile = decodePng(
       t[2] > 0.03 &&
       t[2] < 0.25,
     `Kang locus hits published 2700 K (${x27.toFixed(4)}, ${y27.toFixed(4)}) and 6500 K points to 3e-3; linear tint [1, ${t[1].toFixed(3)}, ${t[2].toFixed(3)}] - warm, red-led, normalised`
+  );
+}
+
+{
+  // The lamps: deterministic, Earth-anchored (roam's shared hash3
+  // on absolute geodetic cells - the same town lights the same
+  // lamps from ANY anchor), density linear in measured radiance.
+  const A = {lat: 46.7, lon: 7.6};
+  const gB = sceneToGeo(60, -40, A);
+  const B = {lat: gB.lat, lon: gB.lon};
+  const flat = () => 7.5; // half of LAMP_FULL everywhere
+  // Uncapped candidate sets: the display budget (cap) is the
+  // theme's - the CANDIDATES are the Earth-anchored model.
+  const l1 = lampCandidates(flat, A, 280, 1e9);
+  const l2 = lampCandidates(flat, A, 280, 1e9);
+  const lB = lampCandidates(flat, B, 280, 1e9);
+  const same =
+    l1.length === l2.length &&
+    l1.every((p, k) => p.lat === l2[k].lat && p.lon === l2[k].lon);
+  // Anchor independence: every lamp of B that geodetically falls
+  // inside A's box must be one of A's lamps, exactly.
+  const setA = new Set(l1.map((p) => p.lat + '/' + p.lon));
+  let missing = 0;
+  let shared = 0;
+  for (const p of lB) {
+    const s = geoToScene(p.lat, p.lon, A);
+    if (Math.abs(s.x) > 139 || Math.abs(s.z) > 139) continue;
+    shared++;
+    if (!setA.has(p.lat + '/' + p.lon)) missing++;
+  }
+  // Density is AREAL: the cos(lat) acceptance exactly compensates
+  // the east-west narrowing of the geodetic cells, so the count
+  // over a (16 km)^2 box is area/cell^2 x rad/LAMP_FULL,
+  // latitude-free. Binomial noise over the iterated (wider)
+  // lattice: n = cells/cos, p = cos x 0.5.
+  const all = l1;
+  const cells = (16000 / 120) ** 2;
+  const expect = cells * (7.5 / LAMP_FULL);
+  const cosA = Math.cos((46.7 * Math.PI) / 180);
+  const sigma = Math.sqrt((cells / cosA) * (cosA * 0.5) * (1 - cosA * 0.5));
+  const densOk = Math.abs(all.length - expect) < 6 * sigma;
+  const dark = lampCandidates(() => LAMP_MIN * 0.9, A, 280);
+  check(
+    'earth-anchored lamps',
+    same && missing === 0 && shared > 500 && densOk && dark.length === 0,
+    `deterministic twice; ${shared} overlap lamps from a second anchor all identical geodetically; count ${all.length} vs expected ${expect.toFixed(0)} (binomial, cos(lat) x rad/${LAMP_FULL}); below ${LAMP_MIN} nW no lamps`
   );
 }
 

--- a/themes/horizon/nightlights.js
+++ b/themes/horizon/nightlights.js
@@ -21,7 +21,7 @@
  * choice, computed (and gated) rather than eyeballed.
  */
 
-import {sceneToGeo} from './roam.js';
+import {geoToScene, hash3, sceneToGeo} from './roam.js';
 
 export const NL_Z = 8; // GoogleMapsCompatible_Level8 (native max)
 export const NL_LAYER =
@@ -340,3 +340,51 @@ export function xyToLinearSrgb(x, y) {
 // choice, stated, not physics).
 export const LAMP_CCT = 2700;
 export const LAMP_TINT = xyToLinearSrgb(...planckianXY(LAMP_CCT));
+
+// ---- individual lamps: the sources, not just the glow ----------
+// The measured radiance says how MUCH light each 500 m cell
+// emits; the lamps make it point sources the eye can resolve.
+// Same Earth-anchored construction as roam's trees: fixed
+// geodetic cells (LAMP_CELL_M of latitude a side, narrowing
+// east-west as cos(lat)), one deterministic candidate per cell
+// (roam.hash3 - the shared avalanche hash), accepted with
+// probability cos(lat) x min(rad / LAMP_FULL, 1), so areal lamp
+// density is UNIFORM per square metre and LINEAR in the measured
+// radiance. The same town lights the same lamps from any anchor.
+export const LAMP_CELL_M = 120;
+export const LAMP_FULL = 15; // nW/(cm^2 sr): every cell lit
+export const LAMP_MIN = 0.35; // below ~3x the airglow floor: none
+
+export function lampCandidates(radAt, anchor, world, cap = 4000) {
+  const M_LAT = 111320;
+  const dCell = LAMP_CELL_M / M_LAT;
+  const half = ((world / 2) * (400 / 7)) / M_LAT;
+  const halfLon =
+    ((world / 2) * (400 / 7)) /
+    Math.max(M_LAT * Math.cos((anchor.lat * Math.PI) / 180), 1e-6);
+  const i0 = Math.floor((anchor.lat - half) / dCell);
+  const i1 = Math.ceil((anchor.lat + half) / dCell);
+  const j0 = Math.floor((anchor.lon - halfLon) / dCell);
+  const j1 = Math.ceil((anchor.lon + halfLon) / dCell);
+  const lim = world / 2 - 1;
+  const out = [];
+  for (let i = i0; i <= i1; i++) {
+    for (let j = j0; j <= j1; j++) {
+      const lat = (i + hash3(i, j, 11)) * dCell;
+      const lon = (j + hash3(i, j, 12)) * dCell;
+      const rad = radAt(lat, lon);
+      if (!(rad >= LAMP_MIN)) continue;
+      const key = hash3(i, j, 10);
+      const p = Math.cos((lat * Math.PI) / 180) * Math.min(rad / LAMP_FULL, 1);
+      if (key >= p) continue;
+      const s = geoToScene(lat, lon, anchor);
+      if (Math.abs(s.x) > lim || Math.abs(s.z) > lim) continue;
+      out.push({x: s.x, z: s.z, lat, lon, rad, key});
+    }
+  }
+  // Sorted by hash before the display budget (same rule as roam's
+  // trees): capping keeps a spatially unbiased, deterministic
+  // subset instead of the box's south-west corner.
+  out.sort((a, b) => a.key - b.key || a.lat - b.lat || a.lon - b.lon);
+  return out.slice(0, cap);
+}

--- a/themes/horizon/roam.js
+++ b/themes/horizon/roam.js
@@ -113,7 +113,9 @@ export const MICRO_M = 400;
 
 // Deterministic integer hash -> [0,1) (the same avalanche family
 // as the theme's mulberry32, applied to a 3D lattice point).
-function hash3(x, y, z) {
+// Exported: nightlights.js seeds its Earth-anchored lamps from
+// the SAME hash, so all deterministic dressing shares one model.
+export function hash3(x, y, z) {
   let a =
     (Math.imul(x | 0, 374761393) ^
       Math.imul(y | 0, 668265263) ^

--- a/themes/horizon/server-reference.mjs
+++ b/themes/horizon/server-reference.mjs
@@ -111,6 +111,43 @@ const FRAME = (mmsi, lat, lon, over = {}) => ({
     `30 nm at 47.3N finds both ships, internals stripped; limit=1 honoured; empty ocean empty; ship at 29.9 of 30 nm north still inside`
   );
 
+  // Static data (message 5): the measured vessel merged into the
+  // query answer - type, length = A+B, beam = C+D, draught in
+  // metres (aisstream decodes it), name filling a blank position
+  // name. A static frame is not a position (returns false).
+  const took = ingest(
+    st,
+    {
+      MessageType: 'ShipStaticData',
+      Message: {
+        ShipStaticData: {
+          UserID: 2,
+          Name: 'EVER GIVEN ',
+          Type: 70,
+          Dimension: {A: 160, B: 80, C: 18, D: 14},
+          MaximumStaticDraught: 13.2
+        }
+      }
+    },
+    t0 + 5
+  );
+  const merged = query(st, 47.5, 9.5, 8).find((s) => s.mmsi === 2);
+  const bare = query(st, 47.3, 9.0, 30).find((s) => s.mmsi === 1);
+  check(
+    'static data merge',
+    took === false &&
+      st.statics.size === 1 &&
+      merged &&
+      merged.type === 70 &&
+      merged.len === 240 &&
+      merged.beam === 32 &&
+      merged.draught === 13.2 &&
+      merged.name === 'DINGHY' &&
+      bare &&
+      !('len' in bare),
+    `message 5 for MMSI 2 -> type 70 cargo, 240 x 32 m draught 13.2 merged into its query row (position name wins); MMSI 1 without statics carries no dimension fields`
+  );
+
   // Prune: ship 1 last heard t0+2, ship 2 at t0+3.
   const n = prune(st, 100, t0 + 103);
   check(

--- a/themes/horizon/server/src/index.mjs
+++ b/themes/horizon/server/src/index.mjs
@@ -111,6 +111,30 @@ export function normalizeShip(meta, p) {
   };
 }
 
+// One AIS static-data report (message 5) -> the measured vessel:
+// ITU-R M.1371 ship type (code table in ships.js) and the REAL
+// dimensions - A/B metres to bow/stern and C/D to port/starboard
+// from the reference point, so length = A+B, beam = C+D (0 =
+// not available). Draught arrives already decoded in metres.
+export function normalizeStatic(s) {
+  const d = s.Dimension || {};
+  const len = (d.A || 0) + (d.B || 0);
+  const beam = (d.C || 0) + (d.D || 0);
+  return {
+    mmsi: s.UserID,
+    name: String(s.Name || '').trim(),
+    type: typeof s.Type === 'number' ? s.Type : 0,
+    len: len > 0 && len < 500 ? len : 0,
+    beam: beam > 0 && beam < 80 ? beam : 0,
+    draught:
+      typeof s.MaximumStaticDraught === 'number' &&
+      s.MaximumStaticDraught > 0 &&
+      s.MaximumStaticDraught < 30
+        ? s.MaximumStaticDraught
+        : 0
+  };
+}
+
 // Centre + radius (nm) -> bounding box: 1 nm of latitude is
 // exactly 1/60 degree; longitude widens by 1/cos(lat), clamped
 // away from the poles.
@@ -138,6 +162,7 @@ const FETCH_MS = 4000;
 export function createAisState() {
   return {
     ships: new Map(), // mmsi -> normalized ship + {gk, t}
+    statics: new Map(), // mmsi -> normalized static data + {t}
     grid: new Map(), // "lat:lon" 1-degree cell -> Set<mmsi>
     frames: 0,
     badFrames: 0, // arrived but failed decode/parse - a nonzero
@@ -170,6 +195,16 @@ export function gridKey(lat, lon) {
 export function ingest(st, m, now = Date.now()) {
   st.frames++;
   st.lastFrame = now;
+  // Static data (message 5): the vessel's MEASURED identity -
+  // type, real length/beam from the A/B/C/D offsets, draught.
+  // Class A transmits it every 6 minutes; latest wins.
+  const sd = m && m.Message && m.Message.ShipStaticData;
+  if (sd && typeof sd.UserID === 'number') {
+    const stat = normalizeStatic(sd);
+    stat.t = now;
+    st.statics.set(stat.mmsi, stat);
+    return false; // not a position - the caller counts positions
+  }
   const p =
     m &&
     m.Message &&
@@ -212,6 +247,10 @@ export function prune(st, maxAgeMs = 20 * 60e3, now = Date.now()) {
       n++;
     }
   }
+  // Statics age out on their own clock (message 5 repeats every
+  // 6 min from Class A; a day of silence means gone for good).
+  for (const [mmsi, s] of st.statics)
+    if (now - s.t > 24 * 3600e3) st.statics.delete(mmsi);
   return n;
 }
 
@@ -231,14 +270,23 @@ export function query(st, lat, lon, dist, limit = 80) {
         const s = st.ships.get(mmsi);
         if (!s) continue;
         if (s.lat < la0 || s.lat > la1 || s.lon < lo0 || s.lon > lo1) continue;
+        // Merge the vessel's measured identity (message 5) when
+        // the picture holds one: type, real length/beam, draught.
+        const sd = st.statics.get(mmsi);
         out.push({
           mmsi: s.mmsi,
-          name: s.name,
+          name: s.name || (sd && sd.name) || '',
           lat: s.lat,
           lon: s.lon,
           sog: s.sog,
           cog: s.cog,
-          hdg: s.hdg
+          hdg: s.hdg,
+          ...(sd && {
+            type: sd.type,
+            len: sd.len,
+            beam: sd.beam,
+            draught: sd.draught
+          })
         });
         if (out.length >= limit) return out;
       }
@@ -497,7 +545,11 @@ function runAisSocket(key, st, log) {
               [90, 180]
             ]
           ],
-          FilterMessageTypes: ['PositionReport', 'StandardClassBPositionReport']
+          FilterMessageTypes: [
+            'PositionReport',
+            'StandardClassBPositionReport',
+            'ShipStaticData'
+          ]
         })
       );
     });
@@ -948,6 +1000,7 @@ function main() {
     if (url.pathname === '/health' || url.pathname === '/probe') {
       const ais = {
         ships: st.ships.size,
+        statics: st.statics.size,
         cells: st.grid.size,
         frames: st.frames,
         badFrames: st.badFrames,

--- a/themes/horizon/ships-reference.mjs
+++ b/themes/horizon/ships-reference.mjs
@@ -18,10 +18,13 @@ import {
   apparentLux,
   KT_MS,
   lightArcs,
+  lightPlan,
   luminousIntensity,
   RANGE_NM,
+  rangesFor,
   relBearing,
-  SUNSET_ELEV
+  SUNSET_ELEV,
+  typeClass
 } from './ships.js';
 import {KT_MS as KT_MS_AIR} from './contrails.js';
 
@@ -151,6 +154,75 @@ const check = (name, ok, detail) => {
     'Rule 20(b) boundary',
     Math.abs(SUNSET_ELEV - -0.8333333333333334) < 1e-12,
     `lights from sunset to sunrise: solar altitude below ${SUNSET_ELEV.toFixed(4)} deg (-50 arcmin: 34' refraction + 16' semidiameter)`
+  );
+}
+
+{
+  // ITU-R M.1371 type codes -> silhouette classes: family by
+  // first digit, specific craft at 30-37 and 52.
+  const ok =
+    typeClass(70) === 'cargo' &&
+    typeClass(79) === 'cargo' &&
+    typeClass(84) === 'tanker' &&
+    typeClass(60) === 'passenger' &&
+    typeClass(30) === 'fishing' &&
+    typeClass(36) === 'sailing' &&
+    typeClass(37) === 'pleasure' &&
+    typeClass(52) === 'tug' &&
+    typeClass(31) === 'tug' &&
+    typeClass(41) === 'hsc' &&
+    typeClass(0) === 'other' &&
+    typeClass(90) === 'other';
+  check(
+    'M.1371 type classes',
+    ok,
+    `70s cargo, 80s tanker, 60s passenger, 30 fishing, 36 sailing, 37 pleasure, 31/32/52 tug, 40s HSC, unknown/other -> other`
+  );
+}
+
+{
+  // The measured light plan, COLREGS made concrete. 240 x 32 m
+  // cargo (Rule 23(a) + Annex I 2(a)/3(a)): TWO mastheads, the
+  // forward at min(6..12, beam-capped) = 12 m (beam 32 caps at
+  // 12), the after 4.5 m higher, separated by min(len/2, 100) =
+  // 100 m, forward light within a quarter length of the stem;
+  // Rule 22(a) ranges 6/3/3.
+  const big = lightPlan(240, 32, 'cargo');
+  const sepBig = big.mastheads[1].z - big.mastheads[0].z;
+  const stemBig = big.mastheads[0].z - -120;
+  // 30 m fisherman: ONE masthead (under 50 m), Rule 22(b) ranges
+  // 5/2/2; an 8 m launch: 2/1/2; a 15 m boat's masthead range 3.
+  const mid = lightPlan(30, 7, 'fishing');
+  const small = rangesFor(8);
+  const fifteen = rangesFor(15);
+  // Rule 25(b): a sailing vessel carries NO masthead light.
+  const sail = lightPlan(14, 4, 'sailing');
+  const ok =
+    big.mastheads.length === 2 &&
+    big.mastheads[0].y === 12 &&
+    big.mastheads[1].y === 16.5 &&
+    sepBig === 100 &&
+    stemBig >= 0 &&
+    stemBig <= 60 &&
+    big.ranges.masthead === 6 &&
+    // Annex I 2(g) is a MAXIMUM: sidelights not above 3/4 of the
+    // forward masthead height (the plan places them at 0.6).
+    Math.abs(big.sideY - 7.2) < 1e-12 &&
+    big.sideY <= 0.75 * big.mastheads[0].y &&
+    mid.mastheads.length === 1 &&
+    mid.mastheads[0].y === 7 &&
+    mid.ranges.masthead === 5 &&
+    mid.ranges.side === 2 &&
+    small.masthead === 2 &&
+    small.side === 1 &&
+    small.stern === 2 &&
+    fifteen.masthead === 3 &&
+    sail.mastheads.length === 0 &&
+    sail.ranges.side === 2;
+  check(
+    'measured light plan',
+    ok,
+    `240 m cargo: two mastheads 12/16.5 m, 100 m apart, forward within L/4 of the stem, 6/3/3 nm; 30 m fisher: one masthead at beam height 7 m, 5/2/2; 8 m launch 2/1/2; 15 m masthead 3 nm; sailing = no masthead (Rule 25(b))`
   );
 }
 

--- a/themes/horizon/ships.js
+++ b/themes/horizon/ships.js
@@ -53,6 +53,75 @@ export const SUNSET_ELEV = -50 / 60;
 // luminous ranges in nautical miles.
 export const RANGE_NM = {masthead: 6, side: 3, stern: 3};
 
+// Rule 22 in full - minimum luminous ranges (nm) by vessel
+// length: (a) >= 50 m: masthead 6, side 3, stern 3; (b) >= 12 m
+// but < 50 m: masthead 5 (3 if under 20 m), side 2, stern 2;
+// (c) < 12 m: masthead 2, side 1, stern 2.
+export function rangesFor(lenM) {
+  if (lenM >= 50) return {masthead: 6, side: 3, stern: 3};
+  if (lenM >= 12) return {masthead: lenM >= 20 ? 5 : 3, side: 2, stern: 2};
+  return {masthead: 2, side: 1, stern: 2};
+}
+
+// ITU-R M.1371 ship-type code (AIS message 5 "Type") -> the
+// silhouette class the theme draws. First digit is the family;
+// 30-37 are specific craft.
+export function typeClass(t) {
+  if (t === 30) return 'fishing';
+  if (t === 31 || t === 32 || t === 52) return 'tug';
+  if (t === 36) return 'sailing';
+  if (t === 37) return 'pleasure';
+  const d = Math.floor((t || 0) / 10);
+  if (d === 4) return 'hsc';
+  if (d === 6) return 'passenger';
+  if (d === 7) return 'cargo';
+  if (d === 8) return 'tanker';
+  return 'other';
+}
+
+/**
+ * The vessel's light plan from its MEASURED length and beam -
+ * COLREGS made concrete:
+ *  - Rule 23(a): power-driven vessels carry a forward masthead
+ *    light, and a second one abaft and higher when >= 50 m.
+ *  - Rule 25(b): sailing vessels underway carry sidelights and
+ *    sternlight ONLY - no masthead light.
+ *  - Annex I 2(a): forward masthead height >= 6 m above the hull
+ *    (>= the beam if broader, need not exceed 12 m); the after
+ *    masthead at least 4.5 m vertically higher.
+ *  - Annex I 3(a): horizontal separation of the mastheads at
+ *    least half the vessel's length (need not exceed 100 m); the
+ *    forward light no more than a quarter length from the stem.
+ *  - Rule 22 ranges via rangesFor.
+ * Ship frame: metres, bow at z = -len/2, +y up. Returns
+ * {mastheads: [{y, z}...], sideY, sternY, ranges}.
+ */
+export function lightPlan(lenM, beamM, cls) {
+  const len = Math.max(lenM || 0, 6);
+  const beam = Math.max(beamM || 0, 2);
+  const ranges = rangesFor(len);
+  // Sailing (Rule 25(b)): no masthead light; side/stern heights
+  // are display placement near deck level (the regulation fixes
+  // the arcs and ranges, not a sailing hull's geometry).
+  if (cls === 'sailing')
+    return {
+      mastheads: [],
+      sideY: Math.min(0.15 * len, 3),
+      sternY: Math.min(0.1 * len, 2),
+      ranges
+    };
+  const h1 = Math.min(Math.max(6, beam), 12);
+  const zFwd = -len / 2 + Math.min(len / 4, len * 0.2);
+  const mastheads = [{y: h1, z: zFwd}];
+  if (len >= 50) {
+    const sep = Math.min(Math.max(len / 2, 0), 100);
+    mastheads.push({y: h1 + 4.5, z: zFwd + sep});
+  }
+  // Annex I 2(g): sidelights not above three quarters of the
+  // forward masthead height.
+  return {mastheads, sideY: 0.6 * h1, sternY: 0.4 * h1, ranges};
+}
+
 // Annex I section 8: luminous intensity (candela) for a light
 // required to be visible at D nautical miles. T = 2e-7 lux
 // threshold, K = 0.8 atmospheric transmissivity.


### PR DESCRIPTION
Both halves of the feedback, one PR.

**"Boats are generic."** True — and the code comment admitted it ("display furniture… reports carry no dimensions"). But AIS *does* transmit the real vessel in message 5; the daemon just never subscribed to it. Now:
- `ShipStaticData` joins the aisstream subscription. `normalizeStatic` (gated) reads the ITU-R M.1371 type and the **measured dimensions** — length = A+B, beam = C+D from the antenna offsets, draught in metres. A statics table rides the resident picture (6-min Class A repeats, 24 h own-clock prune) and `query()` merges type/len/beam/draught into `/ais` and the stream events.
- The theme scales each hull to its measured length/beam and picks the silhouette by type class: cargo hatches, tanker trunk + manifold, white passenger decks, fishing wheelhouse + gantry, sailing mast, tug house. Rebuilt only when identity changes.
- The COLREGS lights got *more* exact with real lengths: `lightPlan` (gated) implements **Rule 23(a)** (second masthead abaft and higher on ≥50 m power vessels), **Rule 25(b)** (sailing vessels carry *no* masthead light), **Rule 22 in full** (ranges by length band — a 15 m boat's masthead is 3 nm, not 6) and **Annex I §2/§3** heights and separations from the measured beam and length. Each light now fades through Allard's law at its own rated range. `?ship=N` spawns one measured-size vessel of each class for the harness.

**"Environment does not have light sources."** Black Marble gave the glow; now it gives the *lamps*. `lampCandidates` seeds Earth-anchored point sources exactly like roam's trees — the shared `hash3` on absolute geodetic cells (exported from roam.js so all deterministic dressing shares one model), cos(lat) acceptance for uniform areal density, hash-sorted display budget — with acceptance **linear in the measured radiance** (15 nW/(cm²·sr) = every 120 m cell lit; below ~3× the airglow floor, none). The theme drops them on the terrain surface (never on water — the 500 m data bleeds over shorelines), as warm additive points through the shared AgX+fog encode, brightness following measured radiance, gated by the same civil-twilight ramp, rebuilt on roam re-anchor. The same town lights the same lamps from any anchor.

**Gate**: 43 sets PASS — server +1 (static-merge fixture), ships +2 (type table; the 240 m / 30 m / 8 m / sailing plans checked against the regulation text), nightlights +1 (determinism, second-anchor overlap identity, areal-density binomial, dark field → no lamps). Browser smoke with the captured Black Marble tile served locally through `?lights=`: the full fetch → decode → field → lamps → compiled-point-cloud pipeline runs with the panel recording the lamp count — and it caught a real bug (a local variable named `sample` shadowed the terrain sampler; the sync's catch now logs under `?debug=1` instead of swallowing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKKBen9kkD562HDVr7cXAx

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKKBen9kkD562HDVr7cXAx)_