### PR TITLE
Horizon: wet soil darkens with measured topsoil moisture

### DIFF
--- a/themes/Horizon.html
+++ b/themes/Horizon.html
@@ -118,7 +118,11 @@
         and the ground itself carries the real cover - OSM landuse
         polygons tint the grass where farmland, meadows, residential
         blocks and bare rock actually are (unknown classes stay
-        base grass, mountains and snow untouched); linear water is
+        base grass, mountains and snow untouched) - and the bare
+        soils DARKEN with the measured topsoil moisture (Lobell &
+        Asner 2002: reflectance falls exponentially with degree of
+        saturation), so the fields dry pale and rain leaves them
+        dark; linear water is
         real too - OSM waterway ways thread the Aare and the alpine
         streams down the valleys (tunnelled reaches skipped), and a
         stream reaching a lake stops at the shore where the polygon
@@ -178,7 +182,8 @@
         OSM railways), trains=0 (skip live trains), aerialways=0
         (skip OSM cable cars), peaks=0 (skip summit labels),
         discharge=0 (pin river widths to the ladder), snowcover=0|URL
-        (measured snow off / tile endpoint override), debug=1
+        (measured snow off / tile endpoint override), soil=0 (pin
+        bare-soil tints dry), debug=1
     -->
     <style>
       html,
@@ -427,7 +432,11 @@
       import {buildVessel} from './horizon/vessels.js';
       import {buildingsGeometry, parseBuildings} from './horizon/buildings.js';
       import {parseRoads, roadsGeometry} from './horizon/roads.js';
-      import {landTint, parseLanduse} from './horizon/landuse.js';
+      import {
+        landTint,
+        parseLanduse,
+        soilDarkening
+      } from './horizon/landuse.js';
       import {
         dischargeFactor,
         parseWaterways,
@@ -1623,6 +1632,51 @@
           if (worldBuilt) placeRivers();
         } catch {
           riversGeo = null; // the polygon water stands alone
+        }
+      }
+
+      // Measured topsoil moisture: the same open-meteo forecast
+      // family serves soil_moisture_0_to_1cm (m³/m³). Wet ground
+      // is DARKER ground - Lobell & Asner (2002): soil reflectance
+      // falls exponentially with degree of saturation (landuse.js,
+      // gated) - so the bare-soil landuse tints (farmland,
+      // farmyard, allotments...) darken after real rain and pale
+      // as the ground dries. Vegetated tints stand: canopy hides
+      // soil. ?soil=0 pins dry.
+      let soilTheta = null;
+      async function syncSoil() {
+        if (params.get('soil') === '0') return;
+        try {
+          const j = await (
+            await fetch(
+              'https://api.open-meteo.com/v1/forecast?latitude=' +
+                state.lat.toFixed(4) +
+                '&longitude=' +
+                state.lon.toFixed(4) +
+                '&hourly=soil_moisture_0_to_1cm&forecast_days=1',
+              {credentials: 'omit'}
+            )
+          ).json();
+          const times = (j.hourly && j.hourly.time) || [];
+          const vals = (j.hourly && j.hourly.soil_moisture_0_to_1cm) || [];
+          const hour = new Date().toISOString().slice(0, 13) + ':00';
+          let i = times.indexOf(hour);
+          if (i < 0) i = 0;
+          const v = vals[i];
+          soilTheta = Number.isFinite(v) ? v : null;
+          if (soilTheta != null) {
+            record(
+              'ERA5 topsoil moisture',
+              soilTheta.toFixed(3) +
+                ' m³/m³ (0-1 cm) · bare-soil tint ×' +
+                soilDarkening(soilTheta).toFixed(2) +
+                ' (Lobell-Asner)'
+            );
+            if (worldBuilt) placeLanduse();
+          }
+        } catch (e) {
+          soilTheta = null; // dry albedo stands - nothing invented
+          if (params.has('debug')) console.warn('soil: ' + e.message);
         }
       }
 
