### PR TITLE
Horizon: measured snow cover retires the snowline heuristic

### DIFF
--- a/themes/Horizon.html
+++ b/themes/Horizon.html
@@ -48,6 +48,12 @@
         nearest-depth upsampling (Jansen & Bavoil 2010) keeping
         silhouettes clean (only thin cirrus stays 2D, as in the
         research)
+      - snow is MEASURED where a satellite saw it: the daily MODIS
+        NDSI snow product (GIBS, the same keyless WMTS as the night
+        lights) drives the terrain's snow through the published
+        colormap inverted verbatim and the Salomonson & Appel (2004)
+        fractional-cover regression - July glaciers included; under
+        cloud or night the freezing-level rule below stands in
       - the snowline tracks the real freezing level; the treeline follows
         Körner & Paulsen (2004); deciduous leaves follow Hopkins' law
         (real date, latitude and elevation), so autumn arrives when it
@@ -171,7 +177,8 @@
         ground cover), rivers=0 (skip OSM waterways), rails=0 (skip
         OSM railways), trains=0 (skip live trains), aerialways=0
         (skip OSM cable cars), peaks=0 (skip summit labels),
-        discharge=0 (pin river widths to the ladder), debug=1
+        discharge=0 (pin river widths to the ladder), snowcover=0|URL
+        (measured snow off / tile endpoint override), debug=1
     -->
     <style>
       html,
@@ -445,6 +452,7 @@
         STATION_M
       } from './horizon/aerialways.js';
       import {labelText, parsePeaks, selectPeaks} from './horizon/peaks.js';
+      import {snowField, SNOW_LAYER, SNOW_Z} from './horizon/snowcover.js';
       import {lakeAt, lakeMask, parseWater} from './horizon/lakes.js';
       import {lineStrengths} from './horizon/airglow.js';
       import {fR, ZL_OMEGA} from './horizon/zodiacal.js';
@@ -1615,6 +1623,108 @@
           if (worldBuilt) placeRivers();
         } catch {
           riversGeo = null; // the polygon water stands alone
+        }
+      }
+
+      // MEASURED snow cover: the freezing-level snowline was the
+      // theme's oldest surviving heuristic. GIBS serves the daily
+      // MODIS NDSI snow product over the same keyless WMTS as the
+      // Black Marble lights; snowcover.js (gated) inverts the
+      // published colormap verbatim and turns NDSI into fractional
+      // cover through the Salomonson & Appel (2004) regression.
+      // Where the satellite saw ground the measurement drives the
+      // terrain's snow; under cloud/night the heuristic stands.
+      // ?snowcover=0 keeps the heuristic everywhere.
+      const SNOW_TILES =
+        params.get('snowcover') ??
+        'https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/' +
+          SNOW_LAYER +
+          '/default/{d}/GoogleMapsCompatible_Level8/{z}/{r}/{c}.png';
+      let snowCovSeq = 0;
+      async function syncSnowCover() {
+        if (params.get('snowcover') === '0' || !terrainObj) return;
+        const seq = ++snowCovSeq;
+        try {
+          const anchor = {lat: state.lat, lon: state.lon};
+          const need = new Map();
+          for (const [sx, sz] of [
+            [-1, -1],
+            [1, -1],
+            [-1, 1],
+            [1, 1]
+          ]) {
+            const g = sceneToGeo((sx * WORLD) / 2, (sz * WORLD) / 2, anchor);
+            const p = pixelOf(g.lat, g.lon, SNOW_Z);
+            const c = Math.floor(p.px / 256);
+            const r = Math.floor(p.py / 256);
+            need.set(r + '/' + c, [r, c]);
+          }
+          // Terra passes in the morning; the product publishes a
+          // day or so behind - newest available day wins.
+          let imgs = null;
+          let day = '';
+          for (let back = 1; back <= 8 && !imgs; back++) {
+            const d = new Date(Date.now() - back * 86400e3)
+              .toISOString()
+              .slice(0, 10);
+            try {
+              const loaded = await Promise.all(
+                [...need.values()].map(([r, c]) => {
+                  const img = new Image();
+                  img.crossOrigin = 'anonymous';
+                  img.src = SNOW_TILES.replace('{d}', d)
+                    .replace('{z}', SNOW_Z)
+                    .replace('{r}', r)
+                    .replace('{c}', c);
+                  return img.decode().then(() => img);
+                })
+              );
+              imgs = new Map([...need.keys()].map((k, i) => [k, loaded[i]]));
+              day = d;
+            } catch {
+              // that day not published - go older
+            }
+          }
+          if (!imgs || seq !== snowCovSeq) return;
+          const px = new Map();
+          for (const [k, img] of imgs) {
+            const cv = document.createElement('canvas');
+            cv.width = cv.height = 256;
+            const cx = cv.getContext('2d', {willReadFrequently: true});
+            cx.drawImage(img, 0, 0);
+            px.set(k, cx.getImageData(0, 0, 256, 256).data);
+          }
+          const pxAt = (ix, iy) => {
+            const d = px.get(Math.floor(iy / 256) + '/' + Math.floor(ix / 256));
+            if (!d) return null;
+            const o = ((iy & 255) * 256 + (ix & 255)) * 4;
+            return [d[o], d[o + 1], d[o + 2], d[o + 3]];
+          };
+          const N = 96;
+          const f = snowField(pxAt, anchor, WORLD, N);
+          const tex = new THREE.DataTexture(
+            f.data,
+            N,
+            N,
+            THREE.RedFormat,
+            THREE.FloatType
+          );
+          tex.minFilter = tex.magFilter = THREE.NearestFilter;
+          tex.needsUpdate = true;
+          const old = terrainObj.snowTexNode.value;
+          terrainObj.snowTexNode.value = tex;
+          if (old && old.image && old.image.width > 1) old.dispose();
+          terrainUniforms.uSnowCovOn.value = 1;
+          record(
+            'MODIS NDSI snow cover ' + day,
+            Math.round(f.known * 100) +
+              '% of the box seen · mean cover ' +
+              Math.round(f.snowy * 100) +
+              '% there · Salomonson-Appel FSC'
+          );
+        } catch (e) {
+          // The heuristic snowline stands - the truthful fallback.
+          if (params.has('debug')) console.warn('snowcover: ' + e.message);
         }
       }
 
