### PR TITLE
Horizon: snow lies on the roofs

### DIFF
--- a/themes/Horizon.html
+++ b/themes/Horizon.html
@@ -114,7 +114,9 @@
         house families, seated on the sampled terrain and never in
         water; after dark the walls emit the town's measured Black
         Marble radiance, so windows warm exactly where the night
-        lights say the town is lit; the street network is real too -
+        lights say the town is lit, and snow lies on the roofs
+        exactly as it lies on the ground beside them - the measured
+        satellite cover or the live snowfall, roof surfaces only; the street network is real too -
         OSM highway ways as ribbons of their tagged width (width >
         lanes x 3.5 m > per-type defaults) and tagged surface
         albedo, cut by water except where a tagged bridge spans it;
@@ -430,7 +432,9 @@
       } from './horizon/nightlights.js';
       import {
         attribute as tslAttribute,
-        uniform as tslUniform
+        mix as tslMix,
+        uniform as tslUniform,
+        vec3 as tslVec3
       } from 'three/tsl';
       import {buildVessel} from './horizon/vessels.js';
       import {buildingsGeometry, parseBuildings} from './horizon/buildings.js';
@@ -1774,6 +1778,16 @@
           terrainObj.snowTexNode.value = tex;
           if (old && old.image && old.image.width > 1) old.dispose();
           terrainUniforms.uSnowCovOn.value = 1;
