### PR TITLE
Horizon: wind turbines from OSM, spun by the real wind

### DIFF
--- a/themes/Horizon.html
+++ b/themes/Horizon.html
@@ -185,7 +185,8 @@
         buildings), roads=0 (skip OSM roads), landuse=0 (skip OSM
         ground cover), rivers=0 (skip OSM waterways), rails=0 (skip
         OSM railways), trains=0 (skip live trains), aerialways=0
-        (skip OSM cable cars), peaks=0 (skip summit labels),
+        (skip OSM cable cars), turbines=0 (skip OSM wind
+        turbines), peaks=0 (skip summit labels),
         discharge=0 (pin river widths to the ladder), snowcover=0|URL
         (measured snow off / tile endpoint override), soil=0 (pin
         bare-soil tints dry), debug=1
@@ -471,6 +472,13 @@
         STATION_M
       } from './horizon/aerialways.js';
       import {labelText, parsePeaks, selectPeaks} from './horizon/peaks.js';
+      import {
+        hubWind,
+        parseTurbines,
+        rotorOmega,
+        YAW_DEG_S
+      } from './horizon/turbines.js';
+      import {buildWindmill} from './horizon/windmills.js';
       import {snowField, SNOW_LAYER, SNOW_Z} from './horizon/snowcover.js';
       import {lakeAt, lakeMask, parseWater} from './horizon/lakes.js';
       import {lineStrengths} from './horizon/airglow.js';
@@ -735,7 +743,8 @@
                 state.lat +
                 '&longitude=' +
                 state.lon +
-                '&current=weather_code,cloud_cover,cloud_cover_low,cloud_cover_mid,cloud_cover_high,visibility,precipitation,snowfall,wind_speed_10m,wind_direction_10m,wind_gusts_10m,temperature_2m,dew_point_2m',
+                '&current=weather_code,cloud_cover,cloud_cover_low,cloud_cover_mid,cloud_cover_high,visibility,precipitation,snowfall,wind_speed_10m,wind_direction_10m,wind_gusts_10m,temperature_2m,dew_point_2m' +
+                '&hourly=wind_speed_80m,wind_speed_120m&forecast_hours=1',
               {credentials: 'omit'}
             )
           ).json();
@@ -755,6 +764,11 @@
           state.gust = c.wind_gusts_10m;
           state.temp = c.temperature_2m;
           state.dew = c.dew_point_2m;
+          // Hub-height winds for the turbines: the forecast
+          // model's own 80/120 m levels (turbines.js
+          // interpolates on ln z between them).
+          state.wind80 = w.hourly?.wind_speed_80m?.[0] ?? null;
+          state.wind120 = w.hourly?.wind_speed_120m?.[0] ?? null;
           record(
             'open-meteo current',
             (WMO[state.code] || state.code) +
@@ -2054,6 +2068,81 @@
           if (worldBuilt) placeAerialways();
         } catch {
           aerialGeo = null; // no invented cables
+        }
+      }
+
+      // Wind turbines (power=generator + generator:source=wind):
+      // real installations with their real model tags, spun by
+      // the measured wind under the manufacturers' published
+      // operating envelopes (turbines.js). Geodetic per anchor;
+      // ?turbines=0 disables.
+      let turbinesGeo = null;
+      async function syncTurbines() {
+        if (params.get('turbines') === '0') return;
+        const key =
+          'horizon-turbines-geo-' +
+          state.lat.toFixed(2) +
+          ',' +
+          state.lon.toFixed(2);
+        try {
+          const hit = localStorage.getItem(key);
+          if (hit) {
+            turbinesGeo = JSON.parse(hit);
+            record(
+              'OSM Overpass wind turbines (cached)',
+              turbinesGeo.length + ' turbines'
+            );
+            if (worldBuilt) placeTurbines();
+            return;
+          }
+        } catch {}
+        try {
+          const mLat = 111320;
+          const mLon = Math.max(111320 * Math.cos(state.lat * RAD), 1e-6);
+          const dLat = DEM_HALF_M / mLat;
+          const dLon = DEM_HALF_M / mLon;
+          const bbox =
+            (state.lat - dLat).toFixed(4) +
+            ',' +
+            (state.lon - dLon).toFixed(4) +
+            ',' +
+            (state.lat + dLat).toFixed(4) +
+            ',' +
+            (state.lon + dLon).toFixed(4);
+          const q =
+            '[out:json][timeout:30];(node["power"="generator"]["generator:source"="wind"](' +
+            bbox +
+            ');way["power"="generator"]["generator:source"="wind"](' +
+            bbox +
+            '););out center 200;';
+          let osm = null;
+          for (const host of [
+            'https://maps.mail.ru/osm/tools/overpass/api/interpreter',
+            'https://overpass-api.de/api/interpreter'
+          ]) {
+            try {
+              const r = await fetch(host + '?data=' + encodeURIComponent(q), {
+                credentials: 'omit'
+              });
+              if (!r.ok) throw new Error(r.status);
+              osm = await r.json();
+              break;
+            } catch {
+              // Try the next mirror.
+            }
+          }
+          if (!osm) throw new Error('overpass unavailable');
+          turbinesGeo = parseTurbines(osm);
+          record(
+            'OSM Overpass wind turbines',
+            turbinesGeo.length + ' turbines'
+          );
+          try {
+            localStorage.setItem(key, JSON.stringify(turbinesGeo));
+          } catch {}
+          if (worldBuilt) placeTurbines();
+        } catch {
+          turbinesGeo = null; // no invented turbines
         }
       }
 
@@ -3707,6 +3796,65 @@
           g.placed + ' of ' + railsGeo.length + ' ways on this box'
         );
       }
+      // Wind turbines: the shared windmills.js silhouettes at
+      // the spec ladder's measured sizes, yawed into the wind
+      // and spun by the frame loop below.
+      let turbinesGroup = null;
+      let turbineMats = null;
+      const turbineRigs = []; // {yaw, rotor, spec, yawA}
+      function placeTurbines() {
+        turbineRigs.length = 0;
+        if (turbinesGroup) {
+          ground.remove(turbinesGroup);
+          turbinesGroup.traverse((o) => o.geometry && o.geometry.dispose());
+          turbinesGroup = null;
+        }
+        if (
+          !turbinesGeo ||
+          !turbinesGeo.length ||
+          params.get('turbines') === '0'
+        )
+          return;
+        if (!turbineMats) {
+          const mk = (color, roughness) => {
+            const m = new THREE.MeshStandardNodeMaterial({color, roughness});
+            applyAerial(m);
+            return m;
+          };
+          // the asset-viewer palette (?asset=windmills)
+          turbineMats = {body: mk('#d5d8d9', 0.55), dark: mk('#3c4146', 0.6)};
+        }
+        turbinesGroup = new THREE.Group();
+        let placed = 0;
+        for (const t of turbinesGeo) {
+          const sc = geoToScene(t.lat, t.lon, dressAnchor);
+          if (Math.max(Math.abs(sc.x), Math.abs(sc.z)) > WORLD / 2) continue;
+          const smp = sample(sc.x, sc.z);
+          if (smp.water) continue; // no turbines in the lake
+          const g = new THREE.Group();
+          g.position.set(sc.x, smp.y, sc.z);
+          const rig = buildWindmill(g, t.spec, turbineMats, 1 / MPU);
+          rig.rotor.rotation.z = placed * 2.4; // dephased blades
+          turbinesGroup.add(g);
+          turbineRigs.push({
+            yaw: rig.yaw,
+            rotor: rig.rotor,
+            spec: t.spec,
+            yawA: null
+          });
+          placed++;
+        }
+        if (!placed) {
+          turbinesGroup = null;
+          return;
+        }
+        ground.add(turbinesGroup);
+        record(
+          'wind turbines placed',
+          placed + ' of ' + turbinesGeo.length + ' on this box'
+        );
+      }
+
       // Cable cars: pylons at the real support nodes, spans hung
       // on the exact catenary between them (interior supports
       // 12 m over the sampled ground, end stations 6 m), cabins
