### PR TITLE
Horizon: measured roof ridges and church spires

### DIFF
--- a/themes/horizon/WEBGPU-PLAN.md
+++ b/themes/horizon/WEBGPU-PLAN.md
@@ -2870,6 +2870,39 @@ secret put AISSTREAM_KEY && npx wrangler deploy`.
   through the factor; panel records theta and the tint; ?soil=0
   pins dry; KEEP_PARAMS carries 'soil'. Gate 53 sets (landuse
   5 -> 6 landmarks); browser smoke clean.
+- DONE: measured ridges and the church spires (Jul 10, the asset
+  lane - every added vertex traceable to a tag or a theorem). The
+  gable decision was a vertex-count heuristic (ring <= 6) and the
+  ridge itself only built for exact quads - an L-shaped house
+  vertex-counted as "rectangular" while a true rectangle with one
+  surveyed notch fell to a flat cap. Now the decision is
+  MEASURED: buildings.js gained convexHull (Andrew monotone
+  chain) and minAreaRect - the minimum-area enclosing rectangle
+  by rotating calipers, EXACT by the Freeman & Shapira (1975)
+  theorem that the optimum shares a side with a hull edge, so
+  testing hull edge directions is complete, not a search. A
+  house-family footprint takes a ridge iff its true area fills >=
+  80% of its own rectangle; the ridge rides the rectangle's
+  measured long axis with the real 0.4 m eave overhang past the
+  walls (roof orders re-hand-checked for outward normals under
+  the general axis pair). On the LIVE fixture the census moved
+  honestly: 31 -> 48 gabled - 17 near-rectangular houses with 5+
+  surveyed vertices now carry correctly oriented ridges. And the
+  churches got their spires: building=church/chapel raises a
+  slate pyramid over a gable end (the END is untagged anywhere -
+  a deterministic pick via the shared hash, the same convention
+  as the facade tints), base a quarter of the measured short
+  axis, height max(1.1 h, 8 m). A REAL church joined the fixture
+  for it: the Evangelisch-Reformierte Kirche Unterseen, 9 surveyed
+  nodes, 1.4 km from the anchor. Gate 5 -> 7 landmarks: the
+  rotated 40 x 25 rectangle recovers its area to 0.0e+0 with its
+  true axis and the L fills 55% (< 80, stays flat); the notched
+  6-vertex house - the OLD rule's blind spot - rides a real
+  sloped ridge, and the live church raises its spire 31.8 m over
+  ground with nothing anywhere facing down. Viewer: the town
+  stage includes the church; the reshoot shows the town's
+  roofscape reorganised along the true footprint axes. Gate 53
+  sets (buildings 5 -> 7 landmarks); browser smoke clean.
 - OPEN (environment, not code) - UPDATE (roam smoke, Jul 7): the
   drift now also manifests as a PER-FRAME uncaught TypeError -
   GPUTexture.createView rejects the `swizzle` field three's

--- a/themes/horizon/buildings-fixture.mjs
+++ b/themes/horizon/buildings-fixture.mjs
@@ -3159,3 +3159,30 @@ export const BUILDINGS_FIXTURE = {
     }
   ]
 };
+
+// A REAL church for the spire landmark (captured 2026-07-10,
+// same mirror): the Evangelisch-Reformierte Kirche Unterseen,
+// a clean 9-node footprint 1.4 km from the anchor.
+export const CHURCH_FIXTURE = {
+  elements: [
+    {
+      type: 'way',
+      id: 184035544,
+      geometry: [
+        {lat: 46.687503, lon: 7.849447},
+        {lat: 46.687541, lon: 7.849297},
+        {lat: 46.687777, lon: 7.849423},
+        {lat: 46.687729, lon: 7.849616},
+        {lat: 46.68752, lon: 7.849504},
+        {lat: 46.687513, lon: 7.849528},
+        {lat: 46.687468, lon: 7.849504},
+        {lat: 46.687485, lon: 7.849437},
+        {lat: 46.687503, lon: 7.849447}
+      ],
+      tags: {
+        building: 'church',
+        name: 'Evangelisch-Reformierte Kirche Unterseen'
+      }
+    }
+  ]
+};

--- a/themes/horizon/buildings-reference.mjs
+++ b/themes/horizon/buildings-reference.mjs
@@ -10,13 +10,15 @@
 import {
   areaM2,
   buildingsGeometry,
+  convexHull,
   DEFAULT_HEIGHT,
   earClip,
   heightOf,
   LEVEL_M,
+  minAreaRect,
   parseBuildings
 } from './buildings.js';
-import {BUILDINGS_FIXTURE} from './buildings-fixture.mjs';
+import {BUILDINGS_FIXTURE, CHURCH_FIXTURE} from './buildings-fixture.mjs';
 import {geoToScene} from './roam.js';
 
 let fail = 0;
@@ -194,6 +196,128 @@ const builds = parseBuildings(BUILDINGS_FIXTURE);
       drowned.placed === 0 &&
       drowned.count === 0,
     `${set.length} buildings (gabled + flat among them) -> ${g.count} vertices: bases at ground-2m, tops within height+gable, ${horiz} horizontal wall normals, ${up} straight-up roof normals, none facing down, glow carried; on water nothing is placed`
+  );
+}
+
+{
+  // Minimum-area rectangle by rotating calipers - EXACT by the
+  // Freeman & Shapira (1975) theorem (the optimum shares a side
+  // with a hull edge): a 40 x 25 rectangle rotated to an awkward
+  // angle recovers its own area, extents and axis; an L-shape
+  // fills well under the 0.8 ridge threshold; the hull ignores an
+  // interior point.
+  const th = (33 * Math.PI) / 180;
+  const rot = ([x, y]) => [
+    x * Math.cos(th) - y * Math.sin(th),
+    x * Math.sin(th) + y * Math.cos(th)
+  ];
+  const rect = [
+    [0, 0],
+    [40, 0],
+    [40, 25],
+    [0, 25]
+  ].map(rot);
+  const r = minAreaRect(rect);
+  const axisDot = Math.abs(r.ux * Math.cos(th) + r.uy * Math.sin(th));
+  const L = [
+    [0, 0],
+    [40, 0],
+    [40, 10],
+    [10, 10],
+    [10, 25],
+    [0, 25]
+  ];
+  const lRect = minAreaRect(L);
+  const lArea = 40 * 10 + 10 * 15; // the L's true area, 550
+  const hull = convexHull([
+    [0, 0],
+    [10, 0],
+    [10, 10],
+    [0, 10],
+    [5, 5]
+  ]);
+  check(
+    'minimum-area rectangle',
+    Math.abs(r.area - 1000) < 1e-9 &&
+      Math.abs(r.L - 40) < 1e-9 &&
+      Math.abs(r.W - 25) < 1e-9 &&
+      Math.abs(axisDot - 1) < 1e-12 &&
+      lArea / lRect.area < 0.8 &&
+      hull.length === 4,
+    `a 33deg-rotated 40 x 25 recovers area 1000 to ${Math.abs(r.area - 1000).toExponential(1)} with its true axis; the L fills ${((lArea / lRect.area) * 100).toFixed(0)}% (< 80, stays flat); the hull drops the interior point`
+  );
+}
+
+{
+  // The measured ridge and the spire: a 6-vertex near-rectangular
+  // house (a notch the OLD vertex-count rule pretended away and
+  // the quad-only builder then dropped to a FLAT cap) now takes a
+  // real sloped ridge; the LIVE Unterseen church (9 real nodes)
+  // raises its spire above ridge height; nothing anywhere faces
+  // down.
+  const anchor = {lat: 46.6863, lon: 7.8632};
+  const U = 7 / 400;
+  const mLat = 111320;
+  const mLon = mLat * Math.cos((46.6863 * Math.PI) / 180);
+  const g2m = (dx, dy) => [46.6863 + dy / mLat, 7.8632 + dx / mLon];
+  const notched = {
+    type: 'way',
+    id: 77,
+    tags: {building: 'house'},
+    geometry: [
+      g2m(0, 0),
+      g2m(14, 0),
+      g2m(14, 8),
+      g2m(6, 8),
+      g2m(6, 7.2),
+      g2m(0, 7.2),
+      g2m(0, 0)
+    ].map(([lat, lon]) => ({lat, lon}))
+  };
+  const parsed = parseBuildings({elements: [notched]});
+  const hg = buildingsGeometry(
+    parsed,
+    anchor,
+    () => 10,
+    () => 0,
+    U,
+    1e9
+  );
+  let sloped = 0;
+  let down = 0;
+  for (let i = 0; i < hg.count; i++) {
+    const ny = hg.normal[3 * i + 1];
+    if (ny > 0.05 && ny < 0.95) sloped++;
+    if (ny < -1e-6) down++;
+  }
+  const church = parseBuildings(CHURCH_FIXTURE);
+  const cg = buildingsGeometry(
+    church,
+    anchor,
+    () => 10,
+    () => 0,
+    U,
+    1e9
+  );
+  let cMax = -Infinity;
+  let cDown = 0;
+  for (let i = 0; i < cg.count; i++) {
+    cMax = Math.max(cMax, cg.position[3 * i + 1]);
+    if (cg.normal[3 * i + 1] < -1e-6) cDown++;
+  }
+  const ridgeTop = 10 + church[0].h * U + 4.5 * U; // walls + max gable
+  check(
+    'measured ridge and the spire',
+    parsed[0].gabled &&
+      sloped >= 12 &&
+      down === 0 &&
+      church.length === 1 &&
+      church[0].spire &&
+      church[0].h === 13 &&
+      cg.placed === 1 &&
+      cMax > ridgeTop + 6 * U &&
+      cDown === 0,
+    `the notched 6-vertex house rides a real ridge (${sloped} sloped roof normals, none down); the Unterseen church (13 m ladder height) raises its spire ${((cMax - 10) / U).toFixed(1)} m over the ground, well above its ridge`
   );
 }
 

--- a/themes/horizon/buildings.js
+++ b/themes/horizon/buildings.js
@@ -66,6 +66,102 @@ const GABLED = new Set([
   'church'
 ]);
 
+// Andrew monotone-chain convex hull of [x, y] points (CCW).
+export function convexHull(pts) {
+  const p = pts.slice().sort((a, b) => a[0] - b[0] || a[1] - b[1]);
+  if (p.length <= 2) return p;
+  const cross = (o, a, b) =>
+    (a[0] - o[0]) * (b[1] - o[1]) - (a[1] - o[1]) * (b[0] - o[0]);
+  const lo = [];
+  for (const q of p) {
+    while (
+      lo.length >= 2 &&
+      cross(lo[lo.length - 2], lo[lo.length - 1], q) <= 0
+    )
+      lo.pop();
+    lo.push(q);
+  }
+  const hi = [];
+  for (let i = p.length - 1; i >= 0; i--) {
+    const q = p[i];
+    while (
+      hi.length >= 2 &&
+      cross(hi[hi.length - 2], hi[hi.length - 1], q) <= 0
+    )
+      hi.pop();
+    hi.push(q);
+  }
+  lo.pop();
+  hi.pop();
+  return lo.concat(hi);
+}
+
+/**
+ * Minimum-area enclosing rectangle by rotating calipers. Freeman
+ * & Shapira (1975): the minimum-area rectangle enclosing a convex
+ * polygon has a side COLLINEAR with one of its edges - so testing
+ * every hull edge direction is EXACT, not a search. Returns
+ * {cx, cy, ux, uy, L, W, area}: centre, unit LONG axis, long and
+ * short extents.
+ */
+export function minAreaRect(pts) {
+  const hull = convexHull(pts);
+  if (hull.length < 3) {
+    const [a, b] = [hull[0], hull[hull.length - 1] || hull[0]];
+    const dx = b[0] - a[0];
+    const dy = b[1] - a[1];
+    const l = Math.hypot(dx, dy) || 1;
+    return {
+      cx: (a[0] + b[0]) / 2,
+      cy: (a[1] + b[1]) / 2,
+      ux: dx / l,
+      uy: dy / l,
+      L: Math.hypot(dx, dy),
+      W: 0,
+      area: 0
+    };
+  }
+  let best = null;
+  for (let i = 0; i < hull.length; i++) {
+    const [ax, ay] = hull[i];
+    const [bx, by] = hull[(i + 1) % hull.length];
+    const el = Math.hypot(bx - ax, by - ay);
+    if (!el) continue;
+    const ux = (bx - ax) / el;
+    const uy = (by - ay) / el;
+    let u0 = Infinity;
+    let u1 = -Infinity;
+    let v0 = Infinity;
+    let v1 = -Infinity;
+    for (const [x, y] of hull) {
+      const u = x * ux + y * uy;
+      const v = -x * uy + y * ux;
+      u0 = Math.min(u0, u);
+      u1 = Math.max(u1, u);
+      v0 = Math.min(v0, v);
+      v1 = Math.max(v1, v);
+    }
+    const area = (u1 - u0) * (v1 - v0);
+    if (!best || area < best.area) {
+      const cu = (u0 + u1) / 2;
+      const cv = (v0 + v1) / 2;
+      const du = u1 - u0;
+      const dv = v1 - v0;
+      const long = du >= dv;
+      best = {
+        cx: cu * ux - cv * uy,
+        cy: cu * uy + cv * ux,
+        ux: long ? ux : -uy,
+        uy: long ? uy : ux,
+        L: Math.max(du, dv),
+        W: Math.min(du, dv),
+        area
+      };
+    }
+  }
+  return best;
+}
+
 // Shoelace area of a geodetic ring, in m^2 (equirectangular).
 export function areaM2(ring) {
   const mLat = 111320;
@@ -97,6 +193,19 @@ export function parseBuildings(json, cap = 400, minAreaM2 = 25) {
     const area = areaM2(ring);
     if (area < minAreaM2) continue;
     const tags = el.tags || {};
+    // The ridge decision is MEASURED, not vertex-counted: the
+    // footprint's minimum-area rectangle (rotating calipers,
+    // exact) against its true area. A near-rectangular house -
+    // whatever its vertex count - fills >= 80% of its rectangle
+    // and takes a ridge; an L-shape does not.
+    const mLat = 111320;
+    const mLon = mLat * Math.cos((ring[0][0] * Math.PI) / 180);
+    const local = ring.map(([la, lo]) => [
+      (lo - ring[0][1]) * mLon,
+      (la - ring[0][0]) * mLat
+    ]);
+    const obb = minAreaRect(local);
+    const fill = obb.area > 0 ? area / obb.area : 0;
     out.push({
       id: el.id,
       ring,
@@ -105,7 +214,11 @@ export function parseBuildings(json, cap = 400, minAreaM2 = 25) {
       // typed as a house family at all -> tiled roof tone even
       // when the footprint is too complex for a ridge
       house: GABLED.has(tags.building),
-      gabled: GABLED.has(tags.building) && ring.length <= 6
+      gabled: GABLED.has(tags.building) && fill >= 0.8,
+      // churches and chapels carry their spire (a documented
+      // designed asset on the real tag, like the vessel
+      // silhouettes) at a deterministic gable end
+      spire: tags.building === 'church' || tags.building === 'chapel'
     });
   }
   // centroid-of-centroids -> nearest first, then the display cap
@@ -272,30 +385,39 @@ export function buildingsGeometry(builds, anchor, groundY, glowAt, U, lim) {
       tri(a0, b0, b1, facade, glow);
       tri(a0, b1, a1, facade, glow);
     }
-    // Roof: gabled ridge for near-rectangular small-house types,
-    // ear-clipped flat cap otherwise.
-    if (b.gabled && pts.length === 4) {
-      // ridge along the longer axis' midpoints
-      const mid = (p, q) => [(p[0] + q[0]) / 2, (p[1] + q[1]) / 2];
-      const len = (p, q) => Math.hypot(q[0] - p[0], q[1] - p[1]);
-      const e01 = len(pts[0], pts[1]);
-      const e12 = len(pts[1], pts[2]);
-      // ridge connects midpoints of the two SHORT edges
-      const [s1, s2, l1, l2] =
-        e01 < e12
-          ? [mid(pts[0], pts[1]), mid(pts[2], pts[3]), [0, 1], [2, 3]]
-          : [mid(pts[1], pts[2]), mid(pts[3], pts[0]), [1, 2], [3, 0]];
-      const gH = Math.min(0.35 * Math.min(e01, e12), 4.5 * U);
-      const r1 = [s1[0], top + gH, s1[1]];
-      const r2 = [s2[0], top + gH, s2[1]];
-      const q = (i) => [pts[i][0], top, pts[i][1]];
-      // two roof planes + two gable triangles
-      tri(q(l1[1]), q(l2[0]), r2, ROOF, glow);
-      tri(q(l1[1]), r2, r1, ROOF, glow);
-      tri(q(l2[1]), q(l1[0]), r1, ROOF, glow);
-      tri(q(l2[1]), r1, r2, ROOF, glow);
-      tri(q(l1[0]), q(l1[1]), r1, facade, glow);
-      tri(q(l2[0]), q(l2[1]), r2, facade, glow);
+    // Roof: the ridge rides the footprint's MEASURED minimum-area
+    // rectangle (rotating calipers - exact by Freeman & Shapira),
+    // so a near-rectangular house takes a correctly ORIENTED
+    // ridge whatever its vertex count, with the real 0.4 m eave
+    // overhang past the walls; ear-clipped flat cap otherwise.
+    const obb = minAreaRect(pts);
+    let gH = 0;
+    if (b.gabled && obb && obb.W > 0) {
+      const EAVE = 0.4 * U;
+      const hl = obb.L / 2 + EAVE;
+      const hw = obb.W / 2 + EAVE;
+      const px = -obb.uy; // perpendicular unit axis
+      const py = obb.ux;
+      gH = Math.min(0.35 * (obb.W + 2 * EAVE), 4.5 * U);
+      const P3 = (du, dv, y) => [
+        obb.cx + obb.ux * du + px * dv,
+        y,
+        obb.cy + obb.uy * du + py * dv
+      ];
+      const A = P3(-hl, -hw, top);
+      const B = P3(hl, -hw, top);
+      const C = P3(hl, hw, top);
+      const D = P3(-hl, hw, top);
+      const R1 = P3(-hl, 0, top + gH);
+      const R2 = P3(hl, 0, top + gH);
+      // two roof planes + two gable triangles (orders hand-checked
+      // for outward normals under the axis convention)
+      tri(A, R2, B, ROOF, glow);
+      tri(A, R1, R2, ROOF, glow);
+      tri(C, R1, D, ROOF, glow);
+      tri(C, R2, R1, ROOF, glow);
+      tri(A, D, R1, facade, glow);
+      tri(C, B, R2, facade, glow);
     } else {
       // earClip emits shoelace-positive triangles - clockwise seen
       // from +y in x-z coords - so emit REVERSED for an up normal.
@@ -309,6 +431,34 @@ export function buildingsGeometry(builds, anchor, groundY, glowAt, U, lim) {
           glow
         );
       }
+    }
+    // The spire: churches and chapels raise one over a gable end.
+    // The END is not tagged anywhere - a deterministic pick via
+    // the shared hash, the same convention as the facade tints.
+    if (b.spire && obb && obb.W > 0) {
+      const e = hash3(b.id | 0, 1, 7) < 0.5 ? -1 : 1;
+      const s2 = 0.25 * obb.W; // half the base side
+      const y0 = top + gH;
+      const spireH = Math.max(1.1 * b.h, 8) * U;
+      const px = -obb.uy;
+      const py = obb.ux;
+      const qcx = obb.cx + obb.ux * e * (obb.L / 2 - s2);
+      const qcy = obb.cy + obb.uy * e * (obb.L / 2 - s2);
+      const S = (du, dv) => [
+        qcx + obb.ux * du + px * dv,
+        y0,
+        qcy + obb.uy * du + py * dv
+      ];
+      const q1 = S(-s2, -s2);
+      const q2 = S(s2, -s2);
+      const q3 = S(s2, s2);
+      const q4 = S(-s2, s2);
+      const apex = [qcx, y0 + spireH, qcy];
+      const SPIRE = [0.24, 0.23, 0.26]; // slate
+      tri(q2, q1, apex, SPIRE, glow);
+      tri(q3, q2, apex, SPIRE, glow);
+      tri(q4, q3, apex, SPIRE, glow);
+      tri(q1, q4, apex, SPIRE, glow);
     }
     placed++;
   }

--- a/themes/horizon/harness/asset-viewer.html
+++ b/themes/horizon/harness/asset-viewer.html
@@ -39,7 +39,10 @@
       import {buildVessel} from '../vessels.js';
       import {typeClass} from '../ships.js';
       import {buildingsGeometry, parseBuildings} from '../buildings.js';
-      import {BUILDINGS_FIXTURE} from '../buildings-fixture.mjs';
+      import {
+        BUILDINGS_FIXTURE,
+        CHURCH_FIXTURE
+      } from '../buildings-fixture.mjs';
       import {parseRoads, roadsGeometry} from '../roads.js';
       import {ROADS_FIXTURE} from '../roads-fixture.mjs';
       import {landTint, parseLanduse} from '../landuse.js';
@@ -206,7 +209,12 @@
             scene.add(landPlane);
           }
         }
-        let builds = parseBuildings(BUILDINGS_FIXTURE);
+        let builds = parseBuildings({
+          elements: [
+            ...BUILDINGS_FIXTURE.elements,
+            ...CHURCH_FIXTURE.elements // the Unterseen spire
+          ]
+        });
         if (+q.get('n')) builds = builds.slice(0, +q.get('n')); // nearest-first
         const g = buildingsGeometry(
           builds,


### PR DESCRIPTION
Asset-design lane: every added vertex traceable to a tag or a theorem.

## The ridge decision is now measured
The gable decision was a vertex-count heuristic (`ring ≤ 6`) and the ridge only built for exact quads — so an L-shaped house *vertex-counted* as rectangular while a true rectangle with one surveyed notch fell to a flat cap. Now:

- `buildings.js` gained **`convexHull`** (Andrew monotone chain) and **`minAreaRect`** — the minimum-area enclosing rectangle by rotating calipers, exact by the **Freeman & Shapira (1975)** theorem that the optimum shares a side with a hull edge (testing hull-edge directions is complete, not a search).
- A house-family footprint takes a ridge **iff its true area fills ≥ 80% of its own rectangle**; the ridge rides the rectangle's measured long axis, with the real **0.4 m eave overhang** past the walls. Roof triangle orders re-hand-checked for outward normals under the general axis pair.
- On the LIVE fixture the census moved honestly: **31 → 48 gabled** — 17 near-rectangular houses with 5+ surveyed vertices now carry correctly oriented ridges.

## The churches got their spires
`building=church/chapel` raises a slate pyramid over a gable end — the end is untagged anywhere, so it's a deterministic pick via the shared hash, the same convention as the facade tints. Base = a quarter of the measured short axis; height = max(1.1·h, 8 m). A **real church joined the fixture**: the Evangelisch-Reformierte Kirche Unterseen, 9 surveyed nodes, 1.4 km from the anchor.

## Gate 5 → 7 landmarks
- **Minimum-area rectangle**: a 33°-rotated 40 × 25 recovers its area to 0.0e+0 with its true axis; the L fills 55% (< 80, stays flat); the hull drops an interior point.
- **Measured ridge and the spire**: the notched 6-vertex house — the old rule's blind spot — rides a real sloped ridge (12 sloped roof normals, none down); the live church raises its spire **31.8 m over ground**, well above its ridge, with nothing anywhere facing down.

Viewer: the town stage includes the church; the reshoot shows the roofscape reorganised along the true footprint axes. Gate 53 sets green; browser smoke clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKKBen9kkD562HDVr7cXAx

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKKBen9kkD562HDVr7cXAx)_