### PR TITLE
Horizon: clouds amplify the skyglow (Kyba 2011)

### DIFF
--- a/themes/Horizon.html
+++ b/themes/Horizon.html
@@ -385,6 +385,7 @@
       import {relPhase} from './horizon/moonphase.js';
       import {
         bortleClass,
+        cloudAmp,
         horizonGlow,
         pointVisibility,
         sampleRatio,
@@ -741,6 +742,8 @@
           const c = w.current;
           state.code = c.weather_code;
           state.cloud = c.cloud_cover;
+          // the measured cover re-scales the skyglow (Kyba 2011)
+          applyCloudSkyglow();
           state.cloudLow = c.cloud_cover_low;
           state.cloudMid = c.cloud_cover_mid;
           state.cloudHigh = c.cloud_cover_high;
@@ -5315,18 +5318,7 @@
         lpRatio = params.has('lp')
           ? +params.get('lp')
           : sampleRatio(SKYGLOW, SKYGLOW_W, SKYGLOW_H, state.lat, state.lon);
-        lpVis = pointVisibility(lpRatio);
-        lpVisBright = 1 / Math.sqrt(1 + lpRatio);
-        lpMag = skyMag(lpRatio);
-        record(
-          'Falchi 2016 skyglow atlas',
-          'zenith ' +
-            lpMag.toFixed(2) +
-            ' mag/arcsec\u00b2 \u00b7 Bortle ' +
-            bortleClass(lpMag) +
-            ' \u00b7 star contrast \u00d7' +
-            lpVis.toFixed(2)
-        );
+        applyCloudSkyglow();
         const g = [];
         for (let i = 0; i < 16; i++)
           g.push(
@@ -5347,8 +5339,37 @@
             3
           );
         lpGlowObj.u.azTex.needsUpdate = true;
-        lpGlowAmp = THREE.MathUtils.clamp(Math.log10(1 + lpRatio) / 2.5, 0, 1);
-        lpGlow.visible = lpGlowAmp > 0.01;
+      }
+      // The LIVE sky over the atlas: clouds amplify the artificial
+      // glow (Kyba et al. 2011, gated in skyglow.js - overcast
+      // multiplied Berlin's zenith by a measured 10.1). Re-applied
+      // whenever the measured cloud cover changes, so an overcast
+      // night over a town is visibly brighter than a clear one and
+      // the stars fade under it exactly as the contrast says.
+      function applyCloudSkyglow() {
+        const amp = cloudAmp(lpRatio, (state.cloud ?? 0) / 100);
+        const rEff = lpRatio * amp;
+        lpVis = pointVisibility(rEff);
+        lpVisBright = 1 / Math.sqrt(1 + rEff);
+        lpMag = skyMag(rEff);
+        lpGlowAmp = THREE.MathUtils.clamp(Math.log10(1 + rEff) / 2.5, 0, 1);
+        if (lpGlow) lpGlow.visible = lpGlowAmp > 0.01;
+        record(
+          'Falchi 2016 skyglow atlas',
+          'zenith ' +
+            lpMag.toFixed(2) +
+            ' mag/arcsec\u00b2 \u00b7 Bortle ' +
+            bortleClass(lpMag) +
+            ' \u00b7 star contrast \u00d7' +
+            lpVis.toFixed(2) +
+            (amp > 1.01
+              ? ' \u00b7 \u00d7' +
+                amp.toFixed(1) +
+                ' under ' +
+                Math.round(state.cloud) +
+                '% cloud (Kyba 2011)'
+              : '')
+        );
       }
       computeSkyglow();
 

