### PR TITLE
Horizon: worldwide trains via transitous.org

### DIFF
--- a/themes/Horizon.html
+++ b/themes/Horizon.html
@@ -125,7 +125,12 @@
         trains run the lines on their real timetable: category,
         number, operator and live delay from the station board,
         positions interpolated between the stops each train
-        reports at its delay-shifted times - and the PIER station's
+        reports at its delay-shifted times; everywhere else the
+        worldwide GTFS aggregator (transitous.org) answers instead -
+        every rail leg operating in the box right now, followed
+        along the polyline of its ACTUAL route by arc length, with
+        its published real-time times (ferries take the boats
+        path) - and the PIER station's
         board does the same for the lake steamers (category BAT):
         where AIS coverage misses them the schedule floats them at
         the lake's measured level, an active AIS vessel nearby
@@ -409,6 +414,7 @@
         BOAT_CATS,
         BOAT_DIMS,
         parseBoard,
+        parseTrips,
         providerFor,
         trainAt
       } from './horizon/trains.js';
@@ -1674,6 +1680,36 @@
         if (!prov) return; // outside every provider's scope: no call
         const seq = ++trainsSeq;
         try {
+          if (prov.kind === 'trips') {
+            // The worldwide aggregator: ONE box query around the
+            // view - every rail leg operating right now with its
+            // real-time times and the polyline of its actual
+            // route, which trainAt follows by arc length. FERRY
+            // legs take the boats path.
+            const legs = await (
+              await fetch(prov.tripsURL(state.lat, state.lon, Date.now()), {
+                credentials: 'omit'
+              })
+            ).json();
+            if (seq !== trainsSeq) return;
+            const all = parseTrips(legs);
+            trainJourneys = all.filter((j) => j.cat !== 'BAT');
+            boatJourneys = all.filter((j) => j.cat === 'BAT');
+            const rt = trainJourneys.filter((j) => j.realTime).length;
+            const first = trainJourneys[0];
+            record(
+              prov.name + ' map trips',
+              trainJourneys.length +
+                ' rail legs (' +
+                rt +
+                ' real-time)' +
+                (boatJourneys.length
+                  ? ' · ' + boatJourneys.length + ' ferries'
+                  : '') +
+                (first ? ' · ' + first.label + ' → ' + first.to : '')
+            );
+            return;
+          }
           const loc = await (
             await fetch(prov.locationsURL(state.lat, state.lon), {
               credentials: 'omit'

--- a/themes/horizon/WEBGPU-PLAN.md
+++ b/themes/horizon/WEBGPU-PLAN.md
@@ -2679,6 +2679,39 @@ secret put AISSTREAM_KEY && npx wrangler deploy`.
   count and next departure. ?trains=0 governs both modes. Gate
   set count unchanged (50) - the trains set grew 5 -> 6
   landmarks. Browser smoke unchanged and clean.
+- DONE: worldwide trains via transitous.org (Jul 10, growing the
+  provider registry - the community DB API answered 503 on both
+  versions, so the SECOND registry entry became the better one:
+  transitous.org aggregates public GTFS feeds worldwide, keyless
+  and CORS-open, and its api/v6/map/trips answers a box + time
+  window with every leg operating there RIGHT THEN - mode, line
+  name (ICE 698), real-time-adjusted departure/arrival with a
+  realTime flag, the from/to stops, and the encoded POLYLINE of
+  the actual route shape). trains.js grew (gate 6 -> 9
+  landmarks): decodePolyline held EXACT against the canonical
+  documented reference polyline (the shared GTFS encoding);
+  pathPoint - a point at LENGTH fraction f along a geodetic path,
+  by cumulative arc length not vertex count (landmark: f = 0.5 on
+  a 300 m + 100 m L sits exactly 200 m up the first leg);
+  parseTrips -> the SAME journey shape the boards produce (one
+  consist ladder, one livery family, one renderer), MODE_CAT
+  mapping GTFS modes to board categories with underground modes
+  deliberately absent (drawing a metro on the surface would be
+  inventing) and FERRY routed to the boats path; trainAt follows
+  a journey carrying its route shape ALONG THE SHAPE by arc
+  length instead of the straight line (the LIVE 57-leg Frankfurt
+  fixture holds ICE 698 mid-leg ON its own polyline). The
+  registry: transitous kind 'trips' with the WORLD as its bbox,
+  ordered AFTER the Swiss national board (richer metadata wins
+  where both cover); the scope landmark now proves Paris and New
+  York fall through to the aggregator while Interlaken stays
+  Swiss - one provider per view, never more. Theme: syncTrains
+  branches on provider.kind - the trips flow is ONE box query
+  (~8 km, 15-minute window) parsed and split rail/ferry; panel
+  records leg count, real-time share and the next departure.
+  Renderers unchanged - the shared journey shape did the work.
+  Gate 50 sets (trains 6 -> 9 landmarks); browser smoke unchanged
+  and clean.
 - OPEN (environment, not code) - UPDATE (roam smoke, Jul 7): the
   drift now also manifests as a PER-FRAME uncaught TypeError -
   GPUTexture.createView rejects the `swizzle` field three's

--- a/themes/horizon/trains-fixture.mjs
+++ b/themes/horizon/trains-fixture.mjs
@@ -1351,3 +1351,1141 @@ export const BOAT_FIXTURE = {
     }
   ]
 };
+
+// Captured transitous.org response (2026-07-10, api/v6/map/
+// trips over Frankfurt, 10-minute window - keyless, CORS-open,
+// worldwide GTFS aggregation): rail legs operating in the box
+// right then - ICE/regional/S-Bahn and a tram sample - each
+// with its line name, mode, real-time-adjusted departure/
+// arrival (realTime flag), the from/to stops, and the encoded
+// POLYLINE of the actual route shape. Buses, coaches and
+// planes dropped; night-train megalines (>6 KB) and trams
+// beyond a 10-leg sample dropped for size.
+export const TRIPS_FIXTURE = [
+  {
+    trips: [{displayName: 'ICE 698'}],
+    mode: 'HIGHSPEED_RAIL',
+    from: {
+      name: 'Frankfurt (Main) Hauptbahnhof',
+      lat: 50.106205,
+      lon: 8.663015
+    },
+    to: {name: 'Aschaffenburg Hbf', lat: 49.98065, lon: 9.14343},
+    departure: '2026-07-10T01:55:00Z',
+    arrival: '2026-07-10T02:25:00Z',
+    scheduledDeparture: '2026-07-10T01:31:00Z',
+    scheduledArrival: '2026-07-10T02:05:00Z',
+    realTime: true,
+    polyline:
+      'sjypH}~zs@x@tCp@dCPh@Pp@Pn@DNn@dCj@tBX~@Lb@FTRn@Pn@H`@BN\\`BNr@Nt@Nr@lAfEb@xA\\nANh@\\rAJb@BF~AnG`@vA`@lARb@Tf@Vf@`@n@JNFHTTRTRPNLXRPJPHZNLDNFPDLBD@L@NBTBN@T@\\AXCNA\\GXGVI\\Od@WHENMPOFGVWRS\\a@NSRUpA_BvA_BX]j@o@tEmFDEjEgFb@i@^e@T]NWTc@Vi@Ti@\\_AZgAd@sBDUT_BPyAFm@JyANoCBu@Bo@B]HwBBgAB{@@eADsB@_CAeE?ECgB?WA]Ay@Cu@IkAGu@Is@Ku@Km@Mq@GSYkAa@mAeA_DUq@]cA_AwCW{@e@{A]mAa@{AYsAi@cDS}AK}@CYIq@]{Ca@eDW{BIm@QwAs@qE}@eFa@sBKk@Qw@YuAOm@a@_Bc@{Ac@}Ae@uAGQ]aACGAECK[{@Ys@Qg@a@kA[}@M[Oe@M[_@iAGOa@mAEMg@qAc@eAOc@CEO[]y@Q_@MWWm@g@aAw@gBa@eAEMc@uAGUIYU}@WmAO{@g@oDYyBAKo@cFE[[kCS_B]mCs@mFEYUeBIo@QwAm@cEWuBU{BAUKwAE{@KwBGaD?OAaB?iB?eD?eEAkB?gA?kBAo@AgDOyc@?kAAy@AiDEyJUgLIgEe@kSg@aUCgAAeAC}A@iFJgED}@TqDn@}F\\oBTwANu@Ns@\\yA@Ef@qBj@}BlBuH`AwDJc@pD}N`@_Bb@gBLc@t@}ClDqNNo@Ps@DK~AwGBKl@aCH]FYLm@Ns@F]BQPeANmADm@Fm@Do@Di@B_@@o@BgABuAAkA?gACu@EeAE}@Eo@AGSiCAQCY?M]eE[gEEq@Ek@McBI_AEg@Gg@KoAMsAEg@Go@Gm@AGCYGg@OaBAKSwBAIWeCC[AKCSEg@m@iGCSSyBAO_@wDQkBEe@QeBAIAKe@_F_@sDIaA_@wDGq@YoCcAmKeA_LQaBk@_GUkCKaBIkAGmAMkDYmIC]EmAEyAAMIyB?EGcAG}@KgAY}CI{@Go@Ee@E]QoAIe@Mw@AGG[GYOy@UaASs@eA{D{@eD]oAU}@e@cBOi@g@{AWw@GUg@_B[aA]eAw@eCKYg@aBu@{BkFqP_A{CoD_Le@{AYcAGUs@}Cm@oCCMCI_@cBU{@GYOc@EKWw@yAyEqBuGgAyDu@mC_AkDoC}JAEcBkGc@}Ac@aBgA_EmC_KyJq^eAyDa@{AWcAU_AYuAYwAI_@AIIg@UsAOeAK{@QyAGi@Gm@MmAGu@Ca@IoAIqBEiAEoAK}CE}AEeBGqBCaACy@A{@EqBOgGWyJ_Ay_@]qOG{BImCCm@IkDGcCSaHAw@KyDmAyh@y@{\\g@}TQcGE}ACcAUmJc@gRw@e]aAg`@?KW{KSoICm@GsCG_DAuA@}@?q@@mAB}@FmAFsAHgAHkARiBPmAzAwIZcBLq@p@uD\\qBRgAn@sDFe@Hk@L_AJeADe@Bg@HoADqABcB@}@Au@CwAG_BE{@I_AKcAMgAMq@Im@Ou@GYI]Ke@Oi@W}@Sk@[}@m@_Bo@_BeBcEa@cAWm@CGCKeG_OOa@EICECISk@GOMa@Sq@K_@Ke@Mo@O{@O{@OqAG}@Ei@EgACi@CiBAyB@y@D}AFsALkAJs@V{ANo@Ru@jA}C\\gAXgANq@Li@@O^_C~@uGJo@@ILk@d@mBTw@Pk@HUx@}BRc@HOvAqCf@{@Zm@Xi@\\q@lAgCZo@`@}@t@}ADGN]v@_BvBqEdCmFdBuDJSBGv@eBBEFKzA_Dv@cBjA_C|AiC|@gA`AcA`Ay@jBgAFC|@_@XGxA_@f@IlAQrB]ZEzA]n@Sj@Sj@Wj@Yh@Y`Aq@l@e@~@y@x@y@p@y@`ByBDIhEmGXa@R]NWR[NUb@q@t@oA\\m@tAaCf@aAvAkCVg@Tc@r@yAfA}B|AgDJW^_AFOZu@Vq@n@cBvHiStAmDnJwVnFwNpG}P~DsKrG}PBEf@sABEh@wAd@oA|AcEPc@fAuCpBmFbJcVbEwKdF_N\\_ABIJUpAgD@EbAqCXu@tAsDJWjA}Cx@uB`AkC`DqIlAaDrAmDfKsX`@cAbDsIx@yBjC_Hh@uAbAoCFMl@cBNc@`AmCrCwHpBeFd@eAxBaFVg@fAyBx@uAxBuDf@s@xAmBhAwAHI|@cAvCaDzA{APOdImHTSrRcP\\Y|FaFbA{@xMeLvMaLlJcIdYiVfPgN`NkL|G{FpGsFlB_B~GaG`FcE`A}@bCsBbBwArBgBpBeBnFsEfDkCj@i@pGqFtIkHnM{KhLuJzVgTpr@}l@hJcIhOgMjOmMrSeQvIqHzMiLbJ{HfEqD|BmBjCwBbFoE~EcEdK{Id@_@nBcBdUuRrEsEzCgDjDuEjDqFLUb@y@nBkDt@wALUJQbByChAuB|A{CfBgElAwCnAsDdAsCnBiHbAaEhAuEtBiLnBiMfAaIRkBf@wEb@oH\\gHRwEBeA@]ByAHgFRcQ@cB?M@KFyG@a@LwMFgFJwIB{BByCLcKXoU?EBoBFuFBgD@YL}K?IFyD@_@F{G?UFgF@iAFmF@s@@QAyE?IA}C?g@AaA?gB?_B@oCHmI'
+  },
+  {
+    trips: [{displayName: 'ICE 699'}],
+    mode: 'HIGHSPEED_RAIL',
+    from: {
+      name: 'Frankfurt (Main) Hauptbahnhof',
+      lat: 50.106205,
+      lon: 8.663015
+    },
+    to: {name: 'Mannheim, Hauptbahnhof', lat: 49.479134, lon: 8.4699},
+    departure: '2026-07-10T01:58:00Z',
+    arrival: '2026-07-10T02:35:00Z',
+    scheduledDeparture: '2026-07-10T01:12:00Z',
+    scheduledArrival: '2026-07-10T01:51:00Z',
+    realTime: true,
+    polyline:
+      'sjypH}~zs@x@tCp@dCPh@Pp@Pn@DNn@dCj@tBX~@Lb@FTRn@Pn@Tt@Tt@d@lAt@fBb@fAh@tAp@`Bd@bBl@tBt@hCVdAl@~Bh@xBFZLd@FVf@pBlAjEvA~EX~@zAhFdAlD~AtFlAbErBhH\\jAp@|B~@vCfAfDVv@Nn@F^H\\Hf@Jp@Jx@JlADx@FdA@d@BnAB|@B~@Bj@Bn@BTD`@Hv@Lt@H`@T~@`AdDLZv@fCBDX|@Xv@Zv@FNVf@DHVd@b@p@\\d@XZVXd@`@f@`@p@^f@X`@Nj@Ph@LRBTBZBN?d@@^AVAPCb@EPCPCZGD?NEdAUbC_ARGnJsDVKVKHEd@QNINGNINILILIRMROtDoCfGqE`@[fAw@jBqARM|@q@TQbEuClAy@NKn@c@|AgAFGHGz@k@~@q@`CcBt@i@d@[`DmB`Am@lA}@PMhCiBdCkBfA}@n@i@p@i@j@_@d@YlAe@DCRGZIh@Ix@It@Cl@@D?d@BjAV\\Hd@Lz@\\n@\\t@f@`@Xn@l@j@l@VZBDLP`@n@Zf@Zp@`@~@Vn@Tt@DLBJHVFXFTNn@d@`CDT^fBBJBNBLFTFVJ\\FVPl@Pl@DPDNFRDRDRFXDRp@hDZzA\\bB@FvCbOz@lEbA~EXnANr@f@hBj@`BXr@r@~AVf@l@bAp@`Av@`A~@|@`@\\xAdAx@h@x@f@h@\\^TfAp@rAx@r@b@FDbDnBVPjC`B~A`ADBnKrGdEhCnBlAl@^j@\\hAp@xA~@|BvA^TdBdAlC`BbDpBb@VDB|A~@dAp@nLjHPJrBpAfF~CjBhAnBlAxA|@FBrCfBxInFfEhCzBtATLxA~@jDtBlElCFF~A`A|D`Cr@d@|@h@pBlArAx@r@d@|@h@PJTLz@h@dGtDn@^hF`DXPd@ZdBdAfC|AdCzAj@\\t@f@rDxB^Vv@f@bEfCXPdEdC~CpBdDpBlEnCdGtDfKlG`@VfAn@hF`DxIlFXPdCzAr@`@dEjCHDhEjCf@ZrEpC~BvAhEfCdIdFFDnElCf@ZHDbBdAZRz@f@hLdHb@VLF`BdA|@j@pAv@fAr@t@b@DBdAp@lDrBp@b@\\RNJLHhAp@zA|@DDbDrBnAt@v@d@PLb@XxEtCjAr@|@h@vBpAlF`DhDtB~@j@pAv@~BxAJFbI|E~A`AfGvDzA~@NHPJn@`@`Al@jBhA|D`Cf@Z~@j@tHtEbDnBdDrBvAz@nGzD^TRL`GpDXPh@ZhDtBLHn@`@p@b@fAp@^RhBfAFDx@f@n@`@dCzAvBtArAz@HFf@^d@^pAdAJLRPb@b@RTDDJLpBbCl@v@nBfCvEjGFHHJ|ArBT\\jExFpI`LTZdChDdArARXpH|JX^tCxDp@z@j@v@dArA|ErG`FvGnI`L|DhF`@j@tH~JtIhLpAbBbCbDzEnGvAlBpFjHLPrAfBzEnGn@z@dDlE\\d@lBdCPTrCvD~EpGNRr@bArAhBhChDfAvArAfBpDzEzBvCvEhGpCrDxAnB`BxB~ErGlDtEZ`@HJ`JvL^f@vDbFDFx@dA\\d@hExFpAdBbC`D|@lAnGnIjGjILP~ErGvFrHhAzALPlAxARZzDbF^f@HJlAxAl@r@b@d@RRd@f@p@l@DDLJ`@\\h@d@l@f@p@f@t@f@ZRXNx@f@b@XHDn@\\x@`@z@`@f@RTLlAb@FBz@Vx@Vb@JRFd@JxB`@vBZ|ANvAHD?z@Bv@Dx@@X@D?dABD?Z@tBDpCDlBD`HNrBD~EJl@@f@@rGLnEHh@Bv@@H?R@|@B\\?`@@hCHdCBlFDrDBrKJxBBvEDj@@R?`@?nFB^@vA@jEDzFDfC@hIFdBB|EB~@@v@@zBB|FDlA@jED~DB~B@n@@N?bB@hFD`DBhCBV@nA@r@@dFBP?p@@`G@hA@`A@~GFh@@`JJfBB\\?fA?vBDzGHl@?vKD~GDpFD|DBbIFhEDdDBjNJnC@v@@rEBjFBbCDp@?`B?|BFpHDt@@xB@nA@jBFp@?|GFrG@t@@hAA~CAnCCr@Aj@AbDErBAr@BpADbBHpALv@Jr@Jz@Nr@Nl@NPD\\Jp@RpAb@vAf@h@TvAp@j@XJFdDhB|BvAhAt@tA|@l@\\jAt@rAz@d@ZHDhC|AtBlAnAt@`CrAr@`@RL`B~@pAx@tBlAVNlIrFHDdAp@zGhEz@j@xA|@JHr@b@bC|A`@V|A`AZRd@Xb@XRNlAt@|A~@~FtDz@j@rAx@`CzA~B|ArBnAjBpApA|@pEpCj@\\zDfC`@V^TTNhEpChC`BpBpAdC~AnAx@dDrBnCbBVN\\RhBfArBbAvAj@hC|@bBf@|AZlB\\lBTl@FfAHZBl@Bx@@jA@hBAbBKp@Ev@IhCWxBWr@IpIiAnDc@zASRCzC]RClC]jAOXERCfDc@pBYlBUfAQFA|Ca@PClBW`AKdAMpBYTCb@GhBUnDc@z@MfIcA`AMvFs@t@KtGw@tC_@d@Gr@Kp@K~AYhAUHC|A[bBg@ZIn@UHCv@Yf@SlAe@|BmAr@c@lDyBnBwAz@m@b@]rBwAbBkAfCcBlBuAtAcAb@[pCsBlDeCZUpCoBnBwARO~CyBhDcClA}@l@c@nF{Dn@e@dAw@tB}AbAu@bCeBxAcAtBoAVQzBgA~@a@bBo@PG`Bg@jBc@zA[HAzAYhASx@ObB]NEdB[vBa@j@MJA~AWhAUpCe@vAYh@IrBa@jAUjB]bASZGnCg@bKmBhCc@PEHAhF_AFA~@Sf@KrDo@DAxCk@n@KbCg@pCg@|Ba@bAO^El@I`@CvAMbBGN?`BArBD\\BJ?nAHh@Ft@Hh@DPDpATj@Lt@P~Ad@dA^XJdA^dIpDDBD@|@`@bAb@`CdAnClAdGpCpEpBfF~BnD`B~Ap@tAn@nBz@jAf@~@`@dFzBjD`BbAh@pAz@n@b@p@d@l@b@hB|AxBvBzB|BzB|B~A~ATTxCzCdCdCJJ`@^hDhDbAbAbBbBhEfEr@r@lAnAz@x@HHvBvBf@h@f@f@VVZZ~A~A^^zAzANPNNNLjCnCxIxIn@n@`F`FbHbHfAfAVV~A~AxBxBpFpF\\\\jIhIJLvAvA`E`EFFHHl@l@~G~GfCfCdCdCzFzFVXXXlClC`B~AjAjAdDfDh@j@`DbDl@p@tBrCdA|A~CzE`DdFn@bAjAjBBDV`@fAfBFLvAvBzBlDhC`El@~@b@r@b@j@x@bAj@l@PN`Av@d@ZXNh@VPFFBVHn@Rx@Nr@JxBF\\AXA^E^E\\G\\GdAWdAY|@YFCpAa@j@QLCzFeBrFaB\\MDAt@Un@Q~CaALEjCw@|Ae@hCy@^KLE~KkDLEfGkBxAc@fIgClGoBt@SjJ{CzEyALEh@Qz@W`Cs@lDgArAa@xH}BnDgAxH_CXKx@YjA]~Ag@JCbCw@|Bq@vFeBdCu@~E}Ar@UtAc@j@QxH_CrA_@f@Q~DoAzEyAJCTGnAa@HCNGnJuCbA[FCf@OrDkAz@WtDiAd@OjCy@tDiA|@Yf@OdA[|GuBj@Q`EmAXIt@UpJyC|CaARGRGfA]d@OtAa@pCy@|Bu@n@SrH}BLErEwAjA]jIgC~Bs@tEwA`AY`Bi@zHaCrGqBjBi@^MvGqBtGqBdBi@tH_C~CaAxBq@lKcDfCw@fCu@h@Q^KvGsBbIcCdA]DAlDgADAtAc@dFcBbC{@p@UTKd@OtHoC`Cy@pBm@xLuDdCu@bCu@dEiAbCs@^I\\IxA_@l@O|Bk@FA^IfAW~Be@|B]jBQrBMbACV?pAA~AEfJCT?dGCjFCzDAj@CR?jB?tDAxIERAhGC~BAD?dDApB?|JGp@?rCAdCAF?xKER?xECfA?xDCvECf@AvFAnEAfD?f@?NAbCAJ?~JG|DA~GAvJGfD?pEChJGF?zCCD?n@?lCApDAf@AX?H?vAA|BAdCAJ?`A?lBApGCbEAhD?bA@xB@F?v@?tB@Z?rIBR?rDAtDArIEhGAjACr@?x@?fCA|BC^?~BA\\?x@AT?vAARAN?vBEfAAdAAZAX?tBCRAhCCNAbAAb@AzAAfC?\\?p@@H@D?jAFP@ZB^Bl@FVDn@HF@h@Hb@HNDjAVnAZlA^`@Nr@VvAn@zAr@bB`AhBjAt@j@z@p@hB`BPNxAzAp@v@n@t@`AlA^h@BDlBpCtAxBFFfC|Dt@lAzAbCrFvIl@~@hDlFpApBnB~CT\\tBdDpB~C\\h@hBrCT^tCpE^l@rAtBnApBlBxCn@bAHJtApBvAjBpA`BHJJLd@h@l@n@fBnBl@n@`AbA^^nArAj@l@`@^xAxAtAjAnA`AvCpBdBbAlHfEtBfAxB~@zBv@tBh@tB`@|BZtBV~@Hv@Hj@HbAHH@n@H`@DxAN`@B\\D\\B^Bd@@X@|@?l@?FApAGnBOTChBWLAzBYbC[zBY`@EfAOjAObAODAxA]tAi@x@a@JGj@]`@[n@i@b@c@HK`@e@^g@d@o@T]f@y@BEd@}@Vg@Vi@Rg@Ri@Ro@Rs@PaADQBMBQB]Ho@Do@B[Bk@FaB?MH}BD}@@GBk@JuARiBToBHq@Ly@BKHi@Nq@T{@b@aBV{@V_AXu@Vm@Xq@l@eBPe@L]Na@DI@Gt@iBj@wAd@oADKHQTk@JY'
+  },
+  {
+    trips: [{displayName: 'ICE 618'}],
+    mode: 'HIGHSPEED_RAIL',
+    from: {name: 'Mannheim, Hauptbahnhof', lat: 49.47923, lon: 8.470026},
+    to: {
+      name: 'Frankfurt (Main) Hauptbahnhof',
+      lat: 50.106964,
+      lon: 8.662199000000001
+    },
+    departure: '2026-07-10T02:01:00Z',
+    arrival: '2026-07-10T02:38:00Z',
+    scheduledDeparture: '2026-07-10T02:01:00Z',
+    scheduledArrival: '2026-07-10T02:38:00Z',
+    realTime: true,
+    polyline:
+      'c|~lHshur@e@hAGPGLw@pB_@bA_@`AITIXO`@GPIVUt@_@lAAHQj@Uv@Ut@W~@Wz@c@`BUz@Op@Ih@CJMx@Ip@UnBShBKtACj@AFE|@I|B?HGdBCj@CZEn@In@C\\CPCLEPQ`ASr@Sn@Sh@Sf@Wh@Wf@e@|@CDg@x@U\\e@n@_@f@a@d@IJc@b@o@h@a@Zg@ZOHy@`@uAh@yA\\E@cANkANgANa@D{BXcCZ{BXM@iBVUBoBNqAFG@m@?}@?YAe@A_@C]C]Ca@EyAOa@Eo@IIAcAIk@Iw@I_AIuBW}B[uBa@uBi@{Bw@yB_AuBgAmHgEeBcAwCqBoAaAuAkAyAyAa@_@k@m@oAsA_@_@aAcAm@o@gBoBm@o@e@i@KMIKqAaBsAgByAuBIKo@cAmByCoAqBsAuB_@m@uCqEU_@iBsC]i@qB_DuBeDU]oB_DqAqBiDmFm@_AsFwI{AcCu@mAgC}DEEwA{BmBqCCE_@i@aAmAo@u@q@w@yA{AMMmBcB{@q@u@k@gBkAeBaA{As@wAo@s@Wa@OmA_@oA[kAWOEc@Ie@GKCo@IWEm@G_@C[CQAkAGE?IAq@A]?gC?{A@a@@eA@O@iCBS@uBBY?[@eA@gA@wBDO?S@wA@U?y@@]?_C@_@?}BBgC@y@?s@?kABiG@sIDuD@sD@S?sIC[?uBAw@?G?yBAcAAeD?gE@qGBmB@aA?K?eC@}B@wA@I?Y?g@@qD@mC@o@?E?{CBG?iJFqEBgD?wJF_H@}D@_KFK?cC@O@g@?gD?oE@wF@g@@wEByDBgA?yEBS?yKDG?eC@sC@q@?}JFqB?eD@E?_C@iGBS@yIDuD@kB?S?k@B{D@kFBeGBU?cJBcBDqA@W?cABsBLkBP}B\\_Cd@gAV_@HG@}Bj@m@NyA^]H_@HcCr@eEhAcCt@eCt@yLtDqBl@aCx@uHnCe@NUJq@TcCz@eFbBuAb@E@mDfAE@eA\\_I`C{GtB_@Ji@PgCt@gCv@mKbDyBp@_D`AuH~BeBh@uGpBwGpB_@LkBh@sGpB{H`CaBh@aAXuEvA_Cr@kIfCkA\\sEvAMDsH|Bo@R}Bt@qCx@uA`@e@NgA\\SFSF}C`AqJxCu@TYHaElAk@P}GtBeAZg@N}@XuDhAkCx@e@NuDhA{@VsDjAg@NGBcAZoJtCOFIBoA`@UFKB{ExA_EnAg@PsA^yH~Bk@PuAb@s@T_F|AeCt@wFdB}Bp@cCv@KB_Bf@kA\\y@XYJyH~BoDfAyH|BsA`@mDfAaCr@{@Vi@PMD{ExAkJzCu@RmGnBgIfCyAb@gGjBMD_LjDMD_@JiCx@}Ad@kCv@MD_D`Ao@Pu@TE@]LsF`B{FdBMBk@PqA`@GB}@XeAXeAV]F]F_@D_@DY@[@{BGs@Ky@Oo@SWIGCQGi@WYOe@[aAw@QOk@m@y@cAc@k@c@s@k@}@kCcE{BmDwAwBCIkAkBWa@CEkAkBo@cAaDeF_D{EeA}AuBsCm@q@aDcDi@k@eDgDkAkAaB_BiCiC]]WY{F{FeCeCgCgC_H_Hm@m@IIGGaEaEwAwAKMkIiI]]qFqFyByB_B_BWWgAgAcHcHaFaFo@o@yIyIkCoCOMOOOQ{A{A_@_@_B_B[[WWg@g@g@i@wBwBII{@y@mAoAs@s@iEgEcBcBcAcAiDiDa@_@KKeCeCyC{CSSaBaB{B}B{B}ByBwBiB}Am@c@q@e@o@c@qA{@cAi@kDaBeF{B_Aa@kAg@oB{@uAo@_Bq@oDaBgF_CqEqBeGqCoCmAaCeAcAc@}@a@EAECeIqDeA_@YKeA_@_Be@u@Qk@MqAUQEi@Eu@Ii@GoAIK?]CsBEaB@O?cBFwALa@Bm@H_@DcAN}B`@qCf@cCf@o@JyCj@E@sDn@g@J_ARG@iF~@I@QDiCb@cKlBoCf@[FcARgBZoAVsB`@i@HwAXqCd@iAT_BVK@g@J{Bb@eBZODcB\\y@NiAR{AXI@{AZkBb@aBf@QFcBn@_A`@{BfAWPuBnAyAbAcCdBcAt@uB|AeAv@o@d@oFzDm@b@mA|@iDbC_DxBSNoBvAqCnB[TmDdCqCrBc@ZuAbAmBtAgCbBcBjAsBvAc@\\{@l@oBvAmDxBs@b@}BlAmAd@g@Rw@XIBo@T[HcBf@}AZIBiAT_BXq@Js@Je@FqC\\yGx@u@JwFr@aALgIbA{@LoDb@iBTa@FWBqBXeALaAJmBVQB}C`@G@gAPmBTqBXgDb@SBYDkANmC\\SB{C\\SB{ARoDb@qIhAs@HyBViCVw@Hq@DcBJiB@kAAy@Am@C[CgAIm@GmBUmB]}A[cBg@iC}@wAk@sBcAiBgA]SWOoCcBeDsBoAy@eC_BqBqAiCaBiEqCUO_@Ua@W{DgCk@]qEqCqA}@kBqAsBoA_C}AaC{AsAy@{@k@_GuD}A_AmAu@SOc@Ya@W_@U}AaAa@WcC}As@c@KIyA}@{@k@{GiEeAq@IEmIsFWOuBmAqAy@aB_ASMs@a@aCsAoAu@uBmAiC}AIEe@[sA{@kAu@m@]uA}@iAu@}BwAeDiBKGk@YwAq@i@UwAg@qAc@q@S]KQEm@Os@O{@Os@Kw@KqAMcBIqAEs@CsB@cDDk@@s@@oCB_D@iA@u@AsGA}GGq@?kBGoAAyBAu@AmHEaCGaB?q@?cCEkFCsECw@AoCAkNKeDCiEEcIG}DCqFE_HEwKEm@?{GIwBEgA?]?gBCaJKi@A_HGaAAiAAaGAq@AQ?eFCs@AoAAWAiCCaDCiFEcBAO?o@A{BAcECkEEmAA}FE{BCw@A_AA}ECeBCiIGgCA{FEkEEsAAc@AoFCa@?S?k@AwEEyBCsKKsDCmFEeCCiCIa@A]?}@CO?MAw@Ai@CoEIsGMg@Am@A_FKsBEaHOmBEqCEuBE[AE?eACE?YAy@Aw@E{@CE?wAI}AOwB[yBa@e@KSGc@Ky@W{@WGCmAc@UMg@S{@a@y@a@o@]IEc@Yy@g@YO[Su@g@q@g@m@g@i@e@a@]MKEEq@m@e@g@SSc@e@m@s@mAyAIK_@g@{DcFS[mAyAMQiA{AwFsH_FsGMQkGkIoGoI}@mAcCaDqAeBiEyF]e@y@eAEGwDcF_@g@aJwLIK[a@mDuE_FsGaByByAoBqCsDwEiG{BwCqD{EsAgBgAwAiCiDsAiBq@_AQW_FqGsCwDQUmBeC]e@eDmEo@{@{EoGsAgBMQoFiHyAoB{EoGcCcDqAcBuIiLuH_Ka@k@}DiFoIaLaFwG}EsGeAsAk@w@q@{@uCyDU[uHaKSYeAsAeCiDU[qIaLkEyFSY_BwBIKGIwEkGoBgCm@w@qBcCKMEESUc@c@SQKMqAeAe@_@g@_@IGsA{@uBuAgC{Ao@a@y@g@GEiBgA_@SgAq@q@c@o@a@MIiDuBi@[YQaGqDSM_@UoG{DwA{@eDsBcDoBuHuE_Ak@g@[}DaCkBiA}@k@s@c@QKOI{A_AgGwD_BaAcI}EKG_CyAqAw@_Ak@iDuBmFaDwBqA}@i@kAs@yEuCc@YQMw@e@oAu@cDsBEE{A}@iAq@MIOK]Sq@c@mDsBeAq@ECu@c@gAs@qAw@}@k@aBeAMGc@WiLeH{@g@[ScBeAIEc@WsEqCGEeIeFeEeCcCyAsEqCg@[iEkCIEeEkCs@a@eC{AYQyImFiFaDgAo@a@WgKmGeGuDmEoCeDqB_DqBeEeCYQcEgCw@g@_@WsDyBu@g@k@]eC{AgC}AeBeAe@[YQiFaDo@_@eGuD{@i@UMQK}@i@s@e@sAy@qBmA}@i@s@e@}DaC_BaAGGmEmCkDuByA_AUM{BuAgEiCyIoFsCgBGCyA}@oBmAkBiAeF_DuBqAQKoLkHeAq@}A_AECc@WcDqBmCaBeBeA_@U}BwAyA_AiAq@k@]m@_@oBmAeEiCoKsGEC_BaAkCaBWQcDoBGEq@a@uA{@gAq@_@Ui@]y@g@y@i@yAeAa@]_A}@w@aAq@aAm@cAWg@s@_BYs@k@aBg@iBOs@YoAcA_F{@mEwCcOAG]cB[{Aq@iDESGYESESGSEOEQQm@Qm@GWK]GWGUCMCOCK_@gBEUe@aCOm@GWGYIWCKEMUu@Wo@a@_A[q@[g@a@o@MQCEW[k@m@o@m@a@Yu@g@o@]{@]e@M]IkAWe@CE?m@Au@By@Hi@H[HSFEBmAd@e@Xk@^q@h@o@h@gA|@eCjBiChBQLmA|@aAl@aDlBe@Zu@h@aCbB_Ap@{@j@IFGF}AfAo@b@KHqAz@_ErCYR}@p@SLkBpAcAt@e@\\gGpEqDlCWPSLMHMHOHOHOFOHe@PIDSH[LoJrDSFcC~@m@TUJG@MD[HYDKBc@D[B]?W?]Am@Eg@Gk@Kc@Oc@Oe@Sw@e@_@[k@c@c@c@a@e@SWOUw@qAWi@CGWo@Sk@_@gAIU[eAg@aBsAoEi@gBy@mCmA{D_@mAWy@a@sAEMOi@Mc@Y}@aAeDMc@m@sBW}@iAyDWy@g@aB{@qCaBsFkA_ESq@K]{@{Cw@gCuBkHM_@Me@EOaAiDsBuHk@sBk@uB_@qAwA}Ee@_BQy@Kg@YuAQw@aAgDkA{Dm@uBAEwAsEgAsDQm@i@iB_AaD'
+  },
+  {
+    trips: [{displayName: 'RB58 (24300)'}],
+    mode: 'REGIONAL_RAIL',
+    from: {name: 'Hanau Hauptbahnhof', lat: 50.12111000000001, lon: 8.929427},
+    to: {
+      name: 'Frankfurt (Main) Südbahnhof',
+      lat: 50.099068,
+      lon: 8.686112999999999
+    },
+    departure: '2026-07-10T02:02:00Z',
+    arrival: '2026-07-10T02:23:00Z',
+    scheduledDeparture: '2026-07-10T02:02:00Z',
+    scheduledArrival: '2026-07-10T02:23:00Z',
+    realTime: true,
+    polyline:
+      'sd|pHq{nu@OXy@fBIPKRiA~Bm@|@a@z@Wh@aAvBu@fBQj@Qn@St@WdACJKb@QdA}@nGADSnAMz@Mj@Mp@[hA]dAw@tBUl@WbAUfAKp@Il@MfAIlAEdBAx@@fA@n@D~BF|AL`BPrAL`ANx@R|@Rz@J^Nf@N^Tn@Rh@fG~NFP\\z@Zt@p@`Br@dBn@|Al@|AZ|@Ph@X`ANf@Jd@J^FZLr@Nv@J|@Hp@LlAH`AFvADhA@lA@x@?t@CfBEpAEn@C^KjAKlAKz@Ij@G`@o@nDAFQhA]jBaAlF]lBsAxHSvAUpBIdAIhAIpAEjAC~@AnAAnB@rA@x@@VDfCFfCTpIVdL~@h`@f@vTt@tZTjJBlADbBLrFbBxr@dAnb@HdE`@vO@r@ZvLFpBPnHLjFJxDr@`ZN`GDtBVxJ@z@Bx@DdAJrED|AJ|CBjA@XD~@H~AHpABb@Fp@JjANrAPxA\\`CRvAJh@@JH\\VrAZzAT|@p@nCjAfEbC~ItFtSlC~JfA~Db@`Bb@|AbBjG@DjCrJ`DlLr@`C|AdFBHnA|Dp@rB~HxVJZBHtFhQNf@rF`Qz@nCn@pBnBdG`@tAdAfDr@~Bd@hB^zA\\dBFZNx@V|ATxAHp@Hl@NvALtAVxDHzAJ`CB`@H`C@P?JFxADlAD|@NzE@NRjFDhAHpALdBH~@HbAj@|F@DN`B@Ld@bF\\hDHt@x@tIXtCHl@^|DH|@^rDd@bFD\\@JZ~C?DNzA?D@H@D?D@JNvALrAZhDVlCPdBJfAPlBh@pFDf@D^Fn@Fn@Ff@Ft@VrCRxBPdCFz@TrCZbE@JF|@T|C?HDl@F|@BbABz@@dA?lAAtAA\\Ad@Ch@Cj@Ch@Gn@En@Gj@OlAQhACPGXOt@Ml@GXI\\k@`CEJEP_BrGc@bBcFlSKd@c@fBa@~AqD|NIZ_AtDqB~Hk@|Be@nBCHQv@WbASbAs@jEo@vF[pFKbE?hF@|ABhABbAf@`Ub@hSJfETfL@`BBzG@fD?x@@nAD~GHtZ@fD?n@@jB@fA?jB@rB@dB@jCDdDD`EJxCDx@J`B@HPtBRrBz@tG@FHl@ZzBj@jE`@~CDVFh@Jp@b@fCf@pDXbCNlA^lCF^N~@XnATv@Pj@Pf@Rl@l@nA^v@Td@v@`BDH^v@b@dADFDLN`@FN`@hAHRZz@d@rADNFNJ^'
+  },
+  {
+    trips: [{displayName: 'RB68 (15301)'}],
+    mode: 'REGIONAL_RAIL',
+    from: {
+      name: 'Frankfurt (Main) Hauptbahnhof',
+      lat: 50.106472000000004,
+      lon: 8.662692000000002
+    },
+    to: {name: 'Langen (Hessen) Bahnhof', lat: 49.993546, lon: 8.656926},
+    departure: '2026-07-10T02:06:00Z',
+    arrival: '2026-07-10T02:16:00Z',
+    scheduledDeparture: '2026-07-10T02:06:00Z',
+    scheduledArrival: '2026-07-10T02:15:00Z',
+    realTime: true,
+    polyline:
+      'klypH}|zs@t@jCr@fCBHNf@DN@FX`An@~BZjARz@Lb@BPDLH\\n@xBj@vAVp@Tj@j@vAb@vAf@dBHXZdAh@jBDL\\pALf@@Hr@pCt@pCZlA`@nARh@FLJTBDl@bA\\d@FHPRDDNLRRRNPL`@TRJ\\LVHPDHBTDNBT@L@X?\\?`@Ch@KTGXIXMRKTOPKNKNOHGFGPQX[^a@hAsAPSp@w@v@}@dAqArDgEf@m@fE{E\\c@V[\\e@LUNYNYTg@Vk@`@kA`@oAb@sBFWT}AN}Ab@oF@EDw@Hw@L{AFk@Hy@Hm@LaAHe@Fa@Jk@Hc@Ha@Li@XiANo@V_ARs@Ne@L_@Ri@Ne@Vs@xA_DbAkBnAiBh@q@|@gAp@q@bAaAjA}@DCh@c@f@[j@Y`Ag@^QTKj@SbA]fAWj@K\\IVEr@G|@Ip@Cj@Ab@?^?t@@`@Bt@DN@~ALvGf@^DR@vKz@zBNbF^vBR`@BbF^fDVfE\\bAHnDXfJt@|DX`AHnBN`@Dx@F`BLrCTbCRZ@bEZz@HN@`BNtBN`CP|ALdHh@jDX~Jx@tCR^BfCTbCPdAFP@~BT~BPr@Dj@F`AFnALh@DfBNlAJz@HvCV`BPl@Dp@FhBPjAJ`AHn@Dz@FdDTh@B|@Fl@DvCPtCTf@D~Fb@tAJjJt@D?PBD?bAJdGd@x@FdBNlCRbAHdAHfHh@dF`@fM`AzE`@zE\\nDZdAFrAJxE^VBfBNb@BRBbGd@dCPhPpAVB|ALfBLhHj@vOlAP@L@\\BtHl@P@|Ir@`Jp@xIp@dF^~ANN@jJr@D?z@HhAHvOnApAJrAJzALl@Dv@FpCTtCTlAHzJv@|E^`CRbAHlDVzDZF@'
+  },
+  {
+    trips: [{displayName: 'S6'}],
+    mode: 'SUBURBAN',
+    from: {
+      name: 'Frankfurt (Main) Louisa Bahnhof',
+      lat: 50.083679999999994,
+      lon: 8.670312999999998
+    },
+    to: {
+      name: 'Frankfurt (Main) Stresemannallee Bahnhof',
+      lat: 50.09454,
+      lon: 8.671271999999998
+    },
+    departure: '2026-07-10T01:59:00Z',
+    arrival: '2026-07-10T02:01:00Z',
+    scheduledDeparture: '2026-07-10T01:59:00Z',
+    scheduledArrival: '2026-07-10T02:01:00Z',
+    realTime: true,
+    polyline:
+      '_~tpH}k|s@y@EoAG_@Aa@?]?u@@G@c@B{@F[B[Fw@Lk@Ji@N}@Te@Ni@Tw@\\mBbAEBc@Xm@b@GD}AnAaBvA[Tc@\\YPEB}@b@uAZYDI@c@@{@Cy@Ku@Qg@Sk@_@II_@[k@k@k@w@a@s@Q]IWYm@GMSg@g@iAu@eBk@qAO_@MYM_@CI'
+  },
+  {
+    trips: [{displayName: 'S6'}],
+    mode: 'SUBURBAN',
+    from: {
+      name: 'Frankfurt (Main) Stresemannallee Bahnhof',
+      lat: 50.09454,
+      lon: 8.671271999999998
+    },
+    to: {
+      name: 'Frankfurt (Main) Südbahnhof',
+      lat: 50.099030000000006,
+      lon: 8.685512000000001
+    },
+    departure: '2026-07-10T02:01:00Z',
+    arrival: '2026-07-10T02:03:00Z',
+    scheduledDeparture: '2026-07-10T02:01:00Z',
+    scheduledArrival: '2026-07-10T02:03:00Z',
+    realTime: true,
+    polyline:
+      'mbwpHyq|s@M[GSGSCIOa@M]ISQk@K]Ia@Kk@SoAIa@]aCa@mCo@mFk@qDs@{E}@{F[sB]oB]eBCGe@_CKa@Ma@GUq@{BCIOu@UmAI]I[Og@AGISM_@e@uAu@wBk@}A'
+  },
+  {
+    trips: [{displayName: 'S6'}],
+    mode: 'SUBURBAN',
+    from: {
+      name: 'Frankfurt (Main) Südbahnhof',
+      lat: 50.099030000000006,
+      lon: 8.685512000000001
+    },
+    to: {name: 'Frankfurt (Main) Lokalbahnhof', lat: 50.101936, lon: 8.692943},
+    departure: '2026-07-10T02:03:00Z',
+    arrival: '2026-07-10T02:05:00Z',
+    scheduledDeparture: '2026-07-10T02:03:00Z',
+    scheduledArrival: '2026-07-10T02:05:00Z',
+    realTime: true,
+    polyline:
+      '}}wpHmk_t@Qi@Uq@GMIY[{@Sk@M_@M[[u@q@yAkAcCO]Ym@EKO]M[KUIUQg@aAyCM_@Mc@EQOk@Om@I]I]E]CMO_Ag@_D'
+  },
+  {
+    trips: [{displayName: 'S6'}],
+    mode: 'SUBURBAN',
+    from: {
+      name: 'Frankfurt (Main) Lokalbahnhof',
+      lat: 50.101936,
+      lon: 8.692943
+    },
+    to: {
+      name: 'Frankfurt (Main) Ostendstraße',
+      lat: 50.112495,
+      lon: 8.697118999999999
+    },
+    departure: '2026-07-10T02:05:00Z',
+    arrival: '2026-07-10T02:07:00Z',
+    scheduledDeparture: '2026-07-10T02:05:00Z',
+    scheduledArrival: '2026-07-10T02:07:00Z',
+    realTime: true,
+    polyline:
+      'mqxpHay`t@CMEWCS]uBAGUwAO_A[yAk@uBSi@]}@aAoBWe@q@{@eA_Ak@[u@_@aA_@c@Mi@Mo@Kw@OaBYw@MkCe@m@M_B[IAqAWuDSyADyAX_Bh@gAn@g@f@KJy@x@i@h@GF[\\KHq@r@'
+  },
+  {
+    trips: [{displayName: 'S6'}],
+    mode: 'SUBURBAN',
+    from: {
+      name: 'Frankfurt (Main) Ostendstraße',
+      lat: 50.112495,
+      lon: 8.697118999999999
+    },
+    to: {
+      name: 'Frankfurt (Main) Konstablerwache',
+      lat: 50.114708,
+      lon: 8.684584000000001
+    },
+    departure: '2026-07-10T02:07:00Z',
+    arrival: '2026-07-10T02:08:00Z',
+    scheduledDeparture: '2026-07-10T02:07:00Z',
+    scheduledArrival: '2026-07-10T02:08:00Z',
+    realTime: true,
+    polyline:
+      'crzpH_tat@UVQNKLg@f@c@h@g@l@[b@]l@Yj@IRYr@Wr@ADEPQn@CFQt@Ov@GXG`@Mx@Ih@UrBAHEb@AXCXKxBEhB?LAX?bB?\\?z@@p@@z@RnCFv@Bh@@Z?pD?b@?P?h@AbC?H?FAjB?nA@z@'
+  },
+  {
+    trips: [{displayName: 'S6'}],
+    mode: 'SUBURBAN',
+    from: {
+      name: 'Frankfurt (Main) Konstablerwache',
+      lat: 50.114708,
+      lon: 8.684584000000001
+    },
+    to: {
+      name: 'Frankfurt (Main) Hauptwache',
+      lat: 50.114059999999995,
+      lon: 8.678142999999999
+    },
+    departure: '2026-07-10T02:09:00Z',
+    arrival: '2026-07-10T02:10:00Z',
+    scheduledDeparture: '2026-07-10T02:09:00Z',
+    scheduledArrival: '2026-07-10T02:10:00Z',
+    realTime: true,
+    polyline:
+      'w_{pHue_t@?Z@TB|@Bf@B`@HbAFl@D`@Jx@@FBJRtADXHl@PlAB^Fj@BRHdBDx@A^GpBEvAEdAAf@AH?HAR'
+  },
+  {
+    trips: [{displayName: 'S6'}],
+    mode: 'SUBURBAN',
+    from: {
+      name: 'Frankfurt (Main) Hauptwache',
+      lat: 50.114059999999995,
+      lon: 8.678142999999999
+    },
+    to: {
+      name: 'Frankfurt (Main) Taunusanlage',
+      lat: 50.113482999999995,
+      lon: 8.668766
+    },
+    departure: '2026-07-10T02:10:00Z',
+    arrival: '2026-07-10T02:12:00Z',
+    scheduledDeparture: '2026-07-10T02:10:00Z',
+    scheduledArrival: '2026-07-10T02:12:00Z',
+    realTime: true,
+    polyline:
+      'e|zpHm}}s@Ct@Ex@Ex@Ex@GdAI|@AHMrAIz@C^C\\El@AZEj@E^OlAK~@Gn@ALC`@Eb@A`B@ZBfBHvAd@~Cj@tBVh@`@|@pA|B`@n@'
+  },
+  {
+    trips: [{displayName: 'S7'}],
+    mode: 'SUBURBAN',
+    from: {
+      name: 'Frankfurt (Main) Hauptbahnhof',
+      lat: 50.106903,
+      lon: 8.662241
+    },
+    to: {
+      name: 'Frankfurt (Main) Niederrad Bahnhof',
+      lat: 50.081061999999996,
+      lon: 8.637008999999999
+    },
+    departure: '2026-07-10T01:58:00Z',
+    arrival: '2026-07-10T02:03:00Z',
+    scheduledDeparture: '2026-07-10T01:58:00Z',
+    scheduledArrival: '2026-07-10T02:02:00Z',
+    realTime: true,
+    polyline:
+      '_oypHczzs@dBlGPj@bAfDZdATt@@FPp@Pz@RdANr@\\bB^hBd@zA@Db@zAf@bBd@bBd@~AvA|E^pAj@tBj@rBrBtH`AhDDNLd@L^tBjHv@fCz@zCJZRr@jA~D`BrFz@pCf@`BVx@hAxDV|@l@rBLb@`AdDX|@Lb@Nh@DL`@rAVx@^lAlAzDx@lCh@fBrAnEf@~AZfAHT^fARj@Vn@BFVh@v@pANTRV`@d@b@b@j@b@ZXz@f@d@Rb@Nb@Nj@Jf@Fj@D^@V?\\?ZCb@EJCXEZILEFATKl@UbC_ARGnJsDVKVKHEd@QNINGNINILILIRMROtDoCfGqE`@[fAw@jBqARMj@_@l@]f@S`Ai@HEHGrCgBLK~@m@rA}@'
+  },
+  {
+    trips: [{displayName: 'S7'}],
+    mode: 'SUBURBAN',
+    from: {
+      name: 'Frankfurt (Main) Niederrad Bahnhof',
+      lat: 50.081061999999996,
+      lon: 8.637008999999999
+    },
+    to: {
+      name: 'Frankfurt (Main) Stadion',
+      lat: 50.067795000000004,
+      lon: 8.632444000000001
+    },
+    departure: '2026-07-10T02:04:00Z',
+    arrival: '2026-07-10T02:06:00Z',
+    scheduledDeparture: '2026-07-10T02:03:00Z',
+    scheduledArrival: '2026-07-10T02:05:00Z',
+    realTime: true,
+    polyline:
+      'omtpH{{us@nA}@z@o@r@g@`Au@RQh@c@d@]xAgAv@g@n@c@j@_@dBkAPOpA_AbAu@rAcAnAcAf@c@r@k@j@]d@YjAe@DCTGVGh@Kx@It@Cp@@H@\\BhAR^Jb@Lz@Zl@\\p@d@d@\\l@l@j@n@VZBDLP`@l@Xh@Zl@`@~@Tn@Tr@Rr@Lh@d@vB^jBjA~FBJDVPt@DRFVHT\\lATx@DRFRFTTbAh@nCh@jCHd@'
+  },
+  {
+    trips: [{displayName: 'S7'}],
+    mode: 'SUBURBAN',
+    from: {
+      name: 'Frankfurt (Main) Stadion',
+      lat: 50.067795000000004,
+      lon: 8.632444000000001
+    },
+    to: {
+      name: 'Neu-Isenburg-Zeppelinheim Bahnhof',
+      lat: 50.036297,
+      lon: 8.604942
+    },
+    departure: '2026-07-10T02:07:00Z',
+    arrival: '2026-07-10T02:09:00Z',
+    scheduledDeparture: '2026-07-10T02:06:00Z',
+    scheduledArrival: '2026-07-10T02:09:00Z',
+    realTime: true,
+    polyline:
+      'g{qpHk_us@zAtHbAdFbAbFZnAPt@d@fBh@`BXv@p@vAZl@l@bAr@bAv@`A~@|@j@d@pA~@TNb@Vv@f@\\RLH^TdDrBn@`@LFjAt@`BbApFfDDBjKpG`HfERLtAz@jAr@TNdAn@dCzAVPdCzAhBhAjElCDBzA~@dAn@vD~BrAv@~DfCjBhA^TfEhChBhAnBlA|A~@xChBtFhDp@b@tG~D~A`AlBlApAv@zA|@rHtE|DbCd@XlAr@nBnA'
+  },
+  {
+    trips: [{displayName: 'S7'}],
+    mode: 'SUBURBAN',
+    from: {
+      name: 'Neu-Isenburg-Zeppelinheim Bahnhof',
+      lat: 50.036297,
+      lon: 8.604942
+    },
+    to: {
+      name: 'Mörfelden-Walldorf-Walldorf Bahnhof',
+      lat: 50.00154,
+      lon: 8.580910999999999
+    },
+    departure: '2026-07-10T02:10:00Z',
+    arrival: '2026-07-10T02:13:00Z',
+    scheduledDeparture: '2026-07-10T02:10:00Z',
+    scheduledArrival: '2026-07-10T02:13:00Z',
+    realTime: true,
+    polyline:
+      'yukpHatos@tAz@dBdATLz@h@fAp@LHZPlEnCrAx@DBjAt@j@\\l@^hAr@dCxAnAv@fC|Ab@XfAp@rEpCv@f@dBfAzA~@XPdJvFdDrBnElCdGtDfKlG`@VhHjEFDvIlFZPbCzAr@`@zK|G\\RrErCHDDB|BvAbEbCfIbFlJ|FnDxBj@\\bHfEd@XJH\\RbAp@r@b@PJjBhAn@`@xBpAlBjA'
+  },
+  {
+    trips: [{displayName: 'S3'}],
+    mode: 'SUBURBAN',
+    from: {
+      name: 'Frankfurt (Main) Lokalbahnhof',
+      lat: 50.101936,
+      lon: 8.692943
+    },
+    to: {
+      name: 'Frankfurt (Main) Ostendstraße',
+      lat: 50.112495,
+      lon: 8.697118999999999
+    },
+    departure: '2026-07-10T02:00:00Z',
+    arrival: '2026-07-10T02:02:00Z',
+    scheduledDeparture: '2026-07-10T02:00:00Z',
+    scheduledArrival: '2026-07-10T02:01:00Z',
+    realTime: true,
+    polyline:
+      'mqxpHay`t@CMEWCS]uBAGUwAO_A[yAk@uBSi@]}@aAoBWe@q@{@eA_Ak@[u@_@aA_@c@Mi@Mo@Kw@OaBYw@MkCe@m@M_B[IAqAWuDSyADyAX_Bh@gAn@g@f@KJy@x@i@h@GF[\\KHq@r@'
+  },
+  {
+    trips: [{displayName: 'S3'}],
+    mode: 'SUBURBAN',
+    from: {
+      name: 'Frankfurt (Main) Ostendstraße',
+      lat: 50.112495,
+      lon: 8.697118999999999
+    },
+    to: {
+      name: 'Frankfurt (Main) Konstablerwache',
+      lat: 50.114708,
+      lon: 8.684584000000001
+    },
+    departure: '2026-07-10T02:02:00Z',
+    arrival: '2026-07-10T02:03:00Z',
+    scheduledDeparture: '2026-07-10T02:02:00Z',
+    scheduledArrival: '2026-07-10T02:03:00Z',
+    realTime: true,
+    polyline:
+      'crzpH_tat@UVQNKLg@f@c@h@g@l@[b@]l@Yj@IRYr@Wr@ADEPQn@CFQt@Ov@GXG`@Mx@Ih@UrBAHEb@AXCXKxBEhB?LAX?bB?\\?z@@p@@z@RnCFv@Bh@@Z?pD?b@?P?h@AbC?H?FAjB?nA@z@'
+  },
+  {
+    trips: [{displayName: 'S3'}],
+    mode: 'SUBURBAN',
+    from: {
+      name: 'Frankfurt (Main) Konstablerwache',
+      lat: 50.114708,
+      lon: 8.684584000000001
+    },
+    to: {
+      name: 'Frankfurt (Main) Hauptwache',
+      lat: 50.114059999999995,
+      lon: 8.678142999999999
+    },
+    departure: '2026-07-10T02:04:00Z',
+    arrival: '2026-07-10T02:05:00Z',
+    scheduledDeparture: '2026-07-10T02:04:00Z',
+    scheduledArrival: '2026-07-10T02:05:00Z',
+    realTime: true,
+    polyline:
+      'w_{pHue_t@?Z@TB|@Bf@B`@HbAFl@D`@Jx@@FBJRtADXHl@PlAB^Fj@BRHdBDx@A^GpBEvAEdAAf@AH?HAR'
+  },
+  {
+    trips: [{displayName: 'S3'}],
+    mode: 'SUBURBAN',
+    from: {
+      name: 'Frankfurt (Main) Hauptwache',
+      lat: 50.114059999999995,
+      lon: 8.678142999999999
+    },
+    to: {
+      name: 'Frankfurt (Main) Taunusanlage',
+      lat: 50.113482999999995,
+      lon: 8.668766
+    },
+    departure: '2026-07-10T02:06:00Z',
+    arrival: '2026-07-10T02:07:00Z',
+    scheduledDeparture: '2026-07-10T02:05:00Z',
+    scheduledArrival: '2026-07-10T02:06:00Z',
+    realTime: true,
+    polyline:
+      'e|zpHm}}s@Ct@Ex@Ex@Ex@GdAI|@AHMrAIz@C^C\\El@AZEj@E^OlAK~@Gn@ALC`@Eb@A`B@ZBfBHvAd@~Cj@tBVh@`@|@pA|B`@n@'
+  },
+  {
+    trips: [{displayName: 'S3'}],
+    mode: 'SUBURBAN',
+    from: {
+      name: 'Frankfurt (Main) Taunusanlage',
+      lat: 50.113482999999995,
+      lon: 8.668766
+    },
+    to: {
+      name: 'Frankfurt (Main) Hauptbahnhof tief',
+      lat: 50.10714,
+      lon: 8.662477
+    },
+    departure: '2026-07-10T02:07:00Z',
+    arrival: '2026-07-10T02:08:00Z',
+    scheduledDeparture: '2026-07-10T02:07:00Z',
+    scheduledArrival: '2026-07-10T02:08:00Z',
+    realTime: true,
+    polyline:
+      'exzpH{b|s@bBhCLP~@jA\\b@^ZrAjAj@Xp@\\NFPHZNRHn@TFBtBj@t@ZbAb@ZJVNbAp@dAt@\\ZVVPPLPHNJVJRf@dAz@hBFNBHDLRp@d@|A'
+  },
+  {
+    trips: [{displayName: 'S3'}],
+    mode: 'SUBURBAN',
+    from: {
+      name: 'Frankfurt (Main) Hauptbahnhof tief',
+      lat: 50.10714,
+      lon: 8.662477
+    },
+    to: {
+      name: 'Frankfurt (Main) Galluswarte',
+      lat: 50.1042,
+      lon: 8.644521999999998
+    },
+    departure: '2026-07-10T02:09:00Z',
+    arrival: '2026-07-10T02:11:00Z',
+    scheduledDeparture: '2026-07-10T02:09:00Z',
+    scheduledArrival: '2026-07-10T02:11:00Z',
+    realTime: true,
+    polyline:
+      'cpypH}{zs@Ph@v@pCdAjDPh@h@fBp@xBTp@dAjDDNBDz@jCb@nABLhBpFBLf@hBdAlDL`@l@fB`@hAv@`CXz@JZp@zBNh@FXBLZxALn@Hl@Fh@B\\@NB^B\\@Z@d@?n@Aj@Af@Ab@Cb@Gl@EZE\\EXEVGVEVGTCHIXUr@a@~@Q^KPOVo@z@QRo@n@m@h@[ZGFQPu@p@'
+  },
+  {
+    trips: [{displayName: 'S6'}],
+    mode: 'SUBURBAN',
+    from: {name: 'Bad Vilbel Bahnhof', lat: 50.188410000000005, lon: 8.739714},
+    to: {name: 'Bad Vilbel Südbahnhof', lat: 50.178474, lon: 8.732834},
+    departure: '2026-07-10T02:10:00Z',
+    arrival: '2026-07-10T02:12:00Z',
+    scheduledDeparture: '2026-07-10T02:10:00Z',
+    scheduledArrival: '2026-07-10T02:12:00Z',
+    realTime: true,
+    polyline:
+      'sliqH_~it@~Bv@nDnAXL|ElCl@Xd@RpAb@xCbAz@X~MnE|Al@\\LXNTN^Vd@`@f@d@ZX\\`@\\f@\\f@^p@\\p@Zt@Tn@\\`AZbAJV'
+  },
+  {
+    trips: [{displayName: 'S7'}],
+    mode: 'SUBURBAN',
+    from: {
+      name: 'Frankfurt (Main) Niederrad Bahnhof',
+      lat: 50.081089999999996,
+      lon: 8.637106
+    },
+    to: {name: 'Frankfurt (Main) Hauptbahnhof', lat: 50.106903, lon: 8.662241},
+    departure: '2026-07-10T01:59:00Z',
+    arrival: '2026-07-10T02:04:00Z',
+    scheduledDeparture: '2026-07-10T01:59:00Z',
+    scheduledArrival: '2026-07-10T02:04:00Z',
+    realTime: true,
+    polyline:
+      'ymtpH}|us@_BhAo@b@KHqAz@_ErCYR}@p@SLkBpAcAt@e@\\gGpEqDlCWPSLMHMHOHOHOFOHe@PIDSH[LoJrDSFcC~@m@TUJG@MD[HYDKBc@D[B]?W?]Am@Eg@Gk@Kc@Oc@Oe@Sw@e@_@[k@c@c@c@a@e@SWOUw@qAWi@CGWo@Sk@_@gAIU[eAg@aBsAoEi@gBy@mCmA{D_@mAWy@a@sAEMOi@Mc@Y}@aAeDMc@m@sBW}@iAyDWy@g@aB{@qCaBsFkA_ESq@K]{@{Cw@gCuBkHM_@Me@EOaAiDsBuHk@sBk@uB_@qAwA}Ee@_Be@cBg@cBc@{AAEe@{A_@iB]cBOs@SeAQ{@Qq@AGUu@[eAcAgDQk@eBmG'
+  },
+  {
+    trips: [{displayName: 'S8'}],
+    mode: 'SUBURBAN',
+    from: {
+      name: 'Frankfurt (Main) Flughafen Regionalbahnhof',
+      lat: 50.051143999999994,
+      lon: 8.571204
+    },
+    to: {
+      name: 'Frankfurt (Main) Gateway Gardens',
+      lat: 50.056582999999996,
+      lon: 8.594049
+    },
+    departure: '2026-07-10T02:00:00Z',
+    arrival: '2026-07-10T02:02:00Z',
+    scheduledDeparture: '2026-07-10T01:57:00Z',
+    scheduledArrival: '2026-07-10T01:59:00Z',
+    realTime: true,
+    polyline:
+      'srnpHaais@]uB{@mFw@}Eg@}Ca@uCOeAGg@Km@Gc@k@qDeAcGqAqF]{@sAcDiA}BeAgB]k@_@k@OWKOQ[IQGMO[Qc@Si@Ma@Kc@S{@O_AOcAQcBs@oGY}BMkAUmBMwAIkAEgACyA@gBB{@DaAFaBFuAJkD@UHuD'
+  },
+  {
+    trips: [{displayName: 'S8'}],
+    mode: 'SUBURBAN',
+    from: {
+      name: 'Frankfurt (Main) Gateway Gardens',
+      lat: 50.056582999999996,
+      lon: 8.594049
+    },
+    to: {
+      name: 'Frankfurt (Main) Stadion',
+      lat: 50.068220000000004,
+      lon: 8.632622
+    },
+    departure: '2026-07-10T02:03:00Z',
+    arrival: '2026-07-10T02:05:00Z',
+    scheduledDeparture: '2026-07-10T01:59:00Z',
+    scheduledArrival: '2026-07-10T02:03:00Z',
+    realTime: true,
+    polyline:
+      'utopHyoms@FiCNiG?MHgFDmBBwB@kDFwCFmCDgCF{BBwADqBBeC?eBC{@ImBQgBS_BUyA]aBi@qBy@}BWi@Uc@S_@CGWc@_@m@]c@m@m@mAcAw@i@YM}@c@w@Yg@K{B[eCB}A?e@@Y?sCKs@I}@Ou@Qy@[q@][Sy@m@{@w@aAiA]g@QWOYS]Sa@Q]Qc@Qc@Qg@Qg@Me@Oi@Kg@Mg@Mu@Mu@E[E_@E]E[Ek@Ek@CWAYAYCe@A[Ak@Ak@?y@AkDEaK?i@AcCAqD?gA?mAAmAAm@Am@CcACi@C_ACi@GsAAK[wGImBAWCa@C[OsBKeAMqAMcAKw@OgASkAGa@]kB]kBIg@a@qB'
+  },
+  {
+    trips: [{displayName: 'S8'}],
+    mode: 'SUBURBAN',
+    from: {
+      name: 'Frankfurt (Main) Stadion',
+      lat: 50.068220000000004,
+      lon: 8.632622
+    },
+    to: {
+      name: 'Frankfurt (Main) Niederrad Bahnhof',
+      lat: 50.080943999999995,
+      lon: 8.636954
+    },
+    departure: '2026-07-10T02:06:00Z',
+    arrival: '2026-07-10T02:08:00Z',
+    scheduledDeparture: '2026-07-10T02:03:00Z',
+    scheduledArrival: '2026-07-10T02:05:00Z',
+    realTime: true,
+    polyline:
+      'k}qpH{`us@SiAi@oCMm@o@gDAIa@wB_@kBaAgFCKe@_CEWe@{BQo@Me@Us@Sk@Wk@[s@Wc@MUS[OSYa@k@q@k@i@a@]u@g@i@Y{@_@[Iw@Qy@Kk@Em@?e@@k@DcAPq@Rg@NWLq@\\i@^EBm@b@}ApAeDbCiDbCgAv@kAt@iAr@}@l@kA~@}AlAYROJ_Ar@aAp@'
+  },
+  {
+    trips: [{displayName: 'S8'}],
+    mode: 'SUBURBAN',
+    from: {
+      name: 'Frankfurt (Main) Niederrad Bahnhof',
+      lat: 50.080943999999995,
+      lon: 8.636954
+    },
+    to: {
+      name: 'Frankfurt (Main) Hauptbahnhof tief',
+      lat: 50.10714,
+      lon: 8.662477
+    },
+    departure: '2026-07-10T02:09:00Z',
+    arrival: '2026-07-10T02:13:00Z',
+    scheduledDeparture: '2026-07-10T02:06:00Z',
+    scheduledArrival: '2026-07-10T02:12:00Z',
+    realTime: true,
+    polyline:
+      '{ltpH}{us@GDKF}@n@}@n@GBYRiAr@u@d@cAn@IFGDqAx@e@ZaAr@YPa@XaBlAc@\\mBtAKFgBrAoEdD_Ap@_BbAMHcBz@wI|DQFw@\\_A\\m@P]H[F[DUBYB[@]?Y?K?QAUAWCYE[EWGk@Oe@Q_@Oi@Wi@_@}@u@s@q@i@q@a@i@a@u@g@_A_@y@Ys@Sg@Qg@Sk@{@oCMc@IYwA_Fi@iBGUyBsHOg@i@mBK[q@_C}@yCuAyEwAuE{@oCc@wAWy@]gA[gAY_AWy@s@_CUu@Sq@a@qAu@gCW_A_@sAQi@]mAEKg@cBGWQo@iA{DUw@EMAE{AsFEQ]sAYkAOi@cAeEqAyEOo@g@iBmAgEcB_Gc@uAe@yAiAsDy@sCsAoEe@cBQk@AE'
+  },
+  {
+    trips: [{displayName: 'S8'}],
+    mode: 'SUBURBAN',
+    from: {
+      name: 'Frankfurt (Main) Südbahnhof',
+      lat: 50.09897000000001,
+      lon: 8.685764
+    },
+    to: {
+      name: 'Offenbach (Main)-Zentrum Hauptbahnhof',
+      lat: 50.098892000000006,
+      lon: 8.758987
+    },
+    departure: '2026-07-10T01:56:00Z',
+    arrival: '2026-07-10T02:02:00Z',
+    scheduledDeparture: '2026-07-10T01:56:00Z',
+    scheduledArrival: '2026-07-10T02:00:00Z',
+    realTime: true,
+    polyline:
+      's}wpH_m_t@K]_@gASk@]aAYw@M]Ui@Se@O_@EIc@}@Yk@KS_@q@a@w@u@cBk@yAa@qAIYGSU}@WoACGMs@g@oDWwBw@iG]mCIs@Gi@EWa@_Dk@kE[{BIm@AG{@uGSsBQuBAIKaBEy@KyCEaEEeDAkCAeBAsB?kBAgAAkB?o@AgDIuZE_HAoA?y@AgDC{GAaBUgLKgEc@iSg@aUCcACiAA}A?iFJcEZqFn@wFr@kERcAVcAPw@BId@oBj@}BpB_I~@uDH[pD}N`@_Bb@gBJe@bFmSb@cB~AsGDQDKj@aCH]FYLm@Nu@FYBQPiANmAFk@Do@Fo@Bi@Bk@Bi@@e@@]@uA?mAAeAC{@CcAG}@Em@?IU{CG_AAK[cEUsCG{@QeC'
+  },
+  {
+    trips: [{displayName: 'S8'}],
+    mode: 'SUBURBAN',
+    from: {
+      name: 'Offenbach (Main)-Zentrum Hauptbahnhof',
+      lat: 50.098892000000006,
+      lon: 8.758987
+    },
+    to: {
+      name: 'Offenbach (Main)-Offenbach Ost Ostbahnhof',
+      lat: 50.10275300000001,
+      lon: 8.784505
+    },
+    departure: '2026-07-10T02:03:00Z',
+    arrival: '2026-07-10T02:04:00Z',
+    scheduledDeparture: '2026-07-10T02:01:00Z',
+    scheduledArrival: '2026-07-10T02:04:00Z',
+    realTime: true,
+    polyline:
+      'k}wpHqvmt@QuBWsCGu@Gg@Go@Go@E_@Eg@i@qFQmBKgAQeBWmC[iDMsAOwAAK?EAEAI?EO{A?E[_DAKE]e@cF_@sDI}@_@}DIm@YuCy@uIIu@]iDe@cFAMOaBAEk@}FIcAI_AMeBIqAEiASkFAOO{EE}@EmAGyA?KAQEqA'
+  },
+  {
+    trips: [{displayName: 'S8'}],
+    mode: 'SUBURBAN',
+    from: {
+      name: 'Offenbach (Main)-Offenbach Ost Ostbahnhof',
+      lat: 50.10275300000001,
+      lon: 8.784505
+    },
+    to: {name: 'Mühlheim (Main) Bahnhof', lat: 50.11932, lon: 8.83818},
+    departure: '2026-07-10T02:05:00Z',
+    arrival: '2026-07-10T02:08:00Z',
+    scheduledDeparture: '2026-07-10T02:05:00Z',
+    scheduledArrival: '2026-07-10T02:09:00Z',
+    realTime: true,
+    polyline:
+      'wuxpHavrt@Co@Ca@KaCI{AWyDMuAOwAIm@Iq@UyAW}AMw@I]]eB_@{Ae@iBs@_CeAgDa@uAoBeGo@qB{@oCsFaQOg@uFiQCIK[_IyVq@sBoA}DCI}AeFs@aCaDmLkCsJAEcBkGc@}Ac@aBgA_EmC_KuFuScC_JkAgEq@oCU}@[{AWsAI]AKKi@SwA]aCQyAOsAKkAGq@Cc@IqAI_BE_AAYCkAK}CE}AKsEEeACy@A{@WyJEuBO_G'
+  },
+  {
+    trips: [{displayName: 'S9'}],
+    mode: 'SUBURBAN',
+    from: {name: 'Raunheim Bahnhof', lat: 50.009530000000005, lon: 8.454294},
+    to: {name: 'Kelsterbach Bahnhof', lat: 50.061855, lon: 8.528861999999998},
+    departure: '2026-07-10T02:05:00Z',
+    arrival: '2026-07-10T02:09:00Z',
+    scheduledDeparture: '2026-07-10T02:04:00Z',
+    scheduledArrival: '2026-07-10T02:09:00Z',
+    realTime: true,
+    polyline:
+      'qnfpHkfrr@cAyB[q@Sa@GOe@aAoAmCEIEIQ_@uCgGgBmDm@eAiBaD_BqCS_@u@mA{AaCoCcEsAqBsAkBmBgCyBsC{CuDyCuD{@eAiEkFW[EGaAmAeLoNoCiDmCeDeKkMkB}BsDsEa@g@g@m@gAuAqCiD}MqPiCcDiCaD_AkAcDaE}CuDmBcCm@u@}CyDuUuYcBsBgDgEgDcEgAuAgAsAeBwBwAkB_BwB}A{B}A_C}AcCg@w@_A{Aq@kAq@kAmA{BmA}Bi@eAg@aAkAeCcAuBo@yAQ]cBsDq@{AkM}XqHgPe@eAYm@O_@e@cAy@gBw@cBkBeEyA_D{AgDwCoG_BmD_BkDyAeDiB_EeCqF{@sBYo@cAiCi@sAg@kAa@_Aa@_A[u@Sg@Sk@s@oBQa@Ws@Ug@c@cAO]'
+  },
+  {
+    trips: [{displayName: 'S9'}],
+    mode: 'SUBURBAN',
+    from: {name: 'Kelsterbach Bahnhof', lat: 50.061855, lon: 8.528861999999998},
+    to: {
+      name: 'Frankfurt (Main) Flughafen Regionalbahnhof',
+      lat: 50.051143999999994,
+      lon: 8.571204
+    },
+    departure: '2026-07-10T02:10:00Z',
+    arrival: '2026-07-10T02:14:00Z',
+    scheduledDeparture: '2026-07-10T02:09:00Z',
+    scheduledArrival: '2026-07-10T02:13:00Z',
+    realTime: true,
+    polyline:
+      'ouppHox`s@EIa@{@i@eAm@eAa@q@o@iAS[w@yAq@uA[q@Ys@Si@Si@e@wA]kAc@aBCMIWI[e@wB[{AWoAWaBOmAMy@Ec@MqAI{@KeAGeAGgAGgAEmAEoAE{BAa@?oAAoA?qA@qADkD@i@Bi@Bm@Bg@Dq@Ds@Fo@Fq@Hk@Fm@Hi@L_APy@Nw@R}@Le@J]HYRq@Ro@Tm@Vo@Rc@Pa@h@cAf@{@f@w@^g@\\c@`@c@^a@FETU\\[n@e@l@a@l@]n@[`@QbA[dAY|@O^EXA^A\\A\\Ah@@L?X@XBd@Db@Fv@Lv@Nt@Pz@TjA\\rAZtAZh@Hh@F|@H\\@\\@|@Az@En@Gn@Il@Ml@Qj@Qh@Sj@Wh@Yv@g@\\UZWZWZ[XYZ]TWTYj@u@Zg@Zg@Xg@P_@Ra@N]rAkDX_AV}@R}@RaADQVaB\\eCTcCNiCHeDAoBAyBKyCMoCoAsSCYYqFSoCQqBu@cFi@cDw@aF'
+  },
+  {
+    trips: [{displayName: 'S8'}],
+    mode: 'SUBURBAN',
+    from: {
+      name: 'Offenbach (Main)-Offenbach Ost Ostbahnhof',
+      lat: 50.10275300000001,
+      lon: 8.784505
+    },
+    to: {
+      name: 'Offenbach (Main)-Zentrum Marktplatz',
+      lat: 50.10530500000001,
+      lon: 8.764909999999999
+    },
+    departure: '2026-07-10T02:00:00Z',
+    arrival: '2026-07-10T02:01:00Z',
+    scheduledDeparture: '2026-07-10T01:58:00Z',
+    scheduledArrival: '2026-07-10T02:00:00Z',
+    realTime: true,
+    polyline:
+      'qtxpHgvrt@@ZDnA@V@p@Bx@@n@?J@b@@PFpE@N@j@@j@Bf@J`DFfA`@rGF`B@`A?n@A`@A`@Ex@Gv@Ed@CPQlA[dB{AbHg@`CU`Ai@fCoBfJs@~CUx@a@|A]lAU~@_@nB_@bCg@lF[dC'
+  },
+  {
+    trips: [{displayName: 'S8'}],
+    mode: 'SUBURBAN',
+    from: {
+      name: 'Offenbach (Main)-Zentrum Marktplatz',
+      lat: 50.10530500000001,
+      lon: 8.764909999999999
+    },
+    to: {
+      name: 'Offenbach (Main)-Westend Ledermuseum',
+      lat: 50.106030000000004,
+      lon: 8.751166
+    },
+    departure: '2026-07-10T02:02:00Z',
+    arrival: '2026-07-10T02:03:00Z',
+    scheduledDeparture: '2026-07-10T02:01:00Z',
+    scheduledArrival: '2026-07-10T02:02:00Z',
+    realTime: true,
+    polyline:
+      'kfypHi|nt@Gb@[vBc@rD}@|GIr@QnAQzACZGr@CVKhBA^EvB?V@x@@jA@n@DxA@RHjCF~AB`AJlCD`AZnG\\vH@l@Bv@@n@'
+  },
+  {
+    trips: [{displayName: 'S8'}],
+    mode: 'SUBURBAN',
+    from: {
+      name: 'Offenbach (Main)-Westend Ledermuseum',
+      lat: 50.106030000000004,
+      lon: 8.751166
+    },
+    to: {
+      name: 'Offenbach (Main)-Kaiserlei Kaiserlei',
+      lat: 50.105267,
+      lon: 8.738490999999998
+    },
+    departure: '2026-07-10T02:04:00Z',
+    arrival: '2026-07-10T02:05:00Z',
+    scheduledDeparture: '2026-07-10T02:03:00Z',
+    scheduledArrival: '2026-07-10T02:04:00Z',
+    realTime: true,
+    polyline:
+      'kiypHyelt@JjDRnI@PDlCBbBBvC?JJ`E?FDtAD|A@X@d@@`@?^?v@@Z?Z@X@^@j@HjCJbDDtA?FF|B?LFzBJvE'
+  },
+  {
+    trips: [{displayName: 'S8'}],
+    mode: 'SUBURBAN',
+    from: {
+      name: 'Offenbach (Main)-Kaiserlei Kaiserlei',
+      lat: 50.105267,
+      lon: 8.738490999999998
+    },
+    to: {
+      name: 'Frankfurt (Main) Mühlberg',
+      lat: 50.101966999999995,
+      lon: 8.700644
+    },
+    departure: '2026-07-10T02:05:00Z',
+    arrival: '2026-07-10T02:08:00Z',
+    scheduledDeparture: '2026-07-10T02:04:00Z',
+    scheduledArrival: '2026-07-10T02:07:00Z',
+    realTime: true,
+    polyline:
+      '}dypHqvit@B`BLxE@t@?D@PFxBFzBHrD@hANbN?JLzJHhF@LFtD?L@j@Bz@FjG@zBB|B?HJvDHhCHvBN`ENzDHdDNzGBtLBzE?H@r@\\pG\\hC`@zBj@xB`@fA`@hAxAnDDJfAjC\\~@FNPd@Xz@VdAVfA@F^fCTxBHpABbA@h@?V?|@Az@AHAd@Cx@Eb@GfAE`@KlAMdAYjBOx@Ml@Mf@GX'
+  },
+  {
+    trips: [{displayName: 'S8'}],
+    mode: 'SUBURBAN',
+    from: {
+      name: 'Frankfurt (Main) Mühlberg',
+      lat: 50.101966999999995,
+      lon: 8.700644
+    },
+    to: {
+      name: 'Frankfurt (Main) Ostendstraße',
+      lat: 50.112495,
+      lon: 8.697118999999999
+    },
+    departure: '2026-07-10T02:08:00Z',
+    arrival: '2026-07-10T02:10:00Z',
+    scheduledDeparture: '2026-07-10T02:07:00Z',
+    scheduledArrival: '2026-07-10T02:09:00Z',
+    realTime: true,
+    polyline:
+      'gpxpH_jbt@EPKh@aAnCEHa@|@ADk@v@g@h@}@|@q@^WNy@\\g@Hq@HU@cBEOAUAi@Io@Iw@OaBYw@MkCe@m@M_B[IAqAWuDSyADyAX_Bh@gAn@g@f@KJy@x@i@h@GF[\\KHq@r@'
+  },
+  {
+    trips: [{displayName: 'S1'}],
+    mode: 'SUBURBAN',
+    from: {
+      name: 'Hattersheim (Main) Bahnhof',
+      lat: 50.06711000000001,
+      lon: 8.488877999999998
+    },
+    to: {
+      name: 'Frankfurt (Main) Sindlingen Bahnhof',
+      lat: 50.087303,
+      lon: 8.512084000000002
+    },
+    departure: '2026-07-10T02:01:00Z',
+    arrival: '2026-07-10T02:03:00Z',
+    scheduledDeparture: '2026-07-10T01:59:00Z',
+    scheduledArrival: '2026-07-10T02:01:00Z',
+    realTime: true,
+    polyline:
+      'ovqpHk~xr@[_@{@eAsA}Ac@c@q@w@k@k@]_@WYqB_CoGwHcFgGyQcUaT{VqA_BsCmDuAcBcUsXaNiPgDcEmAwAg@o@'
+  },
+  {
+    trips: [{displayName: 'S1'}],
+    mode: 'SUBURBAN',
+    from: {
+      name: 'Frankfurt (Main) Sindlingen Bahnhof',
+      lat: 50.087303,
+      lon: 8.512084000000002
+    },
+    to: {
+      name: 'Frankfurt (Main) Höchst Bahnhof',
+      lat: 50.10242,
+      lon: 8.542372999999998
+    },
+    departure: '2026-07-10T02:04:00Z',
+    arrival: '2026-07-10T02:07:00Z',
+    scheduledDeparture: '2026-07-10T02:02:00Z',
+    scheduledArrival: '2026-07-10T02:08:00Z',
+    realTime: true,
+    polyline:
+      'utupHmo}r@GIMO]c@EC{AiBaAmAaD{DwNeQ{AcBcAcAwBkByAsAaA{@oAwAa@k@a@k@i@aAc@{@c@aAa@eAc@iAcAmC_DeIIWWu@Wu@y@gCY_AwAeFEMM]_@oAYy@aA{CaA_DSm@CKmAcEeAqDmAsEe@gBqCcLYoAUcAUeAq@uD_@yBOcAIy@MsAIiAMsBMqBKkBOgCKcBC_@'
+  },
+  {
+    trips: [{displayName: 'S1'}],
+    mode: 'SUBURBAN',
+    from: {
+      name: 'Frankfurt (Main) Höchst Bahnhof',
+      lat: 50.10242,
+      lon: 8.542372999999998
+    },
+    to: {name: 'Frankfurt (Main) Nied Bahnhof', lat: 50.102066, lon: 8.572288},
+    departure: '2026-07-10T02:09:00Z',
+    arrival: '2026-07-10T02:11:00Z',
+    scheduledDeparture: '2026-07-10T02:09:00Z',
+    scheduledArrival: '2026-07-10T02:11:00Z',
+    realTime: true,
+    polyline:
+      'gsxpHylcs@IqASsDWaEKoB_@gGEy@KyASoDEu@EwACa@OkHKyE?YE_BCsAAu@?oB@mBFwHBiC?uFDgV?]DiX?{A?gBB}ABoABw@Bo@Bi@Dg@Dm@Fk@Fe@Fe@Fe@Ji@Lu@ZaB@KXuAVoAf@wBd@qB'
+  },
+  {
+    trips: [{displayName: 'S1'}],
+    mode: 'SUBURBAN',
+    from: {
+      name: 'Offenbach (Main)-Kaiserlei Kaiserlei',
+      lat: 50.105267,
+      lon: 8.738490999999998
+    },
+    to: {
+      name: 'Frankfurt (Main) Mühlberg',
+      lat: 50.101966999999995,
+      lon: 8.700644
+    },
+    departure: '2026-07-10T01:59:00Z',
+    arrival: '2026-07-10T02:02:00Z',
+    scheduledDeparture: '2026-07-10T01:59:00Z',
+    scheduledArrival: '2026-07-10T02:01:00Z',
+    realTime: true,
+    polyline:
+      '}dypHqvit@B`BLxE@t@?D@PFxBFzBHrD@hANbN?JLzJHhF@LFtD?L@j@Bz@FjG@zBB|B?HJvDHhCHvBN`ENzDHdDNzGBtLBzE?H@r@\\pG\\hC`@zBj@xB`@fA`@hAxAnDDJfAjC\\~@FNPd@Xz@VdAVfA@F^fCTxBHpABbA@h@?V?|@Az@AHAd@Cx@Eb@GfAE`@KlAMdAYjBOx@Ml@Mf@GX'
+  },
+  {
+    trips: [{displayName: 'S1'}],
+    mode: 'SUBURBAN',
+    from: {
+      name: 'Frankfurt (Main) Mühlberg',
+      lat: 50.101966999999995,
+      lon: 8.700644
+    },
+    to: {
+      name: 'Frankfurt (Main) Ostendstraße',
+      lat: 50.112495,
+      lon: 8.697118999999999
+    },
+    departure: '2026-07-10T02:03:00Z',
+    arrival: '2026-07-10T02:04:00Z',
+    scheduledDeparture: '2026-07-10T02:02:00Z',
+    scheduledArrival: '2026-07-10T02:04:00Z',
+    realTime: true,
+    polyline:
+      'gpxpH_jbt@EPKh@aAnCEHa@|@ADk@v@g@h@}@|@q@^WNy@\\g@Hq@HU@cBEOAUAi@Io@Iw@OaBYw@MkCe@m@M_B[IAqAWuDSyADyAX_Bh@gAn@g@f@KJy@x@i@h@GF[\\KHq@r@'
+  },
+  {
+    trips: [{displayName: 'S1'}],
+    mode: 'SUBURBAN',
+    from: {
+      name: 'Frankfurt (Main) Ostendstraße',
+      lat: 50.112495,
+      lon: 8.697118999999999
+    },
+    to: {
+      name: 'Frankfurt (Main) Konstablerwache',
+      lat: 50.114708,
+      lon: 8.684584000000001
+    },
+    departure: '2026-07-10T02:05:00Z',
+    arrival: '2026-07-10T02:06:00Z',
+    scheduledDeparture: '2026-07-10T02:04:00Z',
+    scheduledArrival: '2026-07-10T02:06:00Z',
+    realTime: true,
+    polyline:
+      'crzpH_tat@UVQNKLg@f@c@h@g@l@[b@]l@Yj@IRYr@Wr@ADEPQn@CFQt@Ov@GXG`@Mx@Ih@UrBAHEb@AXCXKxBEhB?LAX?bB?\\?z@@p@@z@RnCFv@Bh@@Z?pD?b@?P?h@AbC?H?FAjB?nA@z@'
+  },
+  {
+    trips: [{displayName: 'S1'}],
+    mode: 'SUBURBAN',
+    from: {
+      name: 'Frankfurt (Main) Konstablerwache',
+      lat: 50.114708,
+      lon: 8.684584000000001
+    },
+    to: {
+      name: 'Frankfurt (Main) Hauptwache',
+      lat: 50.114059999999995,
+      lon: 8.678142999999999
+    },
+    departure: '2026-07-10T02:07:00Z',
+    arrival: '2026-07-10T02:08:00Z',
+    scheduledDeparture: '2026-07-10T02:06:00Z',
+    scheduledArrival: '2026-07-10T02:07:00Z',
+    realTime: true,
+    polyline:
+      'w_{pHue_t@?Z@TB|@Bf@B`@HbAFl@D`@Jx@@FBJRtADXHl@PlAB^Fj@BRHdBDx@A^GpBEvAEdAAf@AH?HAR'
+  },
+  {
+    trips: [{displayName: 'S1'}],
+    mode: 'SUBURBAN',
+    from: {
+      name: 'Frankfurt (Main) Hauptwache',
+      lat: 50.114059999999995,
+      lon: 8.678142999999999
+    },
+    to: {
+      name: 'Frankfurt (Main) Taunusanlage',
+      lat: 50.113482999999995,
+      lon: 8.668766
+    },
+    departure: '2026-07-10T02:08:00Z',
+    arrival: '2026-07-10T02:09:00Z',
+    scheduledDeparture: '2026-07-10T02:08:00Z',
+    scheduledArrival: '2026-07-10T02:09:00Z',
+    realTime: true,
+    polyline:
+      'e|zpHm}}s@Ct@Ex@Ex@Ex@GdAI|@AHMrAQvAOxA_@hDSjBCZCh@GtB@v@@fABf@Dp@@HT`BHf@^fBPh@Tt@^x@z@`BJPBD`@p@DF'
+  },
+  {
+    trips: [{displayName: 'S1'}],
+    mode: 'SUBURBAN',
+    from: {
+      name: 'Frankfurt (Main) Taunusanlage',
+      lat: 50.113482999999995,
+      lon: 8.668766
+    },
+    to: {
+      name: 'Frankfurt (Main) Hauptbahnhof tief',
+      lat: 50.10714,
+      lon: 8.662477
+    },
+    departure: '2026-07-10T02:10:00Z',
+    arrival: '2026-07-10T02:11:00Z',
+    scheduledDeparture: '2026-07-10T02:09:00Z',
+    scheduledArrival: '2026-07-10T02:11:00Z',
+    realTime: true,
+    polyline:
+      'wxzpH_b|s@z@rAz@jA~@dA`BhBdCzAFBjAf@THf@PdAXn@Px@ZRHnAn@lAz@LH~@|@DDDFFFV`@Xd@fApBx@bB@DBDFR^lAXdA'
+  },
+  {
+    trips: [{displayName: '16'}],
+    mode: 'TRAM',
+    from: {
+      name: 'Frankfurt (Main) Platz der Republik',
+      lat: 50.108917000000005,
+      lon: 8.661724
+    },
+    to: {name: 'Frankfurt (Main) Hauptbahnhof', lat: 50.10762, lon: 8.664683},
+    departure: '2026-07-10T02:04:00Z',
+    arrival: '2026-07-10T02:06:00Z',
+    scheduledDeparture: '2026-07-10T02:00:00Z',
+    scheduledArrival: '2026-07-10T02:02:00Z',
+    realTime: true,
+    polyline: 'y{ypH{vzs@DKVu@Ne@j@gBRm@HUTy@Ha@Fe@BU@IBQBIBMFQFODGx@gA'
+  },
+  {
+    trips: [{displayName: '16'}],
+    mode: 'TRAM',
+    from: {name: 'Frankfurt (Main) Hauptbahnhof', lat: 50.10762, lon: 8.664683},
+    to: {name: 'Frankfurt (Main) Baseler Platz', lat: 50.10425, lon: 8.664706},
+    departure: '2026-07-10T02:06:00Z',
+    arrival: '2026-07-10T02:08:00Z',
+    scheduledDeparture: '2026-07-10T02:02:00Z',
+    scheduledArrival: '2026-07-10T02:04:00Z',
+    realTime: true,
+    polyline:
+      'wsypHmi{s@V]DCPWNMFGHEHEDADCLEJADAHAJAL?L?J@F@TBVDH@D@^DRBL@VH^Jb@Nl@NXDVDTBP@bA@n@B'
+  },
+  {
+    trips: [{displayName: '16'}],
+    mode: 'TRAM',
+    from: {
+      name: 'Frankfurt (Main) Baseler Platz',
+      lat: 50.10425,
+      lon: 8.664706
+    },
+    to: {
+      name: 'Frankfurt (Main) Friedensbrücke',
+      lat: 50.099464,
+      lon: 8.668583
+    },
+    departure: '2026-07-10T02:08:00Z',
+    arrival: '2026-07-10T02:10:00Z',
+    scheduledDeparture: '2026-07-10T02:04:00Z',
+    scheduledArrival: '2026-07-10T02:06:00Z',
+    realTime: true,
+    polyline:
+      'q~xpHqi{s@H?T@P@D?F?|ABT?VCTCTGRING\\OTKPITQRUFI`BuB|C{D|CwDRULSBENWDKDIDGFKFIDGZ[HM'
+  },
+  {
+    trips: [{displayName: '16'}],
+    mode: 'TRAM',
+    from: {
+      name: 'Frankfurt (Main) Friedensbrücke',
+      lat: 50.099464,
+      lon: 8.668583
+    },
+    to: {
+      name: 'Frankfurt (Main) Otto-Hahn-Platz',
+      lat: 50.101943999999996,
+      lon: 8.676072
+    },
+    departure: '2026-07-10T02:10:00Z',
+    arrival: '2026-07-10T02:12:00Z',
+    scheduledDeparture: '2026-07-10T02:06:00Z',
+    scheduledArrival: '2026-07-10T02:08:00Z',
+    realTime: true,
+    polyline:
+      'y`xpH}a|s@FI@EDI?IBK?E?E?KAGAGAGGUU{@o@}BCKcCaJeBoGkAiEQo@CGKi@EWEUEQe@aB]kA'
+  },
+  {
+    trips: [{displayName: '18'}],
+    mode: 'TRAM',
+    from: {
+      name: 'Frankfurt (Main) Stresemannallee Bahnhof',
+      lat: 50.09465,
+      lon: 8.671354999999998
+    },
+    to: {
+      name: 'Frankfurt (Main) Friedensbrücke',
+      lat: 50.099106000000006,
+      lon: 8.669095
+    },
+    departure: '2026-07-10T01:59:00Z',
+    arrival: '2026-07-10T02:01:00Z',
+    scheduledDeparture: '2026-07-10T01:59:00Z',
+    scheduledArrival: '2026-07-10T02:01:00Z',
+    realTime: true,
+    polyline:
+      'obwpHcr|s@K@[@M@uAFaABM?]@yCP}AJq@NOH]PMJMLMNcAlAYZMNKJSRIFGHOPaAhAMNCD'
+  },
+  {
+    trips: [{displayName: '18'}],
+    mode: 'TRAM',
+    from: {
+      name: 'Frankfurt (Main) Friedensbrücke',
+      lat: 50.099106000000006,
+      lon: 8.669095
+    },
+    to: {
+      name: 'Frankfurt (Main) Otto-Hahn-Platz',
+      lat: 50.101943999999996,
+      lon: 8.676072
+    },
+    departure: '2026-07-10T02:01:00Z',
+    arrival: '2026-07-10T02:03:00Z',
+    scheduledDeparture: '2026-07-10T02:01:00Z',
+    scheduledArrival: '2026-07-10T02:03:00Z',
+    realTime: true,
+    polyline:
+      'm~wpH}d|s@EBEDGBE?E?E?ECECGGEGCGAEUy@o@}BCKcCaJeBoGkAiEQo@CGKi@EWEUEQe@aB]kA'
+  },
+  {
+    trips: [{displayName: '18'}],
+    mode: 'TRAM',
+    from: {
+      name: 'Frankfurt (Main) Otto-Hahn-Platz',
+      lat: 50.101943999999996,
+      lon: 8.676072
+    },
+    to: {
+      name: 'Frankfurt (Main) Schweizer-/Gartenstraße',
+      lat: 50.103176000000005,
+      lon: 8.679307
+    },
+    departure: '2026-07-10T02:03:00Z',
+    arrival: '2026-07-10T02:04:00Z',
+    scheduledDeparture: '2026-07-10T02:03:00Z',
+    scheduledArrival: '2026-07-10T02:04:00Z',
+    realTime: true,
+    polyline: 'kpxpHep}s@AEIWM]W}@GQ{BqI_AcDAE'
+  },
+  {
+    trips: [{displayName: '18'}],
+    mode: 'TRAM',
+    from: {
+      name: 'Frankfurt (Main) Schweizer-/Gartenstraße',
+      lat: 50.103176000000005,
+      lon: 8.679307
+    },
+    to: {
+      name: 'Frankfurt (Main) Schwanthalerstraße',
+      lat: 50.10114,
+      lon: 8.681192999999999
+    },
+    departure: '2026-07-10T02:04:00Z',
+    arrival: '2026-07-10T02:06:00Z',
+    scheduledDeparture: '2026-07-10T02:04:00Z',
+    scheduledArrival: '2026-07-10T02:06:00Z',
+    realTime: true,
+    polyline: 'cxxpHmd~s@AEAIAG?E?E?G@G@GBE@EDEDGpDiCFEXSfAu@XSHEjAy@'
+  },
+  {
+    trips: [{displayName: '18'}],
+    mode: 'TRAM',
+    from: {
+      name: 'Frankfurt (Main) Schwanthalerstraße',
+      lat: 50.10114,
+      lon: 8.681192999999999
+    },
+    to: {
+      name: 'Frankfurt (Main) Südbahnhof',
+      lat: 50.099940000000004,
+      lon: 8.685953
+    },
+    departure: '2026-07-10T02:06:00Z',
+    arrival: '2026-07-10T02:08:00Z',
+    scheduledDeparture: '2026-07-10T02:06:00Z',
+    scheduledArrival: '2026-07-10T02:08:00Z',
+    realTime: true,
+    polyline:
+      'ekxpHsp~s@d@]~DqCjBqAfA}@HIDEDG@EBG@I@M@KAIAKCMAG_BqESk@I[CGCOCQCKAKAGAMESISGUUq@CGCG'
+  },
+  {
+    trips: [{displayName: '18'}],
+    mode: 'TRAM',
+    from: {
+      name: 'Frankfurt (Main) Südbahnhof',
+      lat: 50.099940000000004,
+      lon: 8.685953
+    },
+    to: {
+      name: 'Frankfurt (Main) Brücken-/Textorstraße',
+      lat: 50.101696,
+      lon: 8.687046
+    },
+    departure: '2026-07-10T02:08:00Z',
+    arrival: '2026-07-10T02:09:00Z',
+    scheduledDeparture: '2026-07-10T02:08:00Z',
+    scheduledArrival: '2026-07-10T02:09:00Z',
+    realTime: true,
+    polyline:
+      '}cxpH{m_t@AGEICEECEEEAE?G?G@E@KFGBE@I?GAqCm@ICGCECIGMMKOGOISGSOo@'
+  }
+];

--- a/themes/horizon/trains-reference.mjs
+++ b/themes/horizon/trains-reference.mjs
@@ -14,12 +14,15 @@ import {
   CAR_STD,
   CONSIST_CARS,
   consistOf,
+  decodePolyline,
   DEFAULT_CARS,
   parseBoard,
+  parseTrips,
+  pathPoint,
   providerFor,
   trainAt
 } from './trains.js';
-import {BOARD_FIXTURE, BOAT_FIXTURE} from './trains-fixture.mjs';
+import {BOARD_FIXTURE, BOAT_FIXTURE, TRIPS_FIXTURE} from './trains-fixture.mjs';
 
 let fail = 0;
 const check = (name, ok, detail) => {
@@ -208,23 +211,118 @@ const journeys = parseBoard(BOARD_FIXTURE);
 }
 
 {
-  // Scope: location-specific APIs are only called inside their
-  // coverage - Interlaken and border Basel resolve the Swiss
-  // provider, Paris and New York resolve NONE (no idle traffic).
+  // Scope AND order: the Swiss national board (richer metadata)
+  // wins inside its bbox; everywhere else the worldwide GTFS
+  // aggregator answers - each view calls exactly ONE provider.
   const ch = providerFor(46.69, 7.87);
   const basel = providerFor(47.55, 7.59);
+  const paris = providerFor(48.85, 2.35);
+  const nyc = providerFor(40.71, -74.0);
   const ok =
     ch &&
     ch.name === 'transport.opendata.ch' &&
+    ch.kind === 'board' &&
     basel === ch &&
-    providerFor(48.85, 2.35) === null &&
-    providerFor(40.71, -74.0) === null &&
+    paris &&
+    paris.name === 'transitous.org' &&
+    paris.kind === 'trips' &&
+    nyc === paris &&
     ch.boardURL('8507492').includes('stationboard') &&
-    ch.locationsURL(46.69, 7.87).includes('locations');
+    paris.tripsURL(48.85, 2.35, 1770000000000).includes('map/trips');
   check(
-    'provider scope',
+    'provider scope and order',
     ok,
-    'Interlaken and Basel resolve the Swiss provider; Paris and New York resolve none - outside a scope the API is never called'
+    'Interlaken and Basel resolve the Swiss board; Paris and New York fall through to the worldwide aggregator - one provider per view, never more'
+  );
+}
+
+{
+  // The polyline decoder against the CANONICAL documented example
+  // (the shared GTFS encoding): '_p~iF~ps|U_ulLnnqC_mqNvxq`@'
+  // decodes to (38.5,-120.2) (40.7,-120.95) (43.252,-126.453).
+  const p = decodePolyline('_p~iF~ps|U_ulLnnqC_mqNvxq`@');
+  const want = [
+    [38.5, -120.2],
+    [40.7, -120.95],
+    [43.252, -126.453]
+  ];
+  const exact =
+    p.length === 3 &&
+    p.every(
+      (q, i) =>
+        Math.abs(q[0] - want[i][0]) < 1e-9 && Math.abs(q[1] - want[i][1]) < 1e-9
+    );
+  check(
+    'polyline decoder',
+    exact,
+    'the documented reference polyline decodes to its three published coordinates exactly'
+  );
+}
+
+{
+  // Path interpolation by ARC LENGTH: an L of 300 m north then
+  // 100 m east - f = 0.5 sits at 200 m up the FIRST leg (half the
+  // 400 m total), not at the middle vertex.
+  const mLat = 111320;
+  const path = [
+    [46.7, 7.9],
+    [46.7 + 300 / mLat, 7.9],
+    [
+      46.7 + 300 / mLat,
+      7.9 + 100 / (mLat * Math.cos(((46.7 + 300 / mLat) * Math.PI) / 180))
+    ]
+  ];
+  const half = pathPoint(path, 0.5);
+  const start = pathPoint(path, 0);
+  const end = pathPoint(path, 1);
+  const ok =
+    Math.abs(half.lat - (46.7 + 200 / mLat)) < 1e-9 &&
+    Math.abs(half.lon - 7.9) < 1e-9 &&
+    start.lat === 46.7 &&
+    Math.abs(end.lon - path[2][1]) < 1e-12;
+  check(
+    'arc-length path point',
+    ok,
+    'f = 0.5 on a 300 m + 100 m L sits exactly 200 m up the first leg; f = 0 and f = 1 are the endpoints'
+  );
+}
+
+{
+  // The LIVE transitous fixture: 57 Frankfurt rail legs parse to
+  // the SAME journey shape the boards produce - the ICEs by name,
+  // modes mapped to the one consist ladder, real-time flags
+  // carried, every leg with its decoded route shape - and trainAt
+  // follows that shape: mid-leg the position must sit ON the
+  // polyline (near neither endpoint on a curved route).
+  const legs = parseTrips(TRIPS_FIXTURE);
+  const cats = new Set(legs.map((l) => l.cat));
+  const ice = legs.find((l) => /^ICE/.test(l.label));
+  const rt = legs.filter((l) => l.realTime).length;
+  const withPath = legs.filter((l) => l.path && l.path.length >= 2).length;
+  const mid = ice
+    ? trainAt(ice, (ice.stops[0].depMs + ice.stops[1].arrMs) / 2)
+    : null;
+  const onPath =
+    mid &&
+    ice.path.some(
+      (q) => Math.abs(q[0] - mid.lat) < 0.02 && Math.abs(q[1] - mid.lon) < 0.02
+    );
+  const ok =
+    legs.length >= 50 &&
+    ice &&
+    cats.has('ICE') &&
+    cats.has('S') &&
+    rt > 20 &&
+    withPath === legs.length &&
+    legs.every(
+      (l) => l.stops.length === 2 && l.stops[1].arrMs > l.stops[0].depMs
+    ) &&
+    legs.every((l) => l.consist.cars >= 1) &&
+    onPath;
+  check(
+    'live transitous legs',
+    ok,
+    `${legs.length} Frankfurt rail legs (${[...cats].join('/')}), ${rt} real-time, every one carrying its decoded route shape; ${ice ? ice.label : '?'} mid-leg rides ON its polyline`
   );
 }
 

--- a/themes/horizon/trains.js
+++ b/themes/horizon/trains.js
@@ -39,6 +39,7 @@
 export const PROVIDERS = [
   {
     name: 'transport.opendata.ch',
+    kind: 'board',
     bbox: [45.6, 5.8, 47.95, 10.7],
     locationsURL: (lat, lon) =>
       'https://transport.opendata.ch/v1/locations?type=station&x=' +
@@ -48,6 +49,35 @@ export const PROVIDERS = [
     boardURL: (id) =>
       'https://transport.opendata.ch/v1/stationboard?limit=10&id=' +
       encodeURIComponent(id)
+  },
+  {
+    // The worldwide fallback: transitous.org aggregates public
+    // GTFS feeds globally (keyless, CORS-open). Its scope IS the
+    // world; national boards richer in metadata stay ahead of it
+    // in this registry. ONE box query around the view, a short
+    // window, real route shapes included.
+    name: 'transitous.org',
+    kind: 'trips',
+    bbox: [-90, -180, 90, 180],
+    tripsURL: (lat, lon, nowMs) => {
+      const d = 0.075; // ~8 km - the visible box
+      const iso = (t) => new Date(t).toISOString().slice(0, 19) + 'Z';
+      return (
+        'https://api.transitous.org/api/v6/map/trips?zoom=11&precision=5' +
+        '&max=' +
+        (lat + d).toFixed(4) +
+        ',' +
+        (lon - d).toFixed(4) +
+        '&min=' +
+        (lat - d).toFixed(4) +
+        ',' +
+        (lon + d).toFixed(4) +
+        '&startTime=' +
+        iso(nowMs) +
+        '&endTime=' +
+        iso(nowMs + 15 * 60000)
+      );
+    }
   }
 ];
 
@@ -112,6 +142,126 @@ export const DEFAULT_CARS = 3;
 // size); rendering reuses the gated vessels.js passenger hull.
 export const BOAT_CATS = new Set(['BAT']);
 export const BOAT_DIMS = {len: 48, beam: 9};
+
+// GTFS modes (the transitous aggregator) -> board categories, so
+// ONE consist ladder and ONE livery family serve both provider
+// kinds. Underground modes are deliberately absent: drawing a
+// metro on the surface would be inventing. FERRY routes to the
+// boats path.
+export const MODE_CAT = {
+  HIGHSPEED_RAIL: 'ICE',
+  LONG_DISTANCE: 'IC',
+  NIGHT_RAIL: 'EN',
+  REGIONAL_FAST_RAIL: 'RE',
+  REGIONAL_RAIL: 'R',
+  SUBURBAN: 'S',
+  TRAM: 'T',
+  FERRY: 'BAT'
+};
+
+// Standard encoded-polyline decoder (the Google algorithm the
+// GTFS world shares; transitous emits precision 5). Gated against
+// the canonical documented example.
+export function decodePolyline(str, precision = 5) {
+  const f = 10 ** precision;
+  const out = [];
+  let lat = 0;
+  let lon = 0;
+  for (let i = 0; i < str.length; ) {
+    for (const which of [0, 1]) {
+      let shift = 0;
+      let result = 0;
+      let b;
+      do {
+        b = str.charCodeAt(i++) - 63;
+        result |= (b & 0x1f) << shift;
+        shift += 5;
+      } while (b >= 0x20);
+      const d = result & 1 ? ~(result >> 1) : result >> 1;
+      if (which === 0) lat += d;
+      else lon += d;
+    }
+    out.push([lat / f, lon / f]);
+  }
+  return out;
+}
+
+// A point at LENGTH fraction f along a geodetic path (the real
+// route shape) - by cumulative arc length, not by vertex count.
+export function pathPoint(path, f) {
+  const mLat = 111320;
+  const segLen = [];
+  let total = 0;
+  for (let i = 1; i < path.length; i++) {
+    const dx =
+      (path[i][1] - path[i - 1][1]) *
+      mLat *
+      Math.cos((path[i - 1][0] * Math.PI) / 180);
+    const dy = (path[i][0] - path[i - 1][0]) * mLat;
+    const l = Math.hypot(dx, dy);
+    segLen.push(l);
+    total += l;
+  }
+  if (!total) return {lat: path[0][0], lon: path[0][1], hdgTo: null};
+  let want = Math.max(0, Math.min(1, f)) * total;
+  for (let i = 0; i < segLen.length; i++) {
+    if (want <= segLen[i] || i === segLen.length - 1) {
+      const t = segLen[i] ? want / segLen[i] : 0;
+      return {
+        lat: path[i][0] + (path[i + 1][0] - path[i][0]) * t,
+        lon: path[i][1] + (path[i + 1][1] - path[i][1]) * t,
+        hdgTo: {lat: path[i + 1][0], lon: path[i + 1][1]}
+      };
+    }
+    want -= segLen[i];
+  }
+  return {lat: path[0][0], lon: path[0][1], hdgTo: null};
+}
+
+/**
+ * A transitous map/trips response -> the SAME journey shape the
+ * boards produce, so trainAt and the renderers serve both
+ * providers. Each leg: two timed stops (departure/arrival already
+ * real-time-adjusted upstream - the realTime flag says so) plus
+ * the decoded polyline of the actual route, which trainAt follows
+ * by arc length instead of the straight line. Modes outside
+ * MODE_CAT (bus, coach, plane, underground) are dropped.
+ */
+export function parseTrips(json) {
+  const out = [];
+  for (const leg of Array.isArray(json) ? json : []) {
+    const cat = MODE_CAT[leg.mode];
+    if (!cat) continue;
+    const dep = ms(leg.departure);
+    const arr = ms(leg.arrival);
+    const f = leg.from || {};
+    const t = leg.to || {};
+    if (
+      !Number.isFinite(dep) ||
+      !Number.isFinite(arr) ||
+      !Number.isFinite(f.lat) ||
+      !Number.isFinite(t.lat) ||
+      arr <= dep
+    )
+      continue;
+    const name = ((leg.trips || [])[0] && leg.trips[0].displayName) || cat;
+    out.push({
+      cat,
+      number: '',
+      operator: '',
+      to: t.name || '',
+      label: name,
+      realTime: !!leg.realTime,
+      consist: consistOf(cat, ''),
+      stops: [
+        {lat: f.lat, lon: f.lon, name: f.name || '', arrMs: dep, depMs: dep},
+        {lat: t.lat, lon: t.lon, name: t.name || '', arrMs: arr, depMs: arr}
+      ],
+      path: leg.polyline ? decodePolyline(leg.polyline) : null
+    });
+  }
+  return out;
+}
 
 // The metre-gauge and rack operators run shorter, narrower stock.
 export const NARROW_OPS = new Set([
@@ -206,6 +356,13 @@ export function trainAt(journey, nowMs) {
     }
     if (i + 1 < s.length && nowMs > s[i].depMs && nowMs < s[i + 1].arrMs) {
       const f = (nowMs - s[i].depMs) / (s[i + 1].arrMs - s[i].depMs);
+      // A journey carrying its real route shape (transitous legs)
+      // is followed along the SHAPE by arc length; board journeys
+      // interpolate the straight line between their stops.
+      if (journey.path && journey.path.length >= 2 && s.length === 2) {
+        const p = pathPoint(journey.path, f);
+        return {lat: p.lat, lon: p.lon, hdgTo: p.hdgTo, at: '', moving: true};
+      }
       return {
         lat: s[i].lat + (s[i + 1].lat - s[i].lat) * f,
         lon: s[i].lon + (s[i + 1].lon - s[i].lon) * f,


### PR DESCRIPTION
Grows the provider registry (#74) beyond Switzerland. The community DB API answered 503 on both versions during verification, so the second registry entry became the better one: **transitous.org** aggregates public GTFS feeds **worldwide** (keyless, CORS-open), and its `api/v6/map/trips` answers a box + time window with every leg operating there *right then* — mode, line name (`ICE 698`), real-time-adjusted departure/arrival with a `realTime` flag, the from/to stops, and the **encoded polyline of the actual route shape**.

## trains.js — gate 6 → 9 landmarks
- **`decodePolyline`** held exact against the canonical documented reference polyline (the encoding the GTFS world shares).
- **`pathPoint`** — a point at length-fraction *f* along a geodetic path, by cumulative **arc length**, not vertex count: *f* = 0.5 on a 300 m + 100 m L sits exactly 200 m up the first leg.
- **`parseTrips`** produces the *same journey shape* the Swiss boards do — one consist ladder, one livery family, one renderer serve both provider kinds. `MODE_CAT` maps GTFS modes to board categories; **underground modes are deliberately absent** (drawing a metro on the surface would be inventing); FERRY routes to the boats path.
- **`trainAt` follows the route shape**: a journey carrying its polyline is interpolated along the shape instead of the straight line. The live 57-leg Frankfurt fixture holds **ICE 698 mid-leg ON its own polyline**.
- **Scope and order**: the Swiss national board (richer metadata) stays ahead of the world-scoped aggregator. The landmark proves Paris and New York fall through to transitous while Interlaken stays Swiss — **one provider per view, never more** (the owner's scope rule, now with global coverage).

## Theme
`syncTrains` branches on `provider.kind`: the trips flow is one box query (~8 km, 15-minute window), parsed and split rail/ferry. Panel records leg count, real-time share and the next departure. **Renderers unchanged** — the shared journey shape did the work.

## Validation
- Gate 50 sets green (trains set 6 → 9 landmarks).
- Browser smoke unchanged and clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKKBen9kkD562HDVr7cXAx

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKKBen9kkD562HDVr7cXAx)_