@@ -3966,6 +4114,7 @@
         placeRivers();
         placeRails();
         placeAerialways();
+        placeTurbines();
         placePeaks();
         placeLanduse();
 
@@ -6075,6 +6224,7 @@
         syncDischarge();
         syncRails();
         syncAerialways();
+        syncTurbines();
         syncPeaks();
         syncLanduse();
         syncSoil();
@@ -7593,6 +7743,33 @@
           }
         }
 
+        // Wind turbines: nacelles slew into the measured wind at
+        // the published 0.5 deg/s yaw rate, rotors run the
+        // variable-speed law at the hub-height wind (the
+        // forecast's own 80/120 m levels on the log profile),
+        // clockwise seen from upwind as every sheet states.
+        if (turbineRigs.length) {
+          const target = Math.atan2(-windV.x, -windV.z);
+          const maxYaw = YAW_DEG_S * RAD * dt;
+          for (const r of turbineRigs) {
+            if (r.yawA === null) r.yawA = target; // born facing it
+            let dy = target - r.yawA;
+            dy -= Math.round(dy / (2 * Math.PI)) * 2 * Math.PI;
+            r.yawA += Math.abs(dy) < maxYaw ? dy : Math.sign(dy) * maxYaw;
+            r.yaw.rotation.y = r.yawA;
+            const v =
+              state.wind80 != null
+                ? hubWind(
+                    state.wind / 3.6,
+                    state.wind80 / 3.6,
+                    (state.wind120 ?? state.wind80) / 3.6,
+                    r.spec.hub
+                  )
+                : state.wind / 3.6;
+            r.rotor.rotation.z -= rotorOmega(r.spec, v) * dt;
+          }
+        }
+
         // ISS: SGP4-propagated position; drawn only when the pass is
         // genuinely visible (above horizon, sunlit against a dark sky).
         if (satrec && window.satellite) {
@@ -7934,6 +8111,7 @@
         setInterval(syncDischarge, 6 * 60 * 60 * 1000);
         syncRails();
         syncAerialways();
+        syncTurbines();
         syncPeaks();
         syncLanduse();
         syncSoil();

--- a/themes/horizon/WEBGPU-PLAN.md
+++ b/themes/horizon/WEBGPU-PLAN.md
@@ -2973,6 +2973,36 @@ secret put AISSTREAM_KEY && npx wrangler deploy`.
   brighter than a clear one, and the stars fade under it exactly
   as the contrast ratio says. Gate 53 sets (skyglow 4 -> 5
   landmarks); browser smoke clean.
+- DONE: wind turbines from OSM, spun by the real wind under the
+  manufacturers' own envelopes (Jul 10, all three lanes at once -
+  a real data source, a designed asset, and the published control
+  law followed rather than approximated). turbines.js: the spec
+  ladder (explicit rotor:diameter/height:hub tags > the model's
+  published sheet > fleet medians computed FROM the sheets - no
+  invented constants) resolves Vestas V90-2.0 (facts & figures:
+  cut-in 4/rated 12/cut-out 25 m/s, 9.3-16.6 rpm, nacelle
+  10.4x3.4x4 m), ENERCON E-82 E2 (product overview: 6-18 rpm,
+  storm control 28-34 m/s, cut-in and rated wind read off
+  ENERCON's own calculated power curve, Cp max 0.50) and the
+  V112 platform (General Specification 0011-9181 V03: 6.2-17.7
+  rpm, rotor tilt 6 deg, coning 4 deg, yaw 0.5 deg/s; rated 13).
+  The control law is Burton et al.'s variable-speed scheme:
+  region 2 tracks max Cp at Omega = lambda_opt v / R inside the
+  published interval, with the closure lambda_opt =
+  Omega_max R / v_rated so the rotor hits its published top
+  speed exactly at its published rated wind; Vestas stops hard
+  at cut-out, ENERCON's storm control tapers the speed linearly
+  across its published window instead. Hub wind comes from the
+  forecast model's own 80/120 m levels (syncWeather now asks for
+  them), log-profile interpolated to each hub. windmills.js
+  (vessels.js mould, ?asset=windmills stage): tower/nacelle/
+  three coned blades from the sheets' own dims and ratios (both
+  Vestas sheets put the blade at 0.49 D), nacelles slew into the
+  live wind at the published yaw rate, rotors spin clockwise
+  seen from upwind. Live fixture: the 19-turbine Juvent farm on
+  Mont Crosin (3 models, 16 JUV refs). Gate 54 sets (turbines: 6
+  landmarks - ladder, law, storm control, ENERCON's published
+  curve closing the constants, log-profile anchors, fixture).
 - OPEN (environment, not code) - UPDATE (roam smoke, Jul 7): the
   drift now also manifests as a PER-FRAME uncaught TypeError -
   GPUTexture.createView rejects the `swizzle` field three's

--- a/themes/horizon/explore.js
+++ b/themes/horizon/explore.js
@@ -66,6 +66,7 @@ export const KEEP_PARAMS = [
   'rails',
   'trains',
   'aerialways',
+  'turbines',
   'peaks',
   'discharge',
   'snowcover',

--- a/themes/horizon/harness/asset-viewer.html
+++ b/themes/horizon/harness/asset-viewer.html
@@ -53,6 +53,8 @@
       import {RAILS_FIXTURE} from '../rails-fixture.mjs';
       import {consistOf} from '../trains.js';
       import {buildTrain} from '../rollingstock.js';
+      import {rotorOmega, specOf} from '../turbines.js';
+      import {buildWindmill} from '../windmills.js';
 
       const q = new URLSearchParams(location.search);
       const renderer = new THREE.WebGPURenderer({antialias: true});
@@ -105,9 +107,67 @@
         ].map((c) => mk(c))
       };
 
-      // ?asset=trains: one consist per category family through the
-      // same trains.js/rollingstock.js the theme ships (metres).
-      if (q.get('asset') === 'trains') {
+      // ?asset=windmills: the three Mont Crosin models plus the
+      // model-less power rung through the same turbines.js/
+      // windmills.js the theme ships (metres); rotors run at
+      // their region-2 speed for a 8 m/s hub wind, one blade
+      // phase apart. ?v= sets the wind.
+      if (q.get('asset') === 'windmills') {
+        sea.material.color.set('#5d7a52'); // grass stage
+        sun.position.set(-320, 380, -420);
+        const wmats = {body: mk('#d5d8d9', 0.55), dark: mk('#3c4146', 0.6)};
+        const LINEUP = [
+          {model: 'V90'},
+          {manufacturer: 'Enercon', model: 'E82'},
+          {model: 'V112'},
+          {'generator:output:electricity': '2000 kW'}
+        ];
+        const v = +q.get('v') || 8;
+        const rigs = [];
+        let x = 0;
+        const xs = [];
+        for (const tags of LINEUP) {
+          const spec = specOf(tags);
+          const g = new THREE.Group();
+          const rig = buildWindmill(g, spec, wmats, 1);
+          rig.rotor.rotation.z = rigs.length * 0.7;
+          rigs.push({rig, om: rotorOmega(spec, v)});
+          x += spec.d * 0.62;
+          g.position.set(x, 0, 0);
+          g.rotation.y = ((+q.get('yaw') || 20) * Math.PI) / 180;
+          xs.push(x);
+          x += spec.d * 0.62;
+          scene.add(g);
+        }
+        const mid = (xs[0] + xs[xs.length - 1]) / 2;
+        const az = ((+q.get('az') || 195) * Math.PI) / 180;
+        const el = ((+q.get('el') || 8) * Math.PI) / 180;
+        const d = +q.get('d') || 520;
+        camera.position.set(
+          mid + d * Math.cos(el) * Math.sin(az),
+          Math.max(d * Math.sin(el), 15),
+          d * Math.cos(el) * Math.cos(az)
+        );
+        camera.lookAt(mid, 75, 0);
+        await renderer.init();
+        window.__r = renderer;
+        window.__scene = scene;
+        window.__cam = camera;
+        window.__THREE = THREE;
+        let wframes = 0;
+        let wt = performance.now();
+        renderer.setAnimationLoop(() => {
+          const now = performance.now();
+          const dt = Math.min((now - wt) / 1000, 0.1);
+          wt = now;
+          for (const {rig, om} of rigs) rig.rotor.rotation.z -= om * dt;
+          renderer.render(scene, camera);
+          if (++wframes === 5) console.log('DONE');
+        });
+      } else if (q.get('asset') === 'trains') {
+        // ?asset=trains: one consist per category family through
+        // the same trains.js/rollingstock.js the theme ships
+        // (metres).
         sea.material.color.set('#82868b'); // ballast stage
         sun.position.set(-320, 380, -420);
         const tmats = {

--- a/themes/horizon/harness/validate.sh
+++ b/themes/horizon/harness/validate.sh
@@ -24,7 +24,7 @@ REFDIR=${REFDIR:-..} # where the *-reference.mjs live
 fail=0
 
 echo "== CPU references (double precision, ground truth) =="
-for name in ocean atmo moon optics surf glint aurora leadr radar igrf scintillation ross-li cn2 airglow zodiacal meteors contrails ships navlights lightning milkyway earthshine nlc sats eclipses skyglow explore roam solarwind metar refraction smoke terrain-sample lakes buildings roads landuse rivers rails trains aerialways peaks snowcover grib2 aerosol nightlights server; do
+for name in ocean atmo moon optics surf glint aurora leadr radar igrf scintillation ross-li cn2 airglow zodiacal meteors contrails ships navlights lightning milkyway earthshine nlc sats eclipses skyglow explore roam solarwind metar refraction smoke terrain-sample lakes buildings roads landuse rivers rails trains aerialways turbines peaks snowcover grib2 aerosol nightlights server; do
   ref="$REFDIR/$name-reference.mjs"
   if [ ! -f "$ref" ]; then echo "[FAIL] $name-reference.mjs missing"; fail=1; continue; fi
   if out=$(node "$ref" 2>&1); then

--- a/themes/horizon/turbines-fixture.mjs
+++ b/themes/horizon/turbines-fixture.mjs
@@ -1,0 +1,314 @@
+// Live Overpass capture (maps.mail.ru mirror), 2026-07-10:
+// power=generator + generator:source=wind over 47.15,6.95,47.30,
+// 7.15 - the Juvent wind farm on Mont Crosin above St-Imier,
+// Switzerland's largest. 19 turbines, three models (Vestas V90
+// and V112, ENERCON E-82), 16 carrying their JUV plant refs.
+// Captured verbatim; only the envelope key order is ours.
+export const TURBINES_FIXTURE = {
+  elements: [
+    {
+      type: 'node',
+      id: 795367185,
+      lat: 47.2016179,
+      lon: 7.0740223,
+      tags: {
+        'generator:method': 'wind_turbine',
+        'generator:output:electricity': '2000 kW',
+        'generator:source': 'wind',
+        'generator:type': 'horizontal_axis',
+        manufacturer: 'Vestas',
+        model: 'V90',
+        power: 'generator',
+        ref: 'JUV 16'
+      }
+    },
+    {
+      type: 'node',
+      id: 795367902,
+      lat: 47.19626,
+      lon: 7.050503,
+      tags: {
+        'generator:method': 'wind_turbine',
+        'generator:output:electricity': '2000 kW',
+        'generator:source': 'wind',
+        'generator:type': 'horizontal_axis',
+        manufacturer: 'Vestas',
+        model: 'V90',
+        power: 'generator',
+        ref: 'JUV 15'
+      }
+    },
+    {
+      type: 'node',
+      id: 1145566831,
+      lat: 47.2048283,
+      lon: 6.9712451,
+      tags: {
+        'generator:method': 'wind_turbine',
+        'generator:output:electricity': '2300 kW',
+        'generator:source': 'wind',
+        'generator:type': 'horizontal_axis',
+        manufacturer: 'Enercon',
+        model: 'E82',
+        power: 'generator'
+      }
+    },
+    {
+      type: 'node',
+      id: 2012328785,
+      lat: 47.1654703,
+      lon: 6.9878369,
+      tags: {
+        'generator:method': 'wind_turbine',
+        'generator:output:electricity': '3300 kW',
+        'generator:source': 'wind',
+        'generator:type': 'horizontal_axis',
+        manufacturer: 'Vestas',
+        model: 'V112',
+        operator: 'Juvent',
+        power: 'generator',
+        ref: 'JUV 7'
+      }
+    },
+    {
+      type: 'node',
+      id: 2012328787,
+      lat: 47.202176,
+      lon: 6.9629197,
+      tags: {
+        'generator:method': 'wind_turbine',
+        'generator:output:electricity': '2300 kW',
+        'generator:source': 'wind',
+        'generator:type': 'horizontal_axis',
+        manufacturer: 'Enercon',
+        model: 'E82',
+        power: 'generator'
+      }
+    },
+    {
+      type: 'node',
+      id: 2012328804,
+      lat: 47.2000504,
+      lon: 6.9553558,
+      tags: {
+        'generator:method': 'wind_turbine',
+        'generator:output:electricity': '2300 kW',
+        'generator:source': 'wind',
+        'generator:type': 'horizontal_axis',
+        manufacturer: 'Enercon',
+        model: 'E82',
+        power: 'generator'
+      }
+    },
+    {
+      type: 'node',
+      id: 2026305183,
+      lat: 47.1809168,
+      lon: 7.0197664,
+      tags: {
+        'generator:method': 'wind_turbine',
+        'generator:output:electricity': '2000 kW',
+        'generator:source': 'wind',
+        'generator:type': 'horizontal_axis',
+        manufacturer: 'Vestas',
+        model: 'V90',
+        power: 'generator',
+        ref: 'JUV 12'
+      }
+    },
+    {
+      type: 'node',
+      id: 2026305184,
+      lat: 47.180208,
+      lon: 7.0123584,
+      tags: {
+        'generator:method': 'wind_turbine',
+        'generator:output:electricity': '2000 kW',
+        'generator:source': 'wind',
+        'generator:type': 'horizontal_axis',
+        manufacturer: 'Vestas',
+        model: 'V90',
+        power: 'generator',
+        ref: 'JUV 3'
+      }
+    },
+    {
+      type: 'node',
+      id: 2026305186,
+      lat: 47.198692,
+      lon: 7.059437,
+      tags: {
+        'generator:method': 'wind_turbine',
+        'generator:output:electricity': '3300 kW',
+        'generator:source': 'wind',
+        'generator:type': 'horizontal_axis',
+        manufacturer: 'Vestas',
+        model: 'V112',
+        power: 'generator',
+        ref: 'JUV 5'
+      }
+    },
+    {
+      type: 'node',
+      id: 2026305187,
+      lat: 47.1862058,
+      lon: 7.0225376,
+      tags: {
+        'generator:method': 'wind_turbine',
+        'generator:output:electricity': '2000 kW',
+        'generator:source': 'wind',
+        'generator:type': 'horizontal_axis',
+        manufacturer: 'Vestas',
+        model: 'V90',
+        power: 'generator',
+        ref: 'JUV 13'
+      }
+    },
+    {
+      type: 'node',
+      id: 2026305188,
+      lat: 47.1765224,
+      lon: 7.0092142,
+      tags: {
+        'generator:method': 'wind_turbine',
+        'generator:output:electricity': '2000 kW',
+        'generator:source': 'wind',
+        'generator:type': 'horizontal_axis',
+        manufacturer: 'Vestas',
+        model: 'V90',
+        power: 'generator',
+        ref: 'JUV 10'
+      }
+    },
+    {
+      type: 'node',
+      id: 2026305190,
+      lat: 47.1986541,
+      lon: 7.0638697,
+      tags: {
+        'generator:method': 'wind_turbine',
+        'generator:output:electricity': '3300 kW',
+        'generator:source': 'wind',
+        'generator:type': 'horizontal_axis',
+        manufacturer: 'Vestas',
+        model: 'V112',
+        power: 'generator',
+        ref: 'JUV 6'
+      }
+    },
+    {
+      type: 'node',
+      id: 2026305191,
+      lat: 47.1822666,
+      lon: 7.0102525,
+      tags: {
+        'generator:method': 'wind_turbine',
+        'generator:output:electricity': '2000 kW',
+        'generator:source': 'wind',
+        'generator:type': 'horizontal_axis',
+        manufacturer: 'Vestas',
+        power: 'generator',
+        ref: 'JUV 4'
+      }
+    },
+    {
+      type: 'node',
+      id: 2026305192,
+      lat: 47.1768918,
+      lon: 7.0157049,
+      tags: {
+        'generator:method': 'wind_turbine',
+        'generator:output:electricity': '2000 kW',
+        'generator:source': 'wind',
+        'generator:type': 'horizontal_axis',
+        manufacturer: 'Vestas',
+        model: 'V90',
+        power: 'generator',
+        ref: 'JUV 1'
+      }
+    },
+    {
+      type: 'node',
+      id: 2026305193,
+      lat: 47.1876856,
+      lon: 7.0251293,
+      tags: {
+        'generator:method': 'wind_turbine',
+        'generator:output:electricity': '2000 kW',
+        'generator:source': 'wind',
+        'generator:type': 'horizontal_axis',
+        manufacturer: 'Vestas',
+        model: 'V90',
+        power: 'generator',
+        ref: 'JUV 14'
+      }
+    },
+    {
+      type: 'node',
+      id: 3683030445,
+      lat: 47.1841162,
+      lon: 7.0141507,
+      tags: {
+        'generator:method': 'wind_turbine',
+        'generator:output:electricity': '2000 kW',
+        'generator:source': 'wind',
+        'generator:type': 'horizontal_axis',
+        manufacturer: 'Vestas',
+        model: 'V90',
+        power: 'generator',
+        ref: 'JUV 11'
+      }
+    },
+    {
+      type: 'node',
+      id: 9169006416,
+      lat: 47.16013,
+      lon: 6.9692872,
+      tags: {
+        'generator:method': 'wind_turbine',
+        'generator:output:electricity': '3300 kW',
+        'generator:source': 'wind',
+        'generator:type': 'horizontal_axis',
+        manufacturer: 'Vestas',
+        model: 'V112',
+        operator: 'Juvent',
+        power: 'generator',
+        ref: 'JUV 8'
+      }
+    },
+    {
+      type: 'node',
+      id: 9169042317,
+      lat: 47.1626467,
+      lon: 6.9860041,
+      tags: {
+        'generator:method': 'wind_turbine',
+        'generator:output:electricity': '2000 kW',
+        'generator:source': 'wind',
+        'generator:type': 'horizontal_axis',
+        manufacturer: 'Vestas',
+        model: 'V90',
+        operator: 'Juvent',
+        power: 'generator',
+        ref: 'JUV 9'
+      }
+    },
+    {
+      type: 'node',
+      id: 9169042318,
+      lat: 47.1716638,
+      lon: 7.0033473,
+      tags: {
+        'generator:method': 'wind_turbine',
+        'generator:output:electricity': '2000 kW',
+        'generator:source': 'wind',
+        'generator:type': 'horizontal_axis',
+        manufacturer: 'Vestas',
+        model: 'V90',
+        operator: 'Juvent',
+        power: 'generator',
+        ref: 'JUV 2'
+      }
+    }
+  ]
+};

--- a/themes/horizon/turbines-reference.mjs
+++ b/themes/horizon/turbines-reference.mjs
@@ -1,0 +1,229 @@
+// Reference gate for turbines.js (node turbines-reference.mjs):
+//  - the spec ladder: model sheets, explicit-tag overrides, and
+//    the fleet-median fallback computed from the sheets
+//  - the variable-speed control law at its published landmarks:
+//    the rotor reaches its published top speed EXACTLY at its
+//    published rated wind (the closure identity), tracks
+//    lambda_opt v / R in region 2, and never leaves the
+//    published operational interval
+//  - ENERCON storm control: a linear speed taper across the
+//    published 28-34 m/s window instead of a hard stop
+//  - ENERCON's own calculated power curve (published verbatim
+//    below) closes the E-82 constants: cut-in and rated wind are
+//    READ OFF the table, Cp peaks at 0.50
+//  - the log-profile hub wind: exact at the forecast model's own
+//    10/80/120 m anchors
+//  - the LIVE Mont Crosin fixture: 19 real turbines, three
+//    models, refs carried
+import {
+  GENERIC,
+  hubWind,
+  MODEL_SPECS,
+  parseTurbines,
+  rotorOmega,
+  specOf,
+  YAW_DEG_S
+} from './turbines.js';
+import {TURBINES_FIXTURE} from './turbines-fixture.mjs';
+
+let fail = 0;
+const check = (name, ok, detail) => {
+  console.log(`${ok ? 'REF' : 'FAIL'} ${name}: ${detail}`);
+  if (!ok) fail++;
+};
+
+const RPM = Math.PI / 30;
+
+// ENERCON product overview, E-82 E2 2,300 kW "calculated power
+// curve" - wind speed [m/s], power [kW], Cp [-]. Verbatim.
+const E82_CURVE = [
+  [1, 0, 0],
+  [2, 3, 0.12],
+  [3, 25, 0.29],
+  [4, 82, 0.4],
+  [5, 174, 0.43],
+  [6, 321, 0.46],
+  [7, 532, 0.48],
+  [8, 815, 0.49],
+  [9, 1180, 0.5],
+  [10, 1580, 0.49],
+  [11, 1890, 0.44],
+  [12, 2100, 0.38],
+  [13, 2250, 0.32],
+  [14, 2350, 0.26],
+  [15, 2350, 0.22],
+  [16, 2350, 0.18],
+  [17, 2350, 0.15],
+  [18, 2350, 0.12],
+  [19, 2350, 0.11],
+  [20, 2350, 0.09],
+  [21, 2350, 0.08],
+  [22, 2350, 0.07],
+  [23, 2350, 0.06],
+  [24, 2350, 0.05],
+  [25, 2350, 0.05]
+];
+
+{
+  // The ladder: a model tag resolves the published sheet; an
+  // explicit rotor:diameter beats it (rpm clamps stay published,
+  // the closure recomputes); height - d/2 recovers a hub from a
+  // tip height; an unknown model with a power tag sizes its
+  // rotor from the fleet-median specific power of the sheets.
+  const v90 = specOf({manufacturer: 'Vestas', model: 'V90'});
+  const oride = specOf({model: 'V90', 'rotor:diameter': '100', height: '130'});
+  const unk = specOf({
+    model: 'Windmatic X',
+    'generator:output:electricity': '2000 kW'
+  });
+  const bare = specOf({});
+  const dFromP = Math.sqrt((4 * 2e6) / (Math.PI * GENERIC.specificPower));
+  const ok =
+    v90.d === 90 &&
+    v90.hub === 80 &&
+    v90.cutIn === 4 &&
+    v90.vRated === 12 &&
+    v90.cutOut === 25 &&
+    Math.abs(v90.omMin - 9.3 * RPM) < 1e-12 &&
+    Math.abs(v90.omMax - 16.6 * RPM) < 1e-12 &&
+    oride.d === 100 &&
+    Math.abs(oride.hub - 80) < 1e-12 &&
+    Math.abs(oride.omMax - 16.6 * RPM) < 1e-12 &&
+    unk.model === null &&
+    Math.abs(unk.d - dFromP) < 1e-12 &&
+    bare.d === GENERIC.d &&
+    bare.hub === GENERIC.hub &&
+    YAW_DEG_S === 0.5;
+  check(
+    'spec ladder',
+    ok,
+    `V90 tag -> the published sheet (D 90, hub 80, 9.3-16.6 rpm, cut-in 4, rated 12, cut-out 25); rotor:diameter 100 + tip height 130 override to D 100/hub 80; unknown model with 2000 kW sizes D ${unk.d.toFixed(1)} m from the fleet-median ${GENERIC.specificPower.toFixed(0)} W/m^2; yaw ${YAW_DEG_S} deg/s as published`
+  );
+}
+
+{
+  // The control law: below cut-in parked; region 2 EXACTLY
+  // lambda_opt v / R between the published clamps; the closure
+  // identity Omega(vRated) = Omega_max holds to machine
+  // precision; above rated constant top speed; hard stop at the
+  // Vestas cut-out; the whole sweep stays inside the published
+  // operational interval.
+  const s = specOf({model: 'V90'});
+  const mid = 10; // inside region 2 for the V90
+  let within = true;
+  for (let v = s.cutIn; v < s.cutOut; v += 0.1) {
+    const om = rotorOmega(s, v);
+    if (om < s.omMin - 1e-12 || om > s.omMax + 1e-12) within = false;
+  }
+  const ok =
+    rotorOmega(s, 3.9) === 0 &&
+    Math.abs(rotorOmega(s, mid) - (s.lambda * mid) / s.r) < 1e-12 &&
+    Math.abs(rotorOmega(s, s.vRated) - s.omMax) < 1e-15 &&
+    rotorOmega(s, 20) === s.omMax &&
+    rotorOmega(s, 25) === 0 &&
+    rotorOmega(s, 5) === s.omMin &&
+    within;
+  check(
+    'variable-speed law',
+    ok,
+    `V90: parked below cut-in, Omega = lambda v / R in region 2 (lambda ${s.lambda.toFixed(2)}), Omega(12 m/s) = ${(s.omMax / RPM).toFixed(1)} rpm exactly (the closure), constant to cut-out, 0 at 25; every speed within the published 9.3-16.6 rpm`
+  );
+}
+
+{
+  // ENERCON storm control: full speed to the window's edge, a
+  // linear taper across the published 28-34 m/s (half speed at
+  // 31), zero at 34 - no hard stop ("merely reduces power output
+  // by slowing down the rotational speed").
+  const e = specOf({manufacturer: 'Enercon', model: 'E82'});
+  const ok =
+    e.storm &&
+    e.storm[0] === 28 &&
+    e.storm[1] === 34 &&
+    Math.abs(rotorOmega(e, 28) - e.omMax) < 1e-12 &&
+    Math.abs(rotorOmega(e, 31) - e.omMax / 2) < 1e-12 &&
+    rotorOmega(e, 34) === 0 &&
+    rotorOmega(e, 33.9) > 0 &&
+    specOf({model: 'V90'}).storm === null;
+  check(
+    'ENERCON storm control',
+    ok,
+    `E-82 runs at full ${(e.omMax / RPM).toFixed(0)} rpm to 28 m/s, half at 31, feathered at 34 - the published window, linearly; the Vestas sheets keep their hard cut-out`
+  );
+}
+
+{
+  // The published E-82 power curve closes the module constants:
+  // cut-in = its first powered row, rated wind = its first
+  // plateau row at/above the 2,300 kW nameplate, Cp peaks at
+  // 0.50 (near the region-2 middle), and the published top speed
+  // keeps the tip below the V90-median tip speed band.
+  const e = MODEL_SPECS.E82;
+  const firstPowered = E82_CURVE.find((r) => r[1] > 0)[0];
+  const firstRated = E82_CURVE.find((r) => r[1] >= e.powerKW)[0];
+  const cpMax = Math.max(...E82_CURVE.map((r) => r[2]));
+  const cpAt = E82_CURVE.find((r) => r[2] === cpMax)[0];
+  const tip = (e.rpmMax * RPM * e.d) / 2;
+  const ok =
+    firstPowered === e.cutIn &&
+    firstRated === e.vRated &&
+    cpMax === 0.5 &&
+    cpAt === 9 &&
+    tip < GENERIC.tipMax + 1 &&
+    E82_CURVE.every((r, i) => i === 0 || r[1] >= E82_CURVE[i - 1][1]);
+  check(
+    'published power curve',
+    ok,
+    `ENERCON's own table: first power at ${firstPowered} m/s (= the sheet cut-in), 2,350 kW plateau from ${firstRated} m/s (= the sheet rated wind), Cp max ${cpMax} at ${cpAt} m/s, monotone; tip speed at 18 rpm = ${tip.toFixed(1)} m/s`
+  );
+}
+
+{
+  // The log-profile hub wind: exact at the forecast model's own
+  // anchors, log-linear between them, monotone for an increasing
+  // profile, floored at zero.
+  const ok =
+    hubWind(5, 8, 9, 10) === 5 &&
+    hubWind(5, 8, 9, 80) === 8 &&
+    hubWind(5, 8, 9, 120) === 9 &&
+    Math.abs(hubWind(5, 8, 9, 40) - (5 + (3 * Math.log(4)) / Math.log(8))) <
+      1e-12 &&
+    hubWind(5, 8, 9, 98) > 8 &&
+    hubWind(5, 8, 9, 98) < 9 &&
+    hubWind(0, 0, 0, 78) === 0;
+  check(
+    'log-profile hub wind',
+    ok,
+    `exact at 10/80/120 m; 40 m interpolates on ln z between 10 and 80 (${hubWind(5, 8, 9, 40).toFixed(3)} m/s); hub 98 sits between the 80 and 120 m winds; calm stays calm`
+  );
+}
+
+{
+  // The LIVE fixture: 19 Juvent turbines on Mont Crosin, all
+  // three models resolving their published sheets, 16 with their
+  // JUV plant refs, one Vestas without a model tag falling to
+  // the power rung, every position inside the capture box.
+  const t = parseTurbines(TURBINES_FIXTURE);
+  const byModel = {};
+  for (const x of t) byModel[x.spec.model] = (byModel[x.spec.model] || 0) + 1;
+  const refs = t.filter((x) => /^JUV \d+$/.test(x.ref || '')).length;
+  const inBox = t.every(
+    (x) => x.lat > 47.15 && x.lat < 47.3 && x.lon > 6.95 && x.lon < 7.15
+  );
+  const ok =
+    t.length === 19 &&
+    byModel.V90 === 11 &&
+    byModel.E82 === 3 &&
+    byModel.V112 === 4 &&
+    byModel.null === 1 &&
+    refs === 16 &&
+    inBox &&
+    t.every((x) => x.spec.hub >= 78 && x.spec.d >= 82);
+  check(
+    'live Mont Crosin fixture',
+    ok,
+    `19 turbines: ${byModel.V90} V90 + ${byModel.E82} E-82 + ${byModel.V112} V112 on their sheets, 1 model-less Vestas on the power rung, ${refs} JUV refs, all inside the capture box`
+  );
+}
+
+process.exit(fail ? 1 : 0);

