### PR TITLE
Horizon: cable cabins pendulum in the measured wind

### DIFF
--- a/themes/Horizon.html
+++ b/themes/Horizon.html
@@ -70,7 +70,10 @@
         period from the real wind, deep-water dispersion, whitecap
         fraction from Monahan & O'Muircheartaigh, fresnel sun glitter
       - clouds ride the true wind vector at the real lifting condensation
-        level; trees are spring-dampers forced by real mean wind and gusts
+        level; trees are spring-dampers forced by real mean wind and
+        gusts, and the cable-car cabins pendulum in the same air -
+        drag/gravity statics for the lean, gusts cycling it at the
+        hanger's own sqrt(g/L) frequency
       - USGS M4.5+ earthquakes arrive at their true seismic travel times
         (P then S), attenuated by real distance
       - aurora follows NOAA's OVATION forecast oval: its real latitude
@@ -454,7 +457,9 @@
       } from './horizon/trains.js';
       import {buildTrain} from './horizon/rollingstock.js';
       import {
+        CABIN,
         cabinFractions,
+        cabinSwing,
         catenaryPoints,
         parseAerialways,
         PYLON_M,
@@ -3665,12 +3670,14 @@
       // at deterministic hash fractions along the line. Lines
       // render 1 px at any distance - what a distant cable is.
       let aerialGroup = null;
+      const aerialCabins = []; // {m, hang, phase} - swung per frame
       let cableMat = null;
       let pylonMat = null;
       let cabinMat = null;
       const pylonGeo = new THREE.CylinderGeometry(0.006, 0.009, 1, 5);
       const cabinGeo = new THREE.BoxGeometry(0.045, 0.05, 0.055);
       function placeAerialways() {
+        aerialCabins.length = 0;
         if (aerialGroup) {
           ground.remove(aerialGroup);
           aerialGroup.traverse((o) => {
@@ -3755,8 +3762,11 @@
             const k = Math.min(9, Math.floor(t * 10));
             const q = span[k];
             const cab = new THREE.Mesh(cabinGeo, cabinMat);
-            cab.position.set(q[0], q[1] - 0.03, q[2]);
+            cab.position.set(q[0], q[1] - CABIN.arm / MPU, q[2]);
             aerialGroup.add(cab);
+            // The frame loop swings each cabin as a pendulum in
+            // the measured wind (aerialways.js, gated).
+            aerialCabins.push({m: cab, hang: q, phase: f * Math.PI * 2});
           }
           placed++;
         }
@@ -7493,6 +7503,32 @@
           u.v += (14 * (forcing - u.a) - 4.2 * u.v) * dt;
           u.a += u.v * dt;
           tree.setRotationFromAxisAngle(treeAxis, u.a);
+        }
+
+        // Cable cabins: pendulums in the SAME measured wind that
+        // sways the trees - the drag/gravity statics set the lean,
+        // gusts cycle it at the pendulum's own sqrt(g/L) frequency
+        // (aerialways.js, gated). treeAxis already points along
+        // the true wind's perpendicular this frame.
+        if (aerialCabins.length) {
+          const armU = CABIN.arm / MPU;
+          const tS = t / 1000;
+          for (const c of aerialCabins) {
+            const th = cabinSwing(
+              state.wind / 3.6,
+              state.gust / 3.6,
+              centerElev,
+              tS,
+              c.phase
+            );
+            const s = Math.sin(th) * armU;
+            c.m.position.set(
+              c.hang[0] + windV.x * s,
+              c.hang[1] - Math.cos(th) * armU,
+              c.hang[2] + windV.z * s
+            );
+            c.m.setRotationFromAxisAngle(treeAxis, th);
+          }
         }
 
         // ISS: SGP4-propagated position; drawn only when the pass is

--- a/themes/horizon/WEBGPU-PLAN.md
+++ b/themes/horizon/WEBGPU-PLAN.md
@@ -2903,6 +2903,29 @@ secret put AISSTREAM_KEY && npx wrangler deploy`.
   stage includes the church; the reshoot shows the town's
   roofscape reorganised along the true footprint axes. Gate 53
   sets (buildings 5 -> 7 landmarks); browser smoke clean.
+- DONE: cabins pendulum in the measured wind (Jul 10, the
+  coupling lane - the gusts that already sway the trees now swing
+  the cable cars). A suspended cabin IS a pendulum: statics from
+  the drag equation balanced against gravity, tan(lean) =
+  0.5 rho v^2 Cd A / (m g), leaning the hanger along the TRUE
+  wind direction; dynamics from the pendulum's own natural
+  frequency omega = sqrt(g/L) - gusts cycle the lean between the
+  mean-wind and gust-wind deflections at that frequency, phase
+  decorrelated per cabin via the deterministic fractions. The
+  documented cabin closes the untagged unknowns: an 8-seat
+  monocable gondola (600 kg tare, 2.6 m^2 frontal, Cd 1.1 bluff
+  body, 2.5 m hanger arm); air density thins with the anchor's
+  elevation on the 8.4 km scale height. aerialways.js gained
+  CABIN/windAngle/cabinSwing, gate 4 -> 5 landmarks: the statics
+  identity exact to 1e-15, the density-altitude ratio exactly
+  exp(-1) at one scale height, omega exact, the gust cycle
+  bounded by (and sweeping) the [mean, gust] lean interval, calm
+  hanging plumb. Theme: placeAerialways registers each cabin with
+  its hang point and phase; the frame loop swings them about the
+  SAME treeAxis/windV pair the tree spring-dampers use - one wind,
+  every consumer. Hanger length corrected from the old ad hoc
+  1.7 m offset to the documented 2.5 m arm. Gate 53 sets
+  (aerialways 4 -> 5 landmarks); browser smoke clean.
 - OPEN (environment, not code) - UPDATE (roam smoke, Jul 7): the
   drift now also manifests as a PER-FRAME uncaught TypeError -
   GPUTexture.createView rejects the `swizzle` field three's

--- a/themes/horizon/aerialways-reference.mjs
+++ b/themes/horizon/aerialways-reference.mjs
@@ -9,11 +9,16 @@
 //    names, pylon lines verbatim
 //  - cabins: deterministic hash positions, counts by kind
 import {
+  CABIN,
   cabinFractions,
+  cabinSwing,
   catenaryPoints,
+  G_MS2,
   parseAerialways,
+  PEND_W,
   SAG_FRAC,
-  solveCatenaryA
+  solveCatenaryA,
+  windAngle
 } from './aerialways.js';
 import {AERIAL_FIXTURE} from './aerialways-fixture.mjs';
 
@@ -117,6 +122,42 @@ const ways = parseAerialways(AERIAL_FIXTURE);
     'cabin positions',
     ok,
     `cable car 2 cars, a 2.2 km gondola ${gd.length} cabins at deterministic hash fractions`
+  );
+}
+
+{
+  // The pendulum: the drag/gravity statics identity exact, the
+  // density altitude exact on the scale height, the natural
+  // frequency from sqrt(g/L), the gust cycle bounded by the mean
+  // and gust deflections, calm hangs plumb.
+  const v = 20; // m/s
+  const want = (0.5 * 1.225 * v * v * CABIN.Cd * CABIN.A) / (CABIN.m * G_MS2);
+  const statics = Math.abs(Math.tan(windAngle(v, 0)) - want) < 1e-15;
+  const dens =
+    Math.abs(
+      Math.tan(windAngle(v, 8400)) / Math.tan(windAngle(v, 0)) - Math.exp(-1)
+    ) < 1e-12;
+  const a0 = windAngle(8, 600);
+  const a1 = windAngle(16, 600);
+  let inBounds = true;
+  let lo = Infinity;
+  let hi = -Infinity;
+  for (let t = 0; t < 20; t += 0.1) {
+    const th = cabinSwing(8, 16, 600, t, 1.3);
+    if (th < a0 - 1e-12 || th > a1 + 1e-12) inBounds = false;
+    lo = Math.min(lo, th);
+    hi = Math.max(hi, th);
+  }
+  check(
+    'cabin pendulum',
+    statics &&
+      dens &&
+      Math.abs(PEND_W - Math.sqrt(G_MS2 / CABIN.arm)) < 1e-15 &&
+      windAngle(0, 0) === 0 &&
+      cabinSwing(0, 0, 0, 5, 0) === 0 &&
+      inBounds &&
+      hi - lo > (a1 - a0) * 0.9,
+    `tan(lean) = drag/weight exactly (${((want * 180) / Math.PI).toFixed(1)}deg-scale at 20 m/s); density altitude exp(-h/8400) exact; omega = sqrt(g/${CABIN.arm}); the gust cycle sweeps [mean, gust] lean and calm hangs plumb`
   );
 }
 

--- a/themes/horizon/aerialways.js
+++ b/themes/horizon/aerialways.js
@@ -100,6 +100,36 @@ export function catenaryPoints(p0, p1, n = 12, sagFrac = SAG_FRAC) {
   return out;
 }
 
+// ---- The cabin pendulum: measured wind swings real cabins ----
+// A suspended cabin IS a pendulum. Statics: the drag equation
+// balanced against gravity - tan(theta) = 0.5 rho v^2 Cd A/(m g)
+// - leans the hanger along the wind; dynamics: gusts excite it at
+// the pendulum's OWN natural frequency omega = sqrt(g/L). The
+// documented cabin is an 8-seat monocable gondola: 600 kg tare,
+// 2.6 m^2 frontal area, Cd 1.1 (bluff body), 2.5 m hanger arm;
+// air density thins with altitude on the 8.4 km scale height.
+export const CABIN = {m: 600, A: 2.6, Cd: 1.1, arm: 2.5};
+export const G_MS2 = 9.81;
+export const PEND_W = Math.sqrt(G_MS2 / CABIN.arm); // rad/s
+
+// The static lean under a steady wind (m/s) at elevation (m).
+export function windAngle(vMs, elevM = 0) {
+  if (!Number.isFinite(vMs) || vMs <= 0) return 0;
+  const rho = 1.225 * Math.exp(-Math.max(elevM, 0) / 8400);
+  return Math.atan(
+    (0.5 * rho * vMs * vMs * CABIN.Cd * CABIN.A) / (CABIN.m * G_MS2)
+  );
+}
+
+// The swing at time t: the mean-wind lean, plus the gust-lull
+// cycle riding the pendulum's own frequency between the mean and
+// gust deflections; per-cabin phase decorrelates a line of them.
+export function cabinSwing(vMeanMs, vGustMs, elevM, tSec, phase = 0) {
+  const a0 = windAngle(vMeanMs, elevM);
+  const a1 = windAngle(Math.max(vGustMs || 0, vMeanMs || 0), elevM);
+  return a0 + (a1 - a0) * (0.5 + 0.5 * Math.sin(PEND_W * tSec + phase));
+}
+
 /**
  * Deterministic cabin positions for one installation: gondolas
  * circulate a cabin roughly every spacing metres, a cable car


### PR DESCRIPTION
The coupling lane: the gusts that already sway the trees (#spring-dampers on the real wind) now swing the cable cars (#77).

## The physics
A suspended cabin **is** a pendulum:
- **Statics**: the drag equation balanced against gravity — `tan(lean) = ½ρv²·Cd·A / (m·g)` — leaning the hanger along the *true* wind direction, with air density thinning at the anchor's elevation on the 8.4 km scale height.
- **Dynamics**: gusts cycle the lean between the mean-wind and gust-wind deflections at the pendulum's **own natural frequency** `ω = √(g/L)` (3.2 s period on the documented 2.5 m arm), phase-decorrelated per cabin via the deterministic fractions from #77.

The documented cabin closes the untagged unknowns: an 8-seat monocable gondola — 600 kg tare, 2.6 m² frontal, Cd 1.1 (bluff body), 2.5 m hanger arm.

## Gate (aerialways 4 → 5 landmarks)
The statics identity exact to 1e-15; the density-altitude ratio **exactly `exp(−1)` at one scale height**; ω exact from √(g/L); the gust cycle bounded by *and sweeping* the [mean, gust] lean interval; calm hangs plumb.

## Theme
`placeAerialways` registers each cabin with its hang point and phase; the frame loop swings them about the **same `treeAxis`/`windV` pair the tree spring-dampers use** — one wind, every consumer. The hanger length corrected from the ad hoc 1.7 m offset to the documented 2.5 m arm.

Gate 53 sets green; browser smoke clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKKBen9kkD562HDVr7cXAx

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKKBen9kkD562HDVr7cXAx)_