@@ -3484,7 +3538,13 @@
       function placeLanduse() {
         if (!landGeo || !landGeo.length || params.get('landuse') === '0')
           return;
-        const t = landTint(landGeo, dressAnchor, WORLD, 192);
+        const t = landTint(
+          landGeo,
+          dressAnchor,
+          WORLD,
+          192,
+          soilDarkening(soilTheta)
+        );
         if (!t) {
           terrainUniforms.uLandOn.value = 0;
           return;
@@ -5946,6 +6006,7 @@
         syncAerialways();
         syncPeaks();
         syncLanduse();
+        syncSoil();
         syncTrains();
         // The snow field is anchored to the OLD box too - stand
         // the heuristic back up until the new box's field lands.
@@ -7777,6 +7838,8 @@
         syncAerialways();
         syncPeaks();
         syncLanduse();
+        syncSoil();
+        setInterval(syncSoil, 3 * 60 * 60 * 1000);
         syncTrains();
         setInterval(syncTrains, 90 * 1000);
         syncLights();

--- a/themes/horizon/WEBGPU-PLAN.md
+++ b/themes/horizon/WEBGPU-PLAN.md
@@ -2838,6 +2838,38 @@ secret put AISSTREAM_KEY && npx wrangler deploy`.
   debug-mode offline-fetch warnings of trains/discharge joined
   the smoke's known-offline filter - by-design messages, not
   defects).
+- DONE: wet soil darkens (Jul 10 - the coupling class: two
+  measured systems interacting. The landuse tints painted the
+  fields one dry albedo forever; real fields darken after real
+  rain). Source: the SAME open-meteo forecast family already
+  serving weather/marine/air-quality publishes
+  soil_moisture_0_to_1cm (m³/m³, the reactive top centimetre -
+  the layer the eye actually sees wet). Research: Lobell & Asner
+  (2002, SSSAJ 66:722) - laboratory result that soil reflectance
+  falls EXPONENTIALLY with moisture expressed as DEGREE OF
+  SATURATION, similarly across soil types, R = b + a exp(-c
+  theta_sat), with the visible band saturating by ~0.20 m³/m³
+  volumetric. Two documented parameters close the per-soil
+  unknowns (their four soils differ; no single published
+  constant): the classic visible-band figure that saturated soil
+  reflects about HALF of dry, and loam porosity 0.45 for the
+  volumetric -> saturation conversion; the decay constant is
+  DERIVED from the paper's saturation point rather than picked -
+  exp(-c x 0.20/porosity) = 1/20, c = 6.74. landuse.js:
+  soilDarkening (dry = 1, monotone, saturated floor, factor 1
+  whenever data cannot speak), SOIL_CLASSES (farmland, farmyard,
+  allotments, quarry, sand, beach - vegetated tints stand, canopy
+  hides soil), landTint gained the soilFactor param applied at
+  paint time. Gate 5 -> 6 landmarks: the exponential exact, the
+  derivation identity held to 1e-12, and through the painter - a
+  farmland texel darkens by exactly the factor (float32 fround)
+  while a meadow texel stands. At the LIVE capture (Interlaken,
+  0.108 m³/m³ that morning) the fields render x0.599 - visibly
+  damp ground, measured. Theme: syncSoil (current hour from the
+  hourly series, 3 h refresh, roam re-sync), placeLanduse repaints
+  through the factor; panel records theta and the tint; ?soil=0
+  pins dry; KEEP_PARAMS carries 'soil'. Gate 53 sets (landuse
+  5 -> 6 landmarks); browser smoke clean.
 - OPEN (environment, not code) - UPDATE (roam smoke, Jul 7): the
   drift now also manifests as a PER-FRAME uncaught TypeError -
   GPUTexture.createView rejects the `swizzle` field three's

--- a/themes/horizon/explore.js
+++ b/themes/horizon/explore.js
@@ -69,6 +69,7 @@ export const KEEP_PARAMS = [
   'peaks',
   'discharge',
   'snowcover',
+  'soil',
   'roam'
 ];
 

--- a/themes/horizon/landuse-reference.mjs
+++ b/themes/horizon/landuse-reference.mjs
@@ -10,7 +10,16 @@
 //    texels, the large one keeps the rest
 //  - the LIVE Interlaken fixture parses to the real ground cover
 //    and paints the box
-import {CLASS_ALBEDO, landTint, parseLanduse, tintAt} from './landuse.js';
+import {
+  CLASS_ALBEDO,
+  landTint,
+  parseLanduse,
+  SOIL_C,
+  SOIL_POROSITY,
+  SOIL_SAT_RATIO,
+  soilDarkening,
+  tintAt
+} from './landuse.js';
 import {LANDUSE_FIXTURE} from './landuse-fixture.mjs';
 import {geoToScene} from './roam.js';
 import {inRing} from './smoke.js';
@@ -214,6 +223,75 @@ const WORLD = 280;
       share > 0.015 &&
       share < 0.2,
     `${polys.length} polygons (${cls.size} classes), ${tint.painted} painted onto the box, ${(share * 100).toFixed(0)}% of texels covered`
+  );
+}
+
+{
+  // Wet soil darkens (Lobell & Asner 2002): the exponential form
+  // exact - dry ground 1, the decay constant DERIVED from the
+  // paper's visible-band saturation point (95% of the decay spent
+  // by 0.20 m3/m3), the saturated floor at the documented half,
+  // monotone throughout, and factor 1 whenever the data cannot
+  // speak. Painted through landTint: a farmland texel darkens by
+  // exactly the factor, a meadow texel (canopy over its soil)
+  // does not.
+  const f02 = soilDarkening(0.2);
+  const wantAt02 =
+    SOIL_SAT_RATIO +
+    (1 - SOIL_SAT_RATIO) * Math.exp(-SOIL_C * (0.2 / SOIL_POROSITY));
+  const mono =
+    soilDarkening(0.05) > soilDarkening(0.1) &&
+    soilDarkening(0.1) > soilDarkening(0.2) &&
+    soilDarkening(0.2) > soilDarkening(0.45);
+  const anchor2 = {lat: 46.6863, lon: 7.8632};
+  const sq = (halfM) => {
+    const dLat = halfM / 111320;
+    const dLon = halfM / (111320 * Math.cos((46.6863 * Math.PI) / 180));
+    return [
+      [46.6863 - dLat, 7.8632 - dLon],
+      [46.6863 - dLat, 7.8632 + dLon],
+      [46.6863 + dLat, 7.8632 + dLon],
+      [46.6863 + dLat, 7.8632 - dLon]
+    ];
+  };
+  const mkWay = (id, ring, tags) => ({
+    type: 'way',
+    id,
+    geometry: [...ring, ring[0]].map(([lat, lon]) => ({lat, lon})),
+    tags
+  });
+  const polys2 = parseLanduse({
+    elements: [
+      mkWay(1, sq(500), {landuse: 'farmland'}),
+      mkWay(2, sq(120), {landuse: 'meadow'})
+    ]
+  });
+  const wet = landTint(polys2, anchor2, 280, 192, soilDarkening(0.108));
+  const centreMeadow = tintAt(wet, 0, 0);
+  const ringFarm = tintAt(wet, 0, 5);
+  const fNow = soilDarkening(0.108);
+  const farmOk =
+    ringFarm &&
+    ringFarm.every(
+      (v, k) =>
+        Math.abs(v - Math.fround(CLASS_ALBEDO.farmland[k] * fNow)) < 1e-7
+    );
+  const meadowOk =
+    centreMeadow &&
+    centreMeadow.every(
+      (v, k) => Math.abs(v - Math.fround(CLASS_ALBEDO.meadow[k])) < 1e-7
+    );
+  check(
+    'wet soil darkens',
+    Math.abs(f02 - wantAt02) < 1e-15 &&
+      Math.abs(Math.exp(-SOIL_C * (0.2 / SOIL_POROSITY)) - 0.05) < 1e-12 &&
+      mono &&
+      soilDarkening(0) === 1 &&
+      soilDarkening(NaN) === 1 &&
+      soilDarkening(9) > SOIL_SAT_RATIO &&
+      farmOk &&
+      meadowOk,
+    `Lobell-Asner exponential exact; c = ${SOIL_C.toFixed(2)} derived from the paper's 0.20 m3/m3 visible saturation; at the live capture's 0.108 m3/m3 the farmland texel darkens by x${fNow.toFixed(3)} while the meadow (canopy) stands`
   );
 }
 

--- a/themes/horizon/landuse.js
+++ b/themes/horizon/landuse.js
@@ -136,7 +136,7 @@ export function parseLanduse(json, minSpanM = 60, cap = 400) {
  * largest first). Returns null when nothing painted - the caller
  * keeps the base grass.
  */
-export function landTint(polys, anchor, world, n) {
+export function landTint(polys, anchor, world, n, soilFactor = 1) {
   const data = new Float32Array(n * n * 4);
   const half = world / 2;
   let painted = 0;
@@ -183,11 +183,12 @@ export function landTint(polys, anchor, world, n) {
           n - 1,
           Math.floor(((xs[k + 1] + half) / world) * n - 0.5)
         );
+        const f = SOIL_CLASSES.has(p.cls) ? soilFactor : 1;
         for (let i = i0; i <= i1; i++) {
           const o = (row * n + i) * 4;
-          data[o] = p.albedo[0];
-          data[o + 1] = p.albedo[1];
-          data[o + 2] = p.albedo[2];
+          data[o] = p.albedo[0] * f;
+          data[o + 1] = p.albedo[1] * f;
+          data[o + 2] = p.albedo[2] * f;
           data[o + 3] = 1;
           hit = true;
         }
@@ -196,6 +197,41 @@ export function landTint(polys, anchor, world, n) {
     if (hit) painted++;
   }
   return painted ? {data, n, world, painted} : null;
+}
+
+// ---- Wet soil darkens: Lobell & Asner (2002, SSSAJ 66) ----
+// Their laboratory result: soil reflectance falls EXPONENTIALLY
+// with moisture expressed as degree of saturation, similarly
+// across soil types - R = b + a exp(-c theta_sat) - and in the
+// visible band the decay saturates by ~0.20 m3/m3 volumetric.
+// Two documented parameters close the per-soil unknowns: the
+// classic visible-band figure that saturated soil reflects about
+// HALF of dry (SAT_RATIO), and a typical loam porosity to convert
+// the forecast's volumetric moisture to degree of saturation. The
+// decay constant is DERIVED from the paper's saturation point:
+// exp(-c * 0.20/porosity) = 1/20 (95% of the decay spent there).
+export const SOIL_POROSITY = 0.45;
+export const SOIL_SAT_RATIO = 0.5;
+export const SOIL_C = Math.log(20) / (0.2 / SOIL_POROSITY);
+
+// The bare-soil classes the darkening applies to - vegetated
+// tints (meadow, grass, forest) hide their soil under canopy.
+export const SOIL_CLASSES = new Set([
+  'farmland',
+  'farmyard',
+  'allotments',
+  'quarry',
+  'sand',
+  'beach'
+]);
+
+// Volumetric topsoil moisture (m3/m3, the forecast's
+// soil_moisture_0_to_1cm) -> albedo factor. Dry ground is 1;
+// missing data is 1 - nothing invented.
+export function soilDarkening(theta) {
+  if (!Number.isFinite(theta) || theta <= 0) return 1;
+  const sat = Math.min(1, theta / SOIL_POROSITY);
+  return SOIL_SAT_RATIO + (1 - SOIL_SAT_RATIO) * Math.exp(-SOIL_C * sat);
 }
 
 // The pointwise probe the raster is gated against (and the smoke


### PR DESCRIPTION
The coupling class — two measured systems interacting. The landuse tints (#71) painted the fields one dry albedo forever; real fields darken after real rain.

## Source
The same Open-Meteo forecast family already serving weather, marine and air quality publishes `soil_moisture_0_to_1cm` (m³/m³) — the reactive top centimetre, the layer the eye actually sees wet. Live at capture: **0.108 m³/m³ at Interlaken that morning**.

## Research
**Lobell & Asner (2002, SSSAJ 66:722)** — the laboratory result that soil reflectance falls **exponentially** with moisture expressed as *degree of saturation*, similarly across soil types: `R = b + a·exp(−c·θ_sat)`, with the visible band saturating by ~0.20 m³/m³ volumetric. Their four soils differ (no single published constant), so two documented parameters close the per-soil unknowns — the classic visible-band figure that saturated soil reflects about **half** of dry, and loam porosity 0.45 — and the decay constant is **derived from the paper's own saturation point** rather than picked: `exp(−c·0.20/porosity) = 1/20` → c = 6.74.

## Changes
- `landuse.js`: `soilDarkening` (dry = 1, monotone, saturated floor, **factor 1 whenever the data cannot speak**), `SOIL_CLASSES` (farmland, farmyard, allotments, quarry, sand, beach — vegetated tints stand: canopy hides soil), `landTint` applies the factor at paint time.
- **Gate 5 → 6 landmarks**: the exponential exact, the derivation identity held to 1e-12, and through the painter — a farmland texel darkens by exactly the factor (float32 `fround`) while a meadow texel stands. At the live capture the fields render **×0.599**: visibly damp ground, measured.
- Theme: `syncSoil` picks the current hour, refreshes every 3 h, re-syncs on roam; panel records θ and the tint (`0.108 m³/m³ (0-1 cm) · bare-soil tint ×0.60 (Lobell-Asner)`). `?soil=0` pins dry; KEEP_PARAMS carries `soil`.

## Validation
Gate 53 sets green; browser smoke clean.

Sources: [Lobell & Asner 2002, SSSAJ](https://acsess.onlinelibrary.wiley.com/doi/10.2136/sssaj2002.7220) · [Semantic Scholar record](https://www.semanticscholar.org/paper/Moisture-effects-on-soil-reflectance-Lobell-Asner/9f0599477307abdb6cf725189ec474cf937a3ace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKKBen9kkD562HDVr7cXAx

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKKBen9kkD562HDVr7cXAx)_