--- a/themes/horizon/turbines.js
+++ b/themes/horizon/turbines.js
@@ -1,0 +1,233 @@
+/**
+ * turbines.js - wind turbines from OSM, spun by the real wind
+ * under the manufacturers' own operating envelopes. Pure math
+ * (node-importable); the silhouettes live in windmills.js.
+ *
+ * The spec ladder (like the building-height ladder): explicit
+ * tags (rotor:diameter, height:hub, height-to-tip) beat the
+ * model's published sheet, which beats fleet medians computed
+ * from the published sheets themselves - no invented constants.
+ * The sheets, read at the source:
+ *  - Vestas V90-1.8/2.0 MW facts & figures (2 MW platform
+ *    brochure): cut-in 4, rated 12, cut-out 25 m/s; nominal
+ *    14.5 rpm, operational interval 9.3-16.6 rpm; hub heights
+ *    from 80 m; blade 44 m, max chord 3.5 m; nacelle
+ *    10.4 x 3.4 x 4 m.
+ *  - ENERCON product overview, E-82 E2 2,300 kW: variable
+ *    6-18 rpm; hub heights from 78 m; cut-in and rated read off
+ *    ENERCON's own calculated power curve (first powered row at
+ *    2 m/s, 2,350 kW plateau from 14 m/s; Cp peaks at 0.50);
+ *    storm control runs the cut-out down over 28-34 m/s.
+ *  - Vestas General Specification V112-3.0 MW (0011-9181 V03):
+ *    static 12.8 rpm, dynamic 6.2-17.7 rpm; cut-in 3, cut-out
+ *    25, re-cut-in 23 m/s; blade 54.65 m, max chord 4.0 m; rotor
+ *    tilt 6 deg, blade coning 4 deg; yawing speed 0.5 deg/s.
+ *    Rated 13 m/s (V112 datasheet); the 3.3 shares the platform.
+ *
+ * The control law is the variable-speed pitch-regulated scheme
+ * (Burton, Jenkins, Sharpe & Bossanyi, Wind Energy Handbook):
+ * region 2 tracks maximum Cp at constant tip-speed ratio,
+ * Omega = lambda_opt v / R, clamped to the published operational
+ * interval; above rated the pitch sheds power at constant top
+ * speed; outside cut-in/cut-out the rotor is feathered. The
+ * closure lambda_opt = Omega_max R / v_rated makes the rotor
+ * reach its published top speed exactly at its published rated
+ * wind - every constant in the law is a sheet value. ENERCON's
+ * patented storm control replaces the hard stop: the speed
+ * tapers linearly across the published 28-34 m/s window instead
+ * of shutting down ("merely reduces power output by slowing
+ * down the rotational speed" - ENERCON product overview).
+ */
+
+const RPM = Math.PI / 30; // rad/s per rpm
+
+export const TILT_DEG = 6; // rotor tilt (V112 GS table 2-1)
+export const CONE_DEG = 4; // blade coning (V112 GS table 2-1)
+export const YAW_DEG_S = 0.5; // yawing speed at 50 Hz (V112 GS)
+
+// Published sheet values only. hub is the lowest published hub
+// height (the conservative choice where OSM is silent); blade,
+// chord and nacelle [l, w, h] in metres where the sheet gives
+// them.
+export const MODEL_SPECS = {
+  V90: {
+    d: 90,
+    hub: 80,
+    powerKW: 2000,
+    cutIn: 4,
+    vRated: 12,
+    cutOut: 25,
+    rpmMin: 9.3,
+    rpmMax: 16.6,
+    blade: 44,
+    chord: 3.5,
+    nacelle: [10.4, 3.4, 4]
+  },
+  E82: {
+    d: 82,
+    hub: 78,
+    powerKW: 2300,
+    cutIn: 2,
+    vRated: 14,
+    cutOut: 28,
+    storm: [28, 34],
+    rpmMin: 6,
+    rpmMax: 18
+  },
+  V112: {
+    d: 112,
+    hub: 84,
+    powerKW: 3300,
+    cutIn: 3,
+    vRated: 13,
+    cutOut: 25,
+    rpmMin: 6.2,
+    rpmMax: 17.7,
+    blade: 54.65,
+    chord: 4
+  }
+};
+
+const median = (a) => {
+  const s = a.slice().sort((x, y) => x - y);
+  return s[(s.length - 1) >> 1];
+};
+
+// The fleet medians OF THE PUBLISHED TABLE close the ladder for
+// turbines whose model OSM does not know: median specific power
+// P/A sizes a rotor from a power tag, the median tip-speed ratio
+// and tip speed set its law. Computed, not chosen.
+const SHEETS = Object.values(MODEL_SPECS);
+export const GENERIC = (() => {
+  const sp = median(
+    SHEETS.map((s) => (s.powerKW * 1000) / (Math.PI * s.d * s.d * 0.25))
+  );
+  const lambda = median(
+    SHEETS.map((s) => (s.rpmMax * RPM * s.d) / 2 / s.vRated)
+  );
+  const tip = median(SHEETS.map((s) => (s.rpmMax * RPM * s.d) / 2));
+  return {
+    specificPower: sp, // W/m^2
+    lambda,
+    tipMax: tip, // m/s
+    d: median(SHEETS.map((s) => s.d)),
+    hub: median(SHEETS.map((s) => s.hub)),
+    cutIn: median(SHEETS.map((s) => s.cutIn)),
+    cutOut: median(SHEETS.map((s) => s.cutOut)),
+    rpmMin: median(SHEETS.map((s) => s.rpmMin))
+  };
+})();
+
+const num = (v) => {
+  if (v == null) return null;
+  const m = String(v)
+    .replace(',', '.')
+    .match(/-?\d+(\.\d+)?/);
+  return m ? parseFloat(m[0]) : null;
+};
+
+export function powerKW(tags) {
+  const raw = tags['generator:output:electricity'];
+  if (!raw) return null;
+  const v = num(String(raw).replace(/,/g, ''));
+  if (v == null) return null;
+  return /mw/i.test(raw) ? v * 1000 : v;
+}
+
+const modelKey = (tags) => {
+  const m = (tags.model || '').toUpperCase().replace(/[^A-Z0-9]/g, '');
+  for (const k of Object.keys(MODEL_SPECS)) {
+    if (m === k || m.startsWith(k)) return k;
+  }
+  return null;
+};
+
+/**
+ * Resolve one turbine's spec through the ladder. Returns
+ * {model, d, r, hub, cutIn, vRated, cutOut, storm, omMin, omMax,
+ * lambda, blade, chord, nacelle} with omMin/omMax in rad/s and
+ * the closure lambda = omMax r / vRated already applied.
+ */
+export function specOf(tags = {}) {
+  const key = modelKey(tags);
+  const base = key ? MODEL_SPECS[key] : null;
+  const p = powerKW(tags) ?? base?.powerKW ?? null;
+  const d =
+    num(tags['rotor:diameter']) ??
+    base?.d ??
+    (p != null
+      ? Math.sqrt((4 * p * 1000) / (Math.PI * GENERIC.specificPower))
+      : GENERIC.d);
+  const r = d / 2;
+  const hub =
+    num(tags['height:hub']) ??
+    (num(tags.height) != null ? num(tags.height) - r : null) ??
+    base?.hub ??
+    GENERIC.hub;
+  const omMin = (base?.rpmMin ?? GENERIC.rpmMin) * RPM;
+  const omMax = base ? base.rpmMax * RPM : GENERIC.tipMax / r;
+  const vRated = base?.vRated ?? GENERIC.tipMax / GENERIC.lambda;
+  return {
+    model: key,
+    d,
+    r,
+    hub,
+    powerKW: p,
+    cutIn: base?.cutIn ?? GENERIC.cutIn,
+    vRated,
+    cutOut: base?.cutOut ?? GENERIC.cutOut,
+    storm: base?.storm ?? null,
+    omMin,
+    omMax,
+    lambda: (omMax * r) / vRated,
+    blade: base?.blade ?? null,
+    chord: base?.chord ?? null,
+    nacelle: base?.nacelle ?? null
+  };
+}
+
+/**
+ * Rotor speed (rad/s) at hub wind v (m/s): the variable-speed
+ * law with the published clamps. Vestas stops hard at cut-out;
+ * ENERCON storm control tapers the speed linearly across its
+ * published window instead.
+ */
+export function rotorOmega(spec, v) {
+  if (!(v >= spec.cutIn)) return 0;
+  const stop = spec.storm ? spec.storm[1] : spec.cutOut;
+  if (v >= stop) return 0;
+  let om = Math.min(
+    Math.max((spec.lambda * v) / spec.r, spec.omMin),
+    spec.omMax
+  );
+  if (spec.storm && v > spec.storm[0]) {
+    om *= (spec.storm[1] - v) / (spec.storm[1] - spec.storm[0]);
+  }
+  return om;
+}
+
+/**
+ * Wind at hub height from the forecast model's own levels
+ * (Open-Meteo 10/80/120 m), interpolated on the neutral
+ * surface-layer log profile (wind ~ ln z): exact at each anchor,
+ * log-linear between and beyond. Units pass through.
+ */
+export function hubWind(v10, v80, v120, h) {
+  const [z1, w1, z2, w2] = h <= 80 ? [10, v10, 80, v80] : [80, v80, 120, v120];
+  const f = Math.log(h / z1) / Math.log(z2 / z1);
+  return Math.max(w1 + (w2 - w1) * f, 0);
+}
+
+/** Overpass power=generator + generator:source=wind elements. */
+export function parseTurbines(osm) {
+  const out = [];
+  for (const el of osm?.elements || []) {
+    const t = el.tags || {};
+    if (t['generator:source'] !== 'wind') continue;
+    const lat = el.lat ?? el.center?.lat;
+    const lon = el.lon ?? el.center?.lon;
+    if (lat == null || lon == null) continue;
+    out.push({lat, lon, ref: t.ref || null, spec: specOf(t)});
+  }
+  return out;
+}