--- a/themes/horizon/WEBGPU-PLAN.md
+++ b/themes/horizon/WEBGPU-PLAN.md
@@ -2946,6 +2946,33 @@ secret put AISSTREAM_KEY && npx wrangler deploy`.
   them. Nothing new is invented: one snow state, three consumers
   (terrain, physics drifts, now the roofs). Gate 53 sets
   (buildings landmark strengthened in place); browser smoke clean.
+- DONE: clouds amplify the skyglow (Jul 10, the coupling lane -
+  the live cloud cover and the Falchi atlas meet). Kyba, Ruhtz,
+  Fischer & Hölker (2011, PLoS ONE 6:e17307) measured it:
+  overcast multiplies zenith sky luminance by 10.1 inside Berlin
+  and 2.8 at 32 km out - the amplification grows with how much
+  artificial light is overhead, which is exactly what the Falchi
+  ratio already measures per anchor. skyglow.js gained cloudAmp:
+  the two published anchors log-interpolated in the ratio (the
+  assigned anchor ratios ~20 urban core / ~3 city edge are the
+  documented closure), clamped to the measured range and to >= 1
+  (a pristine sky has nothing to amplify - the rendered clouds
+  already occlude its stars directly), partial cover linear in
+  cloud fraction (the paper's okta bins rise monotonically). Gate
+  landmark (skyglow 4 -> 5): both anchors exact to 1e-12, clear =
+  1, pristine never amplified, clamps hold, monotone both ways,
+  and the magnitude identity - the amplified zenith brightens by
+  exactly 2.5 log10((1+rA)/(1+r)) through the module's own
+  skyMag. Theme: computeSkyglow now computes the STATIC parts
+  (atlas sample, azimuthal glow pattern) and the new
+  applyCloudSkyglow derives everything live - star contrast,
+  zenith mag, Bortle, horizon-glow amplitude - from the AMPLIFIED
+  ratio, re-run on every weather poll as the measured cover
+  changes; the panel shows the factor ('x7.3 under 90% cloud
+  (Kyba 2011)'). An overcast night over a town is now visibly
+  brighter than a clear one, and the stars fade under it exactly
+  as the contrast ratio says. Gate 53 sets (skyglow 4 -> 5
+  landmarks); browser smoke clean.
 - OPEN (environment, not code) - UPDATE (roam smoke, Jul 7): the
   drift now also manifests as a PER-FRAME uncaught TypeError -
   GPUTexture.createView rejects the `swizzle` field three's

--- a/themes/horizon/skyglow-reference.mjs
+++ b/themes/horizon/skyglow-reference.mjs
@@ -26,7 +26,10 @@ import {
   pointVisibility,
   sampleRatio,
   skyMag,
-  WALKER_EXP
+  WALKER_EXP,
+  cloudAmp,
+  KYBA_EDGE,
+  KYBA_URBAN
 } from './skyglow.js';
 import {SKYGLOW, SKYGLOW_H, SKYGLOW_W} from './skyglow-data.js';
 
@@ -110,6 +113,36 @@ const check = (name, ok, detail) => {
       east > 10 * (west + 1e-12) &&
       Math.abs(near / far - Math.pow(4, 2.5)) < 1e-12,
     `city due east: glow(90 deg) = ${east.toFixed(2)} vs glow(270) = ${west.toFixed(4)}; 25 km vs 100 km attenuation ratio 4^2.5 = ${(near / far).toFixed(1)} exactly`
+  );
+}
+
+{
+  // Clouds amplify skyglow (Kyba et al. 2011): both published
+  // anchors exact at full overcast, clear skies untouched,
+  // monotone in ratio and cover, clamped to the measured range,
+  // pristine skies never amplified - and the magnitude identity:
+  // the amplified zenith brightens by exactly
+  // 2.5 log10((1 + rA)/(1 + r)) mag through the module's own
+  // skyMag.
+  const urban = cloudAmp(KYBA_URBAN.ratio, 1);
+  const edge = cloudAmp(KYBA_EDGE.ratio, 1);
+  const r = 40;
+  const A = cloudAmp(r, 1);
+  const dMag = skyMag(r) - skyMag(r * A);
+  const wantD = 2.5 * Math.log10((1 + r * A) / (1 + r));
+  const ok =
+    Math.abs(urban - KYBA_URBAN.amp) < 1e-12 &&
+    Math.abs(edge - KYBA_EDGE.amp) < 1e-12 &&
+    cloudAmp(20, 0) === 1 &&
+    cloudAmp(0.01, 1) === 1 &&
+    cloudAmp(1000, 1) === KYBA_URBAN.amp &&
+    cloudAmp(10, 0.5) > cloudAmp(10, 0.2) &&
+    cloudAmp(15, 1) > cloudAmp(5, 1) &&
+    Math.abs(dMag - wantD) < 1e-12;
+  check(
+    'Kyba cloud amplification',
+    ok,
+    `overcast x${KYBA_URBAN.amp} at the urban anchor and x${KYBA_EDGE.amp} at the edge anchor exactly; clear = 1, pristine never amplified, clamps hold; the amplified zenith brightens by the exact magnitude identity`
   );
 }
 

--- a/themes/horizon/skyglow.js
+++ b/themes/horizon/skyglow.js
@@ -64,6 +64,36 @@ export function pointVisibility(r) {
   return 1 / (1 + r);
 }
 
+// ---- Clouds amplify skyglow: Kyba et al. (2011, PLoS ONE 6,
+// e17307) ----. Overcast multiplies zenith sky luminance by a
+// MEASURED 10.1 inside Berlin and 2.8 at 32 km out - the
+// amplification grows with how much artificial light is overhead,
+// which is exactly what the Falchi ratio measures. The two
+// published anchors are log-interpolated in the ratio (the
+// assigned anchor ratios below are the documented closure: a
+// bright urban core ~20, the city edge ~3 on the Falchi scale),
+// clamped to the measured range and to >= 1 (a pristine sky has
+// nothing to amplify - the rendered clouds already occlude its
+// stars directly). Partial cover scales linearly with cloud
+// fraction (the paper's okta bins rise monotonically).
+export const KYBA_URBAN = {ratio: 20, amp: 10.1}; // central Berlin
+export const KYBA_EDGE = {ratio: 3, amp: 2.8}; // 32 km out
+export function cloudAmp(ratio, cloudFrac) {
+  const c = Math.min(Math.max(cloudFrac ?? 0, 0), 1);
+  if (!(ratio > 0) || c === 0) return 1;
+  const slope =
+    (KYBA_URBAN.amp - KYBA_EDGE.amp) /
+    (Math.log10(KYBA_URBAN.ratio) - Math.log10(KYBA_EDGE.ratio));
+  const overcast = Math.min(
+    Math.max(
+      KYBA_EDGE.amp + slope * (Math.log10(ratio) - Math.log10(KYBA_EDGE.ratio)),
+      1
+    ),
+    KYBA_URBAN.amp
+  );
+  return 1 + (overcast - 1) * c;
+}
+
 // Conventional SQM -> Bortle class mapping (the widely used
 // table; Bortle's 2001 scale is descriptive, this is the
 // documented convention).


### PR DESCRIPTION
Couples the live cloud cover (already polled from Open-Meteo) to the Falchi 2016 skyglow atlas via Kyba, Ruhtz, Fischer & Hölker (2011), *PLoS ONE* 6:e17307 — "Cloud Coverage Acts as an Amplifier for Ecological Light Pollution in Urban Ecosystems". Overcast skies do not dim urban skyglow, they multiply it.

- `skyglow.js` — `cloudAmp(ratio, cloudFrac)` anchored on the paper's two published measurements: overcast ×10.1 over central Berlin (`KYBA_URBAN`, ratio 20) and ×2.8 at the 32 km edge site (`KYBA_EDGE`, ratio 3). Log-interpolated in the Falchi artificial/natural ratio, clamped to the measured range [1, 10.1], linear in cloud fraction, and pristine skies (ratio → 0) are never amplified — clouds there *darken* the sky, which stays the model's floor of 1.
- `Horizon.html` — `computeSkyglow()` keeps only the static atlas sample and the azimuthal Walker glow pattern; a new `applyCloudSkyglow()` derives everything the renderer uses (star contrast `lpVis`, bright-star contrast, zenith magnitude, glow amplitude) from the effective ratio `lpRatio × cloudAmp(...)`, and re-runs on every weather poll so the sky brightens as overcast rolls in. The record line appends "×A under N% cloud (Kyba 2011)" when active.
- `skyglow-reference.mjs` — new "Kyba cloud amplification" landmark (4 → 5): both published anchors exact to 1e-12 at full overcast, clear = 1, pristine never amplified, clamps and monotonicity hold, and the amplified zenith brightens by the exact magnitude identity 2.5·log10((1+rA)/(1+r)) through the module's own `skyMag`.

Gate: all 53 reference sets pass (`VALIDATE PASS`); browser smoke clean at Interlaken (1 known TSL warning class).

Sources:
- https://journals.plos.org/plosone/article?id=10.1371%2Fjournal.pone.0017307
- https://pmc.ncbi.nlm.nih.gov/articles/PMC3047560/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKKBen9kkD562HDVr7cXAx

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKKBen9kkD562HDVr7cXAx)_