+          // The town's roofs read the SAME measured field - re-seat
+          // the buildings so their snow attribute picks it up.
+          bldSnowAt = (x, z) => {
+            const gi = Math.round((x / WORLD + 0.5) * N - 0.5);
+            const gj = Math.round((0.5 - z / WORLD) * N - 0.5);
+            if (gi < 0 || gi >= N || gj < 0 || gj >= N) return 0;
+            const v = f.data[gj * N + gi];
+            return v > 0 ? v : 0;
+          };
+          if (worldBuilt) placeBuildings();
           record(
             'MODIS NDSI snow cover ' + day,
             Math.round(f.known * 100) +
@@ -3444,6 +3458,8 @@
       let bldMat = null;
       let bldNightU = null;
       let bldGlowAt = null; // scene (x,z) -> measured radiance [0..1]
+      let bldSnowAt = null; // scene (x,z) -> measured FSC [0..1]
+      let bldSnowU = null; // live-snowfall term (the terrain's uSnowy)
       function placeBuildings() {
         if (bldMesh) {
           ground.remove(bldMesh);
@@ -3471,13 +3487,37 @@
         geo.setAttribute('normal', new THREE.BufferAttribute(g.normal, 3));
         geo.setAttribute('color', new THREE.BufferAttribute(g.color, 3));
         geo.setAttribute('glow', new THREE.BufferAttribute(g.glow, 1));
+        geo.setAttribute('roof', new THREE.BufferAttribute(g.roof, 1));
+        // Measured snow per vertex: the same FSC field the terrain
+        // reads, sampled at each building vertex (0 until the
+        // satellite answers).
+        const rsnow = new Float32Array(g.count);
+        if (bldSnowAt)
+          for (let i = 0; i < g.count; i++)
+            rsnow[i] = bldSnowAt(g.position[3 * i], g.position[3 * i + 2]);
+        geo.setAttribute('rsnow', new THREE.BufferAttribute(rsnow, 1));
         if (!bldMat) {
           bldNightU = tslUniform(0);
+          bldSnowU = tslUniform(0);
           bldMat = new THREE.MeshStandardNodeMaterial({
             vertexColors: true,
             roughness: 0.9,
             metalness: 0
           });
+          // Snow lies on the roofs exactly as it lies on the
+          // ground beside them: the measured FSC (rsnow) OR the
+          // live-snowfall term the terrain uses (bldSnowU),
+          // whichever says more - and ONLY on the roof-flagged
+          // surfaces (walls, gables and spires stay bare). The
+          // snow albedo is the terrain's own.
+          bldMat.colorNode = tslMix(
+            tslAttribute('color'),
+            tslVec3(0.87, 0.9, 0.93),
+            tslAttribute('roof')
+              .mul(tslAttribute('rsnow').max(bldSnowU))
+              .clamp(0, 1)
+              .mul(0.95)
+          );
           bldMat.emissiveNode = tslUniform(
             new THREE.Color(LAMP_TINT[0], LAMP_TINT[1], LAMP_TINT[2])
           )
@@ -7317,6 +7357,7 @@
           state.temp <= 0.5 && (state.snow > 0 || state.code >= 71) ? 1 : 0;
         terrainUniforms.uSnowy.value +=
           (snowyGround - terrainUniforms.uSnowy.value) * Math.min(dt, 1);
+        if (bldSnowU) bldSnowU.value = terrainUniforms.uSnowy.value;
 
         const snowing =
           state.snow > 0 ||

--- a/themes/horizon/WEBGPU-PLAN.md
+++ b/themes/horizon/WEBGPU-PLAN.md
@@ -2926,6 +2926,26 @@ secret put AISSTREAM_KEY && npx wrangler deploy`.
   every consumer. Hanger length corrected from the old ad hoc
   1.7 m offset to the documented 2.5 m arm. Gate 53 sets
   (aerialways 4 -> 5 landmarks); browser smoke clean.
+- DONE: snow lies on the roofs (Jul 10, the coupling lane - the
+  measured snow cover and the OSM buildings meet). buildingsGeometry
+  gained a fourth attribute: `roof` flags exactly the surfaces
+  snow can LIE on (the sloped ridge planes and flat caps - walls,
+  gable faces and the spires stay bare: snow does not stand on
+  the vertical or the steep). The merged-geometry landmark now
+  holds it structurally: every flagged vertex faces up or
+  up-slope (ny > 0.05), both classes present, nothing mis-flagged.
+  Theme: the buildings' colorNode mixes the terrain's OWN snow
+  albedo (0.87/0.90/0.93) over the roof surfaces by
+  max(measured, live) - `rsnow`, a per-vertex attribute sampled
+  from the SAME Salomonson-Appel FSC field the terrain reads
+  (syncSnowCover re-seats the town when the field lands, the
+  lights-path precedent), OR the live-snowfall term, the very
+  uSnowy value the terrain smooths each frame (bldSnowU mirrors
+  it) - so when it snows tonight the roofs whiten with the ground
+  in real time, and tomorrow the satellite confirms or clears
+  them. Nothing new is invented: one snow state, three consumers
+  (terrain, physics drifts, now the roofs). Gate 53 sets
+  (buildings landmark strengthened in place); browser smoke clean.
 - OPEN (environment, not code) - UPDATE (roam smoke, Jul 7): the
   drift now also manifests as a PER-FRAME uncaught TypeError -
   GPUTexture.createView rejects the `swizzle` field three's

--- a/themes/horizon/buildings-reference.mjs
+++ b/themes/horizon/buildings-reference.mjs
@@ -174,6 +174,17 @@ const builds = parseBuildings(BUILDINGS_FIXTURE);
     if (ny < -1e-6) down++;
     if (y < 10 - 2 * U - 1e-6) yOk = false;
   }
+  // The roof flag: snow lies only where it can - every flagged
+  // vertex faces up or up-slope (ny > 0.05), every wall and gable
+  // is unflagged, and both classes exist in the set.
+  let roofOn = 0;
+  let roofBad = 0;
+  for (let i = 0; i < g.count; i++) {
+    if (g.roof[i] === 1) {
+      roofOn++;
+      if (g.normal[3 * i + 1] <= 0.05) roofBad++;
+    } else if (g.roof[i] !== 0) roofBad++;
+  }
   const hMax = Math.max(...set.map((b) => b.h)) * U;
   const drowned = buildingsGeometry(
     set,
@@ -192,10 +203,13 @@ const builds = parseBuildings(BUILDINGS_FIXTURE);
       up > 0 &&
       down === 0 &&
       maxY <= 10 + hMax * 1.36 &&
+      roofOn > 0 &&
+      roofOn < g.count &&
+      roofBad === 0 &&
       g.glow.every((v) => Math.abs(v - 0.7) < 1e-6) &&
       drowned.placed === 0 &&
       drowned.count === 0,
-    `${set.length} buildings (gabled + flat among them) -> ${g.count} vertices: bases at ground-2m, tops within height+gable, ${horiz} horizontal wall normals, ${up} straight-up roof normals, none facing down, glow carried; on water nothing is placed`
+    `${set.length} buildings (gabled + flat among them) -> ${g.count} vertices: bases at ground-2m, tops within height+gable, ${horiz} horizontal wall normals, ${up} straight-up roof normals, none facing down, glow carried, ${roofOn} snow-bearing roof vertices all facing upward; on water nothing is placed`
   );
 }
 

--- a/themes/horizon/buildings.js
+++ b/themes/horizon/buildings.js
@@ -319,14 +319,18 @@ export function buildingsGeometry(builds, anchor, groundY, glowAt, U, lim) {
   const Nrm = [];
   const C = [];
   const G = [];
+  const R = []; // roof flag: 1 where snow can LIE (roof planes,
+  // flat caps), 0 on walls, gable faces and the spire - snow does
+  // not stand on the vertical or the steep
   let placed = 0;
-  const push = (p, nrm, col, glow) => {
+  const push = (p, nrm, col, glow, roof) => {
     P.push(...p);
     Nrm.push(...nrm);
     C.push(...col);
     G.push(glow);
+    R.push(roof);
   };
-  const tri = (a, b, c, col, glow) => {
+  const tri = (a, b, c, col, glow, roof = 0) => {
     const ux = b[0] - a[0];
     const uy = b[1] - a[1];
     const uz = b[2] - a[2];
@@ -340,7 +344,7 @@ export function buildingsGeometry(builds, anchor, groundY, glowAt, U, lim) {
     nx /= l;
     ny /= l;
     nz /= l;
-    for (const p of [a, b, c]) push(p, [nx, ny, nz], col, glow);
+    for (const p of [a, b, c]) push(p, [nx, ny, nz], col, glow, roof);
   };
   for (const b of builds) {
     const pts = b.ring.map(([la, lo]) => {
@@ -412,10 +416,10 @@ export function buildingsGeometry(builds, anchor, groundY, glowAt, U, lim) {
       const R2 = P3(hl, 0, top + gH);
       // two roof planes + two gable triangles (orders hand-checked
       // for outward normals under the axis convention)
-      tri(A, R2, B, ROOF, glow);
-      tri(A, R1, R2, ROOF, glow);
-      tri(C, R1, D, ROOF, glow);
-      tri(C, R2, R1, ROOF, glow);
+      tri(A, R2, B, ROOF, glow, 1);
+      tri(A, R1, R2, ROOF, glow, 1);
+      tri(C, R1, D, ROOF, glow, 1);
+      tri(C, R2, R1, ROOF, glow, 1);
       tri(A, D, R1, facade, glow);
       tri(C, B, R2, facade, glow);
     } else {
@@ -428,7 +432,8 @@ export function buildingsGeometry(builds, anchor, groundY, glowAt, U, lim) {
           [pts[c][0], top, pts[c][1]],
           [pts[bb][0], top, pts[bb][1]],
           cap,
-          glow
+          glow,
+          1
         );
       }
     }
@@ -467,6 +472,7 @@ export function buildingsGeometry(builds, anchor, groundY, glowAt, U, lim) {
     normal: new Float32Array(Nrm),
     color: new Float32Array(C),
     glow: new Float32Array(G),
+    roof: new Float32Array(R),
     count: P.length / 3,
     placed
   };


### PR DESCRIPTION
The coupling lane again: the measured snow cover (#80) and the OSM buildings (#69/#82) meet.

## Geometry
`buildingsGeometry` gained a fourth attribute — **`roof` flags exactly the surfaces snow can lie on**: the sloped ridge planes and flat caps. Walls, gable faces and the spires stay bare — snow does not stand on the vertical or the steep. The merged-geometry landmark holds it structurally: every flagged vertex faces up or up-slope (ny > 0.05), both classes present, nothing mis-flagged.

## Rendering
The buildings' `colorNode` mixes the **terrain's own snow albedo** (0.87/0.90/0.93) over the roof surfaces by `max(measured, live)`:
- **`rsnow`** — a per-vertex attribute sampled from the *same* Salomonson–Appel FSC field the terrain reads; `syncSnowCover` re-seats the town when the field lands (the lights-path precedent), so roofs whiten where the satellite saw snow — glaciers-adjacent hamlets included.
- **`bldSnowU`** — the live-snowfall term, mirroring the very `uSnowy` value the terrain smooths each frame. When it snows tonight the roofs whiten with the ground in real time; tomorrow's pass confirms or clears them.

One snow state, three consumers — terrain, physics drifts, now the roofs. Nothing new invented.

## Validation
Gate 53 sets green (the buildings landmark strengthened in place — `120 snow-bearing roof vertices all facing upward`); browser smoke clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKKBen9kkD562HDVr7cXAx

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKKBen9kkD562HDVr7cXAx)_