--- a/themes/horizon/windmills.js
+++ b/themes/horizon/windmills.js
@@ -1,0 +1,104 @@
+/**
+ * windmills.js - the wind-turbine silhouettes, in the vessels.js
+ * mould: a shared visual module (three import allowed here, never
+ * node-imported) both the theme and the asset viewer render, so
+ * the shapes are designed once in the viewer loop and shipped
+ * identically. The MEASURED identity comes from turbines.js: the
+ * spec ladder sets rotor diameter, hub height, and where the
+ * sheet publishes them the nacelle box (V90: 10.4 x 3.4 x 4 m)
+ * and blade length/chord. Where a sheet is silent the dims
+ * derive from the rotor by the PUBLISHED sheets' own ratios -
+ * both Vestas sheets put the blade at 0.49 D (44/90, 54.65/112),
+ * the V90 nacelle at 0.116/0.038/0.044 D. The rotor rides the
+ * published 6 deg tilt with 4 deg blade coning (V112 GS), and
+ * the caller yaws the head and spins the rotor - clockwise seen
+ * from upwind, as every sheet states. Light-grey paint is the
+ * industry's agreed low-visibility finish (RAL 7035), a
+ * documented design default like the rolling stock's liveries.
+ */
+
+import {
+  BoxGeometry,
+  ConeGeometry,
+  CylinderGeometry,
+  Group,
+  Mesh
+} from 'three/webgpu';
+import {CONE_DEG, TILT_DEG} from './turbines.js';
+
+const RAD = Math.PI / 180;
+
+// Published-ratio fallbacks (see header).
+export function bladeLenM(spec) {
+  return spec.blade ?? 0.49 * spec.d;
+}
+export function nacelleDims(spec) {
+  return spec.nacelle ?? [0.116 * spec.d, 0.038 * spec.d, 0.044 * spec.d];
+}
+
+/**
+ * Build one turbine into `group` (ground at y = 0): tapered
+ * tubular tower to the hub, yaw head with the nacelle, tilted
+ * rotor with spinner and three coned blades. mats:
+ * {body, dark}; U = scene units per metre. Returns {yaw, rotor}
+ * for the caller's frame loop (yaw about +y; spin about the
+ * rotor's local +z, negative = clockwise from upwind).
+ */
+export function buildWindmill(group, spec, mats, U) {
+  const [nl, nw, nh] = nacelleDims(spec);
+  const hubY = spec.hub * U;
+  // Tower: the sheets publish hub heights, not base diameters -
+  // the taper is a design default sized against the published
+  // nacelle width.
+  const towerH = spec.hub - nh / 2;
+  const tower = new Mesh(
+    new CylinderGeometry(0.33 * nw * U, 0.62 * nw * U, towerH * U, 12),
+    mats.body
+  );
+  tower.position.y = (towerH / 2) * U;
+  group.add(tower);
+
+  const yaw = new Group();
+  yaw.position.y = hubY;
+  group.add(yaw);
+
+  const nacelle = new Mesh(new BoxGeometry(nw * U, nh * U, nl * U), mats.body);
+  nacelle.position.z = -0.18 * nl * U; // hub overhangs the tower
+  yaw.add(nacelle);
+
+  // Rotor: published 6 deg tilt (upwind clearance), nose along
+  // +z - the caller points +z into the wind.
+  const rotor = new Group();
+  rotor.position.z = (0.5 * nl - 0.18 * nl) * U;
+  rotor.rotation.x = -TILT_DEG * RAD;
+  yaw.add(rotor);
+
+  const noseR = 0.55 * nh * U;
+  const nose = new Mesh(new ConeGeometry(noseR, 1.6 * noseR, 10), mats.dark);
+  nose.rotation.x = Math.PI / 2;
+  nose.position.z = 0.8 * noseR;
+  rotor.add(nose);
+
+  const bl = bladeLenM(spec);
+  const chord = spec.chord ?? 0.08 * bl;
+  for (let i = 0; i < 3; i++) {
+    // A tapered, flattened spar: root at the published max
+    // chord, fine tip; coned the published 4 deg away from the
+    // tower.
+    const g = new CylinderGeometry(
+      0.14 * chord * U,
+      0.5 * chord * U,
+      bl * U,
+      5
+    );
+    g.translate(0, (bl / 2) * U, 0);
+    g.scale(1, 1, 0.22);
+    const blade = new Mesh(g, mats.body);
+    const arm = new Group();
+    arm.rotation.z = i * ((2 * Math.PI) / 3);
+    blade.rotation.x = -CONE_DEG * RAD;
+    arm.add(blade);
+    rotor.add(arm);
+  }
+  return {yaw, rotor};
+}