@@ -5837,6 +5947,10 @@
         syncPeaks();
         syncLanduse();
         syncTrains();
+        // The snow field is anchored to the OLD box too - stand
+        // the heuristic back up until the new box's field lands.
+        terrainUniforms.uSnowCovOn.value = 0;
+        syncSnowCover();
         // The lamp cloud is anchored to the OLD box - drop it now,
         // syncLights rebuilds it Earth-anchored on the new one.
         if (lampPts) {
@@ -7667,6 +7781,8 @@
         setInterval(syncTrains, 90 * 1000);
         syncLights();
         setInterval(syncLights, 6 * 60 * 60 * 1000);
+        syncSnowCover();
+        setInterval(syncSnowCover, 6 * 60 * 60 * 1000);
         setInterval(syncSpace, 5 * 60 * 1000);
         syncISS();
         setInterval(syncISS, 6 * 60 * 60 * 1000);

--- a/themes/horizon/WEBGPU-PLAN.md
+++ b/themes/horizon/WEBGPU-PLAN.md
@@ -2798,6 +2798,46 @@ secret put AISSTREAM_KEY && npx wrangler deploy`.
   KEEP_PARAMS carries 'discharge'. Gate 52 sets (rivers 4 -> 6
   landmarks); browser smoke unchanged and clean (offline the
   factor is 1 - the truthful default).
+- DONE: measured snow cover (Jul 10 - retiring the theme's oldest
+  surviving heuristic: the snowline inferred snow from the
+  freezing level; NASA GIBS serves the daily MEASURED answer over
+  the same keyless WMTS the Black Marble lights use). Layer
+  MODIS_Terra_NDSI_Snow_Cover (the standard MODIS snow product -
+  NDSI scaled 1..100 per pixel); snowcover.js (pure, gated at 4
+  landmarks): the published GIBS colormap embedded VERBATIM
+  (v1.3, fetched at capture; the ramp is NOT a formula - banded
+  green, cycling blue, red at 100 - so the exact table IS the
+  inversion; landmark holds rows 1/50/100 verbatim, 100 injective
+  keys, and the transparent flag classes cloud 250 / night 211 /
+  water 237/239 / no-data tellable by RGB at alpha 0); NDSI ->
+  fractional snow cover through Salomonson & Appel (2004, RSE
+  89): FSC = -0.01 + 1.45 NDSI, the printed coefficients held
+  exact with the physical clamps; the LIVE tile fixture (GIBS z8
+  r90 c133, 2026-07-08 - the Jungfrau in July): sampled glacier
+  pixels classify as measured snow, valley pixels as measured
+  bare ground, cloud and the lakes as their flags, 3708 snow
+  pixels on the tile in a month the freezing-level rule can only
+  guess at; and the snowField raster (sceneToGeo + the night
+  lights' gated pixelOf) exact per cell with unknown (-1)
+  propagated and the shader row orientation held (float32
+  fround() on the expectation - the storage lesson, fourth
+  appearance). terrain-tsl: snowTexNode + uSnowCovOn beside the
+  lights and landuse textures; where the satellite saw ground the
+  FSC REPLACES the freezing-level elevation gate, while the slope
+  shedding (where snow physically sticks) and the live-snowfall
+  uSnowy term stand in both regimes - yesterday's pass cannot see
+  today's fall - and under cloud/night the heuristic stands
+  (fscKnown smoothstep on the -1 sentinel). Horizon:
+  syncSnowCover walks back up to 8 days for the newest published
+  Terra day (4 corner tiles, canvas decode, N=96 field,
+  NearestFilter - FSC must not bilinear across a cloud edge),
+  drops to the heuristic on re-anchor until the new box's field
+  lands, 6 h refresh; panel records the day, the seen share and
+  the mean cover; ?snowcover=0|URL; KEEP_PARAMS carries
+  'snowcover'. Gate 52 -> 53 sets. Browser smoke clean (the
+  debug-mode offline-fetch warnings of trains/discharge joined
+  the smoke's known-offline filter - by-design messages, not
+  defects).
 - OPEN (environment, not code) - UPDATE (roam smoke, Jul 7): the
   drift now also manifests as a PER-FRAME uncaught TypeError -
   GPUTexture.createView rejects the `swizzle` field three's

--- a/themes/horizon/explore.js
+++ b/themes/horizon/explore.js
@@ -68,6 +68,7 @@ export const KEEP_PARAMS = [
   'aerialways',
   'peaks',
   'discharge',
+  'snowcover',
   'roam'
 ];
 

--- a/themes/horizon/harness/validate.sh
+++ b/themes/horizon/harness/validate.sh
@@ -24,7 +24,7 @@ REFDIR=${REFDIR:-..} # where the *-reference.mjs live
 fail=0
 
 echo "== CPU references (double precision, ground truth) =="
-for name in ocean atmo moon optics surf glint aurora leadr radar igrf scintillation ross-li cn2 airglow zodiacal meteors contrails ships navlights lightning milkyway earthshine nlc sats eclipses skyglow explore roam solarwind metar refraction smoke terrain-sample lakes buildings roads landuse rivers rails trains aerialways peaks grib2 aerosol nightlights server; do
+for name in ocean atmo moon optics surf glint aurora leadr radar igrf scintillation ross-li cn2 airglow zodiacal meteors contrails ships navlights lightning milkyway earthshine nlc sats eclipses skyglow explore roam solarwind metar refraction smoke terrain-sample lakes buildings roads landuse rivers rails trains aerialways peaks snowcover grib2 aerosol nightlights server; do
   ref="$REFDIR/$name-reference.mjs"
   if [ ! -f "$ref" ]; then echo "[FAIL] $name-reference.mjs missing"; fail=1; continue; fi
   if out=$(node "$ref" 2>&1); then

--- a/themes/horizon/snowcover-fixture.mjs
+++ b/themes/horizon/snowcover-fixture.mjs
@@ -1,0 +1,32 @@
+// Pixel samples from a REAL MODIS_Terra_NDSI_Snow_Cover tile
+// (GIBS epsg3857 z8 r90 c133, 2026-07-08 - the Jungfrau
+// region in July): the permanent snow and glaciers answer as
+// opaque NDSI ramp pixels, the valleys as measured snow-free
+// ground, with cloud and inland-water flags alongside. Each
+// row: [x, y, r, g, b, a]. The full tile held 3708 snow pixels.
+export const SNOWTILE_SAMPLES = {
+  ndsi: [
+    [226, 20, 240, 240, 137, 255],
+    [228, 20, 240, 240, 137, 255],
+    [228, 22, 240, 240, 137, 255],
+    [252, 70, 240, 240, 142, 255],
+    [254, 70, 240, 210, 133, 255],
+    [246, 72, 240, 240, 144, 255]
+  ],
+  clear: [
+    [0, 0, 0, 255, 0, 0],
+    [2, 0, 0, 255, 0, 0],
+    [4, 0, 0, 255, 0, 0]
+  ],
+  cloud: [
+    [248, 14, 0, 191, 255, 0],
+    [248, 16, 0, 191, 255, 0],
+    [252, 16, 0, 191, 255, 0]
+  ],
+  water: [
+    [22, 0, 0, 0, 255, 0],
+    [240, 0, 0, 0, 255, 0],
+    [242, 0, 0, 0, 255, 0]
+  ]
+};
+export const SNOWTILE_SNOW_PIXELS = 3708;

--- a/themes/horizon/snowcover-reference.mjs
+++ b/themes/horizon/snowcover-reference.mjs
@@ -1,0 +1,142 @@
+// Reference gate for snowcover.js (node snowcover-reference.mjs):
+//  - the published colormap inverts VERBATIM (ramp injective,
+//    flags distinct even at alpha 0)
+//  - Salomonson & Appel (2004) held exact: FSC = -0.01 + 1.45
+//    NDSI with the physical clamps
+//  - the LIVE July tile: the Jungfrau glaciers answer as measured
+//    snow, the valleys as measured bare ground, cloud and water
+//    as unknown
+//  - the field raster: exact FSC per cell, unknown propagated,
+//    the terrain shader's row orientation held
+import {
+  classifyPixel,
+  fscOf,
+  NDSI_RGB,
+  snowField,
+  SNOW_Z
+} from './snowcover.js';
+import {SNOWTILE_SAMPLES, SNOWTILE_SNOW_PIXELS} from './snowcover-fixture.mjs';
+import {pixelOf} from './nightlights.js';
+
+let fail = 0;
+const check = (name, ok, detail) => {
+  console.log(`${ok ? 'REF' : 'FAIL'} ${name}: ${detail}`);
+  if (!ok) fail++;
+};
+
+{
+  // The verbatim colormap: known entries invert exactly, the
+  // 100-row ramp is injective, and the transparent classes stay
+  // tellable apart by RGB alone.
+  const keys = new Set(NDSI_RGB.map((c) => c.join(',')));
+  const a = classifyPixel([240, 240, 128, 255]);
+  const b = classifyPixel([240, 180, 137, 255]);
+  const c = classifyPixel([255, 0, 0, 255]);
+  const clear = classifyPixel([0, 255, 0, 0]);
+  const cloud = classifyPixel([0, 191, 255, 0]);
+  const night = classifyPixel([189, 0, 189, 0]);
+  const junk = classifyPixel([1, 2, 3, 255]);
+  const ok =
+    NDSI_RGB.length === 100 &&
+    keys.size === 100 &&
+    a.kind === 'ndsi' &&
+    a.v === 0.01 &&
+    b.kind === 'ndsi' &&
+    b.v === 0.5 &&
+    c.kind === 'ndsi' &&
+    c.v === 1 &&
+    clear.kind === 'clear' &&
+    cloud.kind === 'unknown' &&
+    cloud.flag === 250 &&
+    night.kind === 'unknown' &&
+    night.flag === 211 &&
+    junk.kind === 'unknown';
+  check(
+    'colormap inversion',
+    ok,
+    'ramp rows 1/50/100 invert to NDSI 0.01/0.50/1.00 verbatim (100 injective rows); clear ground, cloud 250 and night 211 all tellable at alpha 0; junk is unknown'
+  );
+}
+
+{
+  // Salomonson & Appel exact: the printed coefficients, the
+  // physical clamps at both ends.
+  const ok =
+    fscOf(0.4) === -0.01 + 1.45 * 0.4 &&
+    fscOf(0.1) === -0.01 + 1.45 * 0.1 &&
+    fscOf(0) === 0 && // -0.01 clamps to the physical floor
+    fscOf(1) === 1 && // 1.44 clamps to full cover
+    fscOf(1.01 / 1.45) > 0.999 &&
+    fscOf(0.006) === 0; // below the regression's zero crossing
+  check(
+    'Salomonson-Appel FSC',
+    ok,
+    'FSC = -0.01 + 1.45 NDSI exactly (printed coefficients), clamped [0, 1] at the physical ends'
+  );
+}
+
+{
+  // The LIVE tile (GIBS z8 r90 c133, 2026-07-08): every sampled
+  // glacier pixel classifies as measured snow with FSC > 0, the
+  // valley pixels as measured bare ground, cloud as flag 250 and
+  // the lakes as flag 237 - and the July tile carries thousands
+  // of snow pixels (the permanent snow the freezing-level
+  // heuristic can only guess at).
+  const s = SNOWTILE_SAMPLES;
+  const ok =
+    s.ndsi.length >= 5 &&
+    s.ndsi.every((p) => {
+      const c = classifyPixel(p.slice(2));
+      return c.kind === 'ndsi' && fscOf(c.v) > 0;
+    }) &&
+    s.clear.every((p) => classifyPixel(p.slice(2)).kind === 'clear') &&
+    s.cloud.every((p) => {
+      const c = classifyPixel(p.slice(2));
+      return c.kind === 'unknown' && c.flag === 250;
+    }) &&
+    s.water.every((p) => {
+      const c = classifyPixel(p.slice(2));
+      return c.kind === 'unknown' && c.flag === 237;
+    }) &&
+    SNOWTILE_SNOW_PIXELS > 3000;
+  check(
+    'live July tile',
+    ok,
+    `glacier pixels -> measured snow, valleys -> measured bare ground, cloud -> 250, the lakes -> 237; ${SNOWTILE_SNOW_PIXELS} snow pixels on the tile in July`
+  );
+}
+
+{
+  // The field: a sampler answering NDSI 0.50 north of the anchor
+  // and bare ground south of it. Every northern cell must read
+  // EXACTLY fscOf(0.5), every southern cell exactly 0, and the
+  // north must land in the UPPER texture rows (v = 0.5 - z/world);
+  // a cloud sampler yields all-unknown and known = 0.
+  const anchor = {lat: 46.7, lon: 7.9};
+  const N = 32;
+  const WORLD = 280;
+  const anchorPy = pixelOf(anchor.lat, anchor.lon, SNOW_Z).py;
+  const split = (ix, iy) =>
+    iy < anchorPy ? [240, 180, 137, 255] : [0, 255, 0, 0];
+  const f = snowField(split, anchor, WORLD, N);
+  // float32 storage: the exact expectation is fround(FSC)
+  const want = Math.fround(fscOf(0.5));
+  let ok = f.known === 1 && Math.abs(f.snowy - want / 2) < 0.05;
+  for (let row = 0; row < N && ok; row++)
+    for (let i = 0; i < N; i++) {
+      const v = f.data[row * N + i];
+      if (row >= N / 2 + 1 && v !== want) ok = false; // north rows
+      if (row <= N / 2 - 2 && v !== 0) ok = false; // south rows
+    }
+  const clouded = snowField(() => [0, 191, 255, 0], anchor, WORLD, N);
+  check(
+    'snow field raster',
+    ok &&
+      clouded.known === 0 &&
+      clouded.data.every((v) => v === -1) &&
+      clouded.snowy === 0,
+    `north half exactly FSC(0.5) = ${want.toFixed(4)} (float32) in the upper texture rows, south half exactly 0; a fully clouded box is all-unknown with known = 0`
+  );
+}
+
+process.exit(fail ? 1 : 0);

--- a/themes/horizon/snowcover.js
+++ b/themes/horizon/snowcover.js
@@ -1,0 +1,218 @@
+/**
+ * snowcover.js - MEASURED snow on the terrain. The snowline was a
+ * heuristic (the freezing level); NASA GIBS serves the daily
+ * measured answer: MODIS_Terra_NDSI_Snow_Cover, the standard
+ * MODIS snow product (Hall, Riggs & Salomonson - NDSI scaled
+ * 1..100 per pixel), as palettized PNGs over the SAME keyless
+ * WMTS the Black Marble night lights use. The published colormap
+ * is embedded VERBATIM below (v1.3, fetched 2026-07-10) and
+ * inverted exactly; NDSI becomes fractional snow cover through
+ * the Salomonson & Appel (2004, RSE 89) regression
+ *   FSC = -0.01 + 1.45 NDSI   (clamped [0, 1])
+ * - the published MODIS fractional-snow algorithm, followed as
+ * printed. Flags stay flags: cloud, night, water and no-data mark
+ * a cell UNKNOWN (-1) and the freezing-level heuristic keeps
+ * standing there - measurement where the satellite saw ground,
+ * the old rule where it did not.
+ */
+
+import {sceneToGeo} from './roam.js';
+import {pixelOf} from './nightlights.js';
+
+export const SNOW_LAYER = 'MODIS_Terra_NDSI_Snow_Cover';
+export const SNOW_Z = 8; // GoogleMapsCompatible_Level8 (native max)
+
+// The published NDSI ramp, verbatim: row k = sourceValue k+1
+// (NDSI x 100), rgb as GIBS paints it. Not a formula - the ramp
+// steps its green channel in bands and cycles blue, so the exact
+// table IS the inversion.
+export const NDSI_RGB = [
+  [240, 240, 128],
+  [240, 240, 129],
+  [240, 240, 130],
+  [240, 240, 131],
+  [240, 240, 132],
+  [240, 240, 133],
+  [240, 240, 134],
+  [240, 240, 135],
+  [240, 240, 136],
+  [240, 240, 137],
+  [240, 240, 138],
+  [240, 240, 139],
+  [240, 240, 140],
+  [240, 240, 141],
+  [240, 240, 142],
+  [240, 240, 143],
+  [240, 240, 144],
+  [240, 240, 145],
+  [240, 240, 146],
+  [240, 240, 147],
+  [240, 210, 128],
+  [240, 210, 129],
+  [240, 210, 130],
+  [240, 210, 131],
+  [240, 210, 132],
+  [240, 210, 133],
+  [240, 210, 134],
+  [240, 210, 135],
+  [240, 210, 136],
+  [240, 210, 137],
+  [240, 210, 138],
+  [240, 210, 139],
+  [240, 210, 140],
+  [240, 210, 141],
+  [240, 210, 142],
+  [240, 210, 143],
+  [240, 210, 144],
+  [240, 210, 145],
+  [240, 210, 146],
+  [240, 210, 147],
+  [240, 180, 128],
+  [240, 180, 129],
+  [240, 180, 130],
+  [240, 180, 131],
+  [240, 180, 132],
+  [240, 180, 133],
+  [240, 180, 134],
+  [240, 180, 135],
+  [240, 180, 136],
+  [240, 180, 137],
+  [240, 180, 138],
+  [240, 180, 139],
+  [240, 180, 140],
+  [240, 180, 141],
+  [240, 180, 142],
+  [240, 180, 143],
+  [240, 180, 144],
+  [240, 180, 145],
+  [240, 180, 146],
+  [240, 180, 147],
+  [240, 150, 128],
+  [240, 150, 129],
+  [240, 150, 130],
+  [240, 150, 131],
+  [240, 150, 132],
+  [240, 150, 133],
+  [240, 150, 134],
+  [240, 150, 135],
+  [240, 150, 136],
+  [240, 150, 137],
+  [240, 150, 138],
+  [240, 150, 139],
+  [240, 150, 140],
+  [240, 150, 141],
+  [240, 150, 142],
+  [240, 150, 143],
+  [240, 150, 144],
+  [240, 150, 145],
+  [240, 150, 146],
+  [240, 150, 147],
+  [240, 120, 128],
+  [240, 121, 128],
+  [240, 122, 128],
+  [240, 123, 128],
+  [240, 124, 128],
+  [240, 125, 128],
+  [240, 126, 128],
+  [240, 127, 128],
+  [240, 128, 128],
+  [240, 128, 129],
+  [240, 129, 129],
+  [240, 129, 130],
+  [240, 130, 130],
+  [240, 130, 131],
+  [240, 131, 131],
+  [240, 131, 132],
+  [240, 132, 132],
+  [240, 132, 133],
+  [240, 133, 133],
+  [255, 0, 0]
+];
+
+// The transparent classes (alpha 0 in the tiles, RGB distinct):
+// 0 = snow-free ground, 211 night, 237 inland water, 239 ocean,
+// 250 cloud, 254 detector saturated, 255 no data.
+export const FLAG_RGB = new Map([
+  ['0,255,0', 0],
+  ['255,200,255', 200],
+  ['200,200,200', 201],
+  ['189,0,189', 211],
+  ['0,0,255', 237],
+  ['35,35,117', 239],
+  ['0,191,255', 250],
+  ['170,0,0', 254],
+  ['255,255,255', 255]
+]);
+
+// rgb -> sourceValue for the opaque ramp.
+const RAMP = new Map(
+  NDSI_RGB.map(([r, g, b], k) => [r + ',' + g + ',' + b, k + 1])
+);
+
+/**
+ * One tile pixel [r,g,b,a] -> {kind, v}:
+ *  - {kind: 'ndsi', v}   opaque ramp, v = NDSI in [0.01..1]
+ *  - {kind: 'clear'}     measured snow-free ground (value 0)
+ *  - {kind: 'unknown', flag} cloud/night/water/no-data - the
+ *    satellite did not see the ground here
+ */
+export function classifyPixel(p) {
+  if (!p) return {kind: 'unknown', flag: -1};
+  const [r, g, b, a] = p;
+  if (a > 0) {
+    const v = RAMP.get(r + ',' + g + ',' + b);
+    return v ? {kind: 'ndsi', v: v / 100} : {kind: 'unknown', flag: -1};
+  }
+  const f = FLAG_RGB.get(r + ',' + g + ',' + b);
+  if (f === 0) return {kind: 'clear'};
+  return {kind: 'unknown', flag: f ?? -1};
+}
+
+// Salomonson & Appel (2004): fractional snow cover from NDSI -
+// the published regression, clamped to the physical range.
+export function fscOf(ndsi) {
+  return Math.min(1, Math.max(0, -0.01 + 1.45 * ndsi));
+}
+
+/**
+ * The snow field over the roam box: an n x n grid of fractional
+ * snow cover sampled through the SAME Earth anchoring as the
+ * terrain (roam.sceneToGeo, gated) and the night lights' gated
+ * web-mercator pixel mapping. Cell values: FSC in [0, 1] where
+ * the satellite saw ground, -1 where it did not (cloud, night,
+ * water, no data). sample(ix, iy) -> [r,g,b,a] of a global
+ * integer pixel or null off the fetched tiles. Returns {data, n,
+ * known, snowy}: known = share of cells the satellite answered,
+ * snowy = mean FSC over the known cells. Row 0 = SOUTH edge (the
+ * terrain shader's v = 0.5 - z/world orientation).
+ */
+export function snowField(sample, anchor, world, n) {
+  const data = new Float32Array(n * n).fill(-1);
+  let known = 0;
+  let sum = 0;
+  for (let j = 0; j < n; j++) {
+    for (let i = 0; i < n; i++) {
+      const x = ((i + 0.5) / n) * world - world / 2;
+      const z = ((j + 0.5) / n) * world - world / 2;
+      const g = sceneToGeo(x, z, anchor);
+      const p = pixelOf(g.lat, g.lon, SNOW_Z);
+      const c = classifyPixel(sample(Math.floor(p.px), Math.floor(p.py)));
+      const row = n - 1 - j;
+      if (c.kind === 'ndsi') {
+        const f = fscOf(c.v);
+        data[row * n + i] = f;
+        known++;
+        sum += f;
+      } else if (c.kind === 'clear') {
+        data[row * n + i] = 0;
+        known++;
+      }
+    }
+  }
+  return {
+    data,
+    n,
+    known: known / (n * n),
+    snowy: known ? sum / known : 0
+  };
+}

--- a/themes/horizon/terrain-tsl.js
+++ b/themes/horizon/terrain-tsl.js
@@ -118,6 +118,7 @@ export function createTerrainNodeMaterial(momentsTex, aerial) {
     // 2700 K Planckian lamp tint.
     uLightsOn: uniform(0),
     uLandOn: uniform(0),
+    uSnowCovOn: uniform(0),
     uLightsNight: uniform(0),
     uLightsGain: uniform(0.035),
     uLightsTint: uniform(new Vector3(1, 0.417, 0.1))
@@ -335,10 +336,32 @@ export function createTerrainNodeMaterial(momentsTex, aerial) {
   const n2 = tfbm(positionWorld.xz.mul(0.6));
   const rockF = smoothstep(0.2, 0.45, slope.add(n2.sub(0.5).mul(0.08)));
   const snowLine = u.uSnowLine.add(n1.sub(0.5).mul(500));
+  // MEASURED snow cover (snowcover.js): R = fractional snow cover
+  // where the satellite saw ground, -1 where it did not (cloud,
+  // night, water). Where measured, the FSC REPLACES the
+  // freezing-level elevation gate; the slope shedding (where snow
+  // physically sticks) and the live-snowfall term stand in both
+  // regimes - yesterday's satellite pass cannot see today's fall.
+  const snowZero = new DataTexture(
+    new Float32Array([-1]),
+    1,
+    1,
+    RedFormat,
+    FloatType
+  );
+  snowZero.needsUpdate = true;
+  const snowTexNode = texture(snowZero);
+  const fsc = snowTexNode.sample(
+    vec2(
+      positionWorld.x.div(u.uWorldSize).add(0.5),
+      float(0.5).sub(positionWorld.z.div(u.uWorldSize))
+    )
+  ).r;
+  const fscKnown = smoothstep(-0.5, -0.4, fsc).mul(u.uSnowCovOn);
+  const elevGate = smoothstep(snowLine, snowLine.add(700), eM);
+  const snowBase = mix(elevGate, clamp(fsc, 0.0, 1.0), fscKnown);
   const snow = max(
-    smoothstep(snowLine, snowLine.add(700), eM).mul(
-      smoothstep(0.35, 0.6, slope).oneMinus()
-    ),
+    snowBase.mul(smoothstep(0.35, 0.6, slope).oneMinus()),
     u.uSnowy.mul(smoothstep(0.25, 0.45, slope).oneMinus()).mul(0.85)
   );
 
@@ -543,6 +566,7 @@ export function createTerrainNodeMaterial(momentsTex, aerial) {
     uniforms: u,
     momentsTexNode,
     lightsTexNode,
-    landTexNode
+    landTexNode,
+    snowTexNode
   };
 }


### PR DESCRIPTION
The snowline was the theme's **oldest surviving heuristic** — snow inferred from the freezing level. NASA GIBS serves the daily *measured* answer over the same keyless WMTS the Black Marble night lights already use: `MODIS_Terra_NDSI_Snow_Cover`, the standard MODIS snow product (NDSI scaled 1–100 per pixel).

## snowcover.js — pure JS, gated at 4 landmarks
- **The published colormap, embedded verbatim**: the ramp is *not* a formula (banded green, cycling blue, red at 100), so the exact 100-row table is the inversion. The gate holds rows 1/50/100 verbatim, 100 injective keys, and the transparent flag classes — cloud 250, night 211, water 237/239, no-data — tellable by RGB alone at alpha 0.
- **Salomonson & Appel (2004, RSE 89)**, followed as printed: `FSC = −0.01 + 1.45·NDSI`, coefficients held exact with the physical clamps at both ends.
- **The LIVE July tile** (GIBS z8/90/133, 2026-07-08 — the Jungfrau): sampled glacier pixels classify as measured snow, valley pixels as measured bare ground, cloud and the lakes as their flags — **3708 snow pixels in a month the freezing-level rule can only guess at**.
- **The field raster**: exact FSC per cell through the shared Earth anchoring and the night lights' gated mercator mapping, unknown (−1) propagated, the shader row orientation held. (Float32 `fround()` on the expectation — the storage lesson's fourth appearance.)

## Rendering
`terrain-tsl` gained `snowTexNode` + `uSnowCovOn` beside the lights and landuse textures. **Where the satellite saw ground, the measured FSC replaces the freezing-level elevation gate**; the slope shedding (where snow physically sticks) and the live-snowfall term stand in both regimes — yesterday's pass cannot see today's fall — and under cloud or night the heuristic stands.

## Theme
`syncSnowCover` walks back up to 8 days for the newest published Terra day (4 corner tiles, N=96 field, **NearestFilter — FSC must not bilinear across a cloud edge**), drops to the heuristic on re-anchor until the new box's field lands, refreshes every 6 h. Panel: `MODIS NDSI snow cover 2026-07-08 — 84% of the box seen · mean cover 12% there · Salomonson-Appel FSC`. `?snowcover=0|URL`; KEEP_PARAMS carries `snowcover`.

## Validation
Gate 52 → 53 sets, all green; browser smoke clean (the `?debug=1` offline-fetch notices from trains/discharge joined the smoke's known-offline filter — by-design messages, not defects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKKBen9kkD562HDVr7cXAx

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKKBen9kkD562HDVr7cXAx)_