### PR DESCRIPTION
All three lanes at once: a real data source (OSM `power=generator` + `generator:source=wind`, per-anchor like the other Overpass layers), a designed asset (`windmills.js` in the vessels/rollingstock mould with an `?asset=windmills` viewer stage), and the published engineering followed rather than approximated.

- **`turbines.js`** — the spec ladder: explicit tags (`rotor:diameter`, `height:hub`, tip `height` − R) beat the model's published sheet, which beats fleet medians computed *from the sheets themselves* (median specific power sizes a rotor from a bare power tag) — no invented constants. Three sheets read at the source: Vestas V90-2.0 facts & figures (cut-in 4 / rated 12 / cut-out 25 m/s, 9.3–16.6 rpm, nacelle 10.4×3.4×4 m), ENERCON E-82 E2 product overview (6–18 rpm, storm control 28–34 m/s, cut-in and rated wind read off ENERCON's own calculated power curve, Cp max 0.50), and the Vestas General Specification V112-3.0 MW doc 0011-9181 (6.2–17.7 rpm, rotor tilt 6°, blade coning 4°, yaw speed 0.5°/s, blade 54.65 m).
- **The control law** is the variable-speed pitch-regulated scheme (Burton, Jenkins, Sharpe & Bossanyi, *Wind Energy Handbook*): region 2 tracks maximum Cp at Ω = λ_opt·v/R inside the published operational interval, with the closure λ_opt = Ω_max·R/v_rated so the rotor reaches its published top speed exactly at its published rated wind. Vestas machines stop hard at cut-out; ENERCON's storm control tapers the speed linearly across its published window instead of shutting down.
- **Hub wind** comes from the forecast model's own 80/120 m levels (`syncWeather` now requests them), log-profile interpolated to each turbine's hub.
- **Theme**: nacelles slew into the live wind at the published 0.5°/s, rotors spin clockwise seen from upwind, dephased per turbine; turbines never stand in water; `?turbines=0` disables and roam keeps the param.
- **Live fixture**: the 19-turbine Juvent farm on Mont Crosin (11 V90 + 3 E-82 + 4 V112 + one model-less Vestas on the power rung, 16 `JUV` plant refs).
- **Gate 54 sets** — turbines: 6 landmarks (ladder, law with the closure identity exact, storm control, ENERCON's published power/Cp table closing the module constants, log-profile anchors, live fixture). Theme smoke places 19 of 19 at Mont Crosin and stays clean at Interlaken (1 known TSL warning class). Also restored the gate's GPU probes in this environment (harness `writeups` self-symlink + playwright resolution) — ocean-wind / ocean-sea / glints all pass again.

Sources:
- Vestas 2 MW platform brochure (V90-1.8/2.0 facts & figures): https://www.ledsjovind.se/tolvmanstegen/Vestas%20V90-2MW.pdf
- ENERCON product overview (E-82 E2 specs, calculated power curve, storm control): https://docs.wind-watch.org/Enercon.pdf
- Vestas General Specification V112-3.0 MW (0011-9181 V03): https://docs.wind-watch.org/Vestas-specs-V112-3MW.pdf
- V112-3.3 operating data (cut-in 3 / rated 13 / cut-out 25): https://en.wind-turbine-models.com/turbines/693-vestas-v112-3-3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKKBen9kkD562HDVr7cXAx

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKKBen9kkD562HDVr7cXAx)_