### PR TITLE
Horizon: wind-farm wakes — the farm robs itself (Jensen/Katic)

### DIFF
--- a/themes/Horizon.html
+++ b/themes/Horizon.html
@@ -479,6 +479,7 @@
         YAW_DEG_S
       } from './horizon/turbines.js';
       import {buildWindmill} from './horizon/windmills.js';
+      import {farmFactors} from './horizon/wakes.js';
       import {snowField, SNOW_LAYER, SNOW_Z} from './horizon/snowcover.js';
       import {lakeAt, lakeMask, parseWater} from './horizon/lakes.js';
       import {lineStrengths} from './horizon/airglow.js';
@@ -769,6 +770,8 @@
           // interpolates on ln z between them).
           state.wind80 = w.hourly?.wind_speed_80m?.[0] ?? null;
           state.wind120 = w.hourly?.wind_speed_120m?.[0] ?? null;
+          // the measured wind re-lays the farm wakes
+          applyWakes();
           record(
             'open-meteo current',
             (WMO[state.code] || state.code) +
@@ -3840,6 +3843,12 @@
             yaw: rig.yaw,
             rotor: rig.rotor,
             spec: t.spec,
+            // metres for the wake geometry (the scene's
+            // asinh-warped Y is not a length)
+            mx: sc.x * MPU,
+            mz: sc.z * MPU,
+            my: elevOfY(smp.y, centerElev) + t.spec.hub,
+            wake: 1,
             yawA: null
           });
           placed++;
@@ -3853,6 +3862,49 @@
           'wind turbines placed',
           placed + ' of ' + turbinesGeo.length + ' on this box'
         );
+        applyWakes();
+      }
+
+      // The farm robs itself (wakes.js - the Jensen/Katic PARK
+      // model on the published V112 thrust curve): each turbine's
+      // effective wind is its free hub wind times its farm
+      // factor, recomputed whenever the measured wind (speed or
+      // direction) changes.
+      function turbineHubWind(spec) {
+        return state.wind80 != null
+          ? hubWind(
+              state.wind / 3.6,
+              state.wind80 / 3.6,
+              (state.wind120 ?? state.wind80) / 3.6,
+              spec.hub
+            )
+          : state.wind / 3.6;
+      }
+      function applyWakes() {
+        if (!turbineRigs.length) return;
+        const a = (state.winddir + 180) * RAD;
+        const f = farmFactors(
+          turbineRigs.map((r) => ({x: r.mx, y: r.my, z: r.mz, spec: r.spec})),
+          {x: Math.sin(a), z: -Math.cos(a)},
+          (i) => turbineHubWind(turbineRigs[i].spec)
+        );
+        let waked = 0;
+        let worst = 1;
+        for (let i = 0; i < f.length; i++) {
+          turbineRigs[i].wake = f[i];
+          if (f[i] < 0.999) waked++;
+          worst = Math.min(worst, f[i]);
+        }
+        if (waked)
+          record(
+            'Jensen wind-farm wakes',
+            waked +
+              ' of ' +
+              turbineRigs.length +
+              ' turbines waked \u00b7 deepest -' +
+              Math.round((1 - worst) * 100) +
+              '% wind (Katic 1986, k 0.075)'
+          );
       }
 
       // Cable cars: pylons at the real support nodes, spans hung
@@ -7757,15 +7809,7 @@
             dy -= Math.round(dy / (2 * Math.PI)) * 2 * Math.PI;
             r.yawA += Math.abs(dy) < maxYaw ? dy : Math.sign(dy) * maxYaw;
             r.yaw.rotation.y = r.yawA;
-            const v =
-              state.wind80 != null
-                ? hubWind(
-                    state.wind / 3.6,
-                    state.wind80 / 3.6,
-                    (state.wind120 ?? state.wind80) / 3.6,
-                    r.spec.hub
-                  )
-                : state.wind / 3.6;
+            const v = turbineHubWind(r.spec) * (r.wake || 1);
             r.rotor.rotation.z -= rotorOmega(r.spec, v) * dt;
           }
         }

--- a/themes/horizon/WEBGPU-PLAN.md
+++ b/themes/horizon/WEBGPU-PLAN.md
@@ -3003,6 +3003,42 @@ secret put AISSTREAM_KEY && npx wrangler deploy`.
   Mont Crosin (3 models, 16 JUV refs). Gate 54 sets (turbines: 6
   landmarks - ladder, law, storm control, ENERCON's published
   curve closing the constants, log-profile anchors, fixture).
+- DONE: wind-farm wakes - the farm robs itself (Jul 10, frontier
+  research on the data shipped hours earlier). wakes.js follows
+  the industry PARK scheme from its sources: Jensen (1983,
+  Risoe-M-2411) top-hat wake expanding at r0 + k s with the
+  momentum initial reduction (1 - Ct) = (V/U0)^2; Katic,
+  Hoejstrup & Jensen (1986, EWEC Rome) partial shadowing by the
+  exact circle-circle lens and root-sum-square superposition;
+  WAsP's land decay k = 0.075. Thrust is published data end to
+  end: Vestas prints the V112's full Ct table in the General
+  Specification (table 12-2 - the 1.225 kg/m^3 column carried
+  verbatim, 45 rows), and the other pitch-regulated models ride
+  that curve on the non-dimensional v / v_rated axis of their
+  own sheets' rated winds. The E-82's storm control tapers its
+  thrust across the same published 28-34 window as its speed.
+  The gate holds the transfer against a THEOREM, not a feeling:
+  inverting ENERCON's own published Cp curve through
+  one-dimensional momentum theory (Cp = 4a(1-a)^2 on a <= 1/3,
+  Ct = 4a(1-a)) is a strict lower bound on true thrust - losses
+  only lower Cp at fixed induction - and the transferred curve
+  clears that floor at every published row, converging above
+  rated where the loss share vanishes (within 22% by 20 m/s).
+  An earlier draft used the inversion DIRECTLY as the E-82's
+  thrust; the gate's own cross-check exposed the bias (Cp 0.50
+  inverts to 0.62 against the V112's published 0.80 in the same
+  regime) and the design changed - the reference-first loop
+  working as intended. Landmarks (6): the published curve
+  verbatim/monotone/physical; the floor theorem; Jensen closed
+  points (initial reduction exact, deficit exactly /4 where the
+  wake doubles, s^-2 far field); the lens at its closed forms
+  (equal circles at one radius = (2pi/3 - sqrt(3)/2)/pi exactly);
+  sqrt(2) superposition; the live Juvent farm (west wind 8 m/s:
+  6 of 19 waked, deepest at 74% of free wind, calm lays none).
+  Theme: farm factors in METRES (the asinh-warped scene Y is not
+  a length), recomputed per weather poll, rotors visibly slower
+  deep in the farm; panel records 'Jensen wind-farm wakes - N of
+  M waked, deepest -P%'. Gate 55 sets.
 - OPEN (environment, not code) - UPDATE (roam smoke, Jul 7): the
   drift now also manifests as a PER-FRAME uncaught TypeError -
   GPUTexture.createView rejects the `swizzle` field three's

--- a/themes/horizon/harness/validate.sh
+++ b/themes/horizon/harness/validate.sh
@@ -24,7 +24,7 @@ REFDIR=${REFDIR:-..} # where the *-reference.mjs live
 fail=0
 
 echo "== CPU references (double precision, ground truth) =="
-for name in ocean atmo moon optics surf glint aurora leadr radar igrf scintillation ross-li cn2 airglow zodiacal meteors contrails ships navlights lightning milkyway earthshine nlc sats eclipses skyglow explore roam solarwind metar refraction smoke terrain-sample lakes buildings roads landuse rivers rails trains aerialways turbines peaks snowcover grib2 aerosol nightlights server; do
+for name in ocean atmo moon optics surf glint aurora leadr radar igrf scintillation ross-li cn2 airglow zodiacal meteors contrails ships navlights lightning milkyway earthshine nlc sats eclipses skyglow explore roam solarwind metar refraction smoke terrain-sample lakes buildings roads landuse rivers rails trains aerialways turbines wakes peaks snowcover grib2 aerosol nightlights server; do
   ref="$REFDIR/$name-reference.mjs"
   if [ ! -f "$ref" ]; then echo "[FAIL] $name-reference.mjs missing"; fail=1; continue; fi
   if out=$(node "$ref" 2>&1); then

--- a/themes/horizon/wakes-reference.mjs
+++ b/themes/horizon/wakes-reference.mjs
@@ -1,0 +1,231 @@
+// Reference gate for wakes.js (node wakes-reference.mjs):
+//  - the published V112 thrust curve carried exactly (spot rows
+//    of GS 0011-9181 table 12-2), physical and monotone
+//  - the actuator-disc floor: the momentum inversion exact at
+//    its closed points (a = 1/4 round trip; the Betz point to
+//    the sqrt(eps) the flat optimum permits), and the THEOREM -
+//    the transferred thrust clears the floor inverted from
+//    ENERCON's own published Cp at every row, converging above
+//    rated where the loss share vanishes
+//  - Jensen's wake at its closed points: the initial reduction
+//    1 - sqrt(1 - Ct) exact at s -> 0, the (r0/(r0 + k s))^2
+//    decay exactly 1/4 when the wake has doubled its radius
+//  - Katic partial shadowing: the circle-circle lens at its
+//    exact cases, monotone in offset
+//  - Katic root-sum-square: two equal wakes -> sqrt(2) times one
+//  - the LIVE Juvent farm: a west wind at 8 m/s wakes the
+//    downwind rows and nothing upwind of them
+import {
+  ctFromCp,
+  ctOf,
+  E82_CP,
+  farmFactors,
+  overlapFrac,
+  V112_CT,
+  WAKE_K,
+  wakeDeficit
+} from './wakes.js';
+import {parseTurbines, specOf} from './turbines.js';
+import {TURBINES_FIXTURE} from './turbines-fixture.mjs';
+
+let fail = 0;
+const check = (name, ok, detail) => {
+  console.log(`${ok ? 'REF' : 'FAIL'} ${name}: ${detail}`);
+  if (!ok) fail++;
+};
+
+{
+  // The published thrust curve: spot rows verbatim, all rows in
+  // (0, 1), monotone non-increasing (thrust coefficient falls as
+  // the pitch sheds load), the full 3-25 m/s domain at 0.5
+  // steps.
+  const at = (v) => V112_CT.find((r) => r[0] === v)?.[1];
+  let mono = true;
+  for (let i = 1; i < V112_CT.length; i++) {
+    if (V112_CT[i][1] > V112_CT[i - 1][1]) mono = false;
+  }
+  const ok =
+    V112_CT.length === 45 &&
+    at(3) === 0.913 &&
+    at(8) === 0.798 &&
+    at(12) === 0.409 &&
+    at(25) === 0.045 &&
+    mono &&
+    V112_CT.every((r) => r[1] > 0 && r[1] < 1) &&
+    WAKE_K === 0.075;
+  check(
+    'published thrust curve',
+    ok,
+    `GS table 12-2 at 1.225 kg/m^3: Ct(3) = 0.913, Ct(8) = 0.798, Ct(12) = 0.409, Ct(25) = 0.045 verbatim; 45 rows, monotone, physical; k = ${WAKE_K} (WAsP land)`
+  );
+}
+
+{
+  // The actuator-disc floor. Closed points first: a = 1/4
+  // (Cp = 0.5625 -> Ct = 0.75) exact to 1e-12; the Betz point
+  // (Cp = 16/27 -> Ct = 8/9) exact to the ~sqrt(eps) the FLAT
+  // optimum permits (dCp/da = 0 there - no inversion can do
+  // better in doubles). Then the theorem: real losses only
+  // lower Cp at fixed induction, so inverting a MEASURED Cp
+  // understates the induction and the floor sits under the true
+  // thrust - the transferred E-82 curve must clear it at every
+  // published row, and converge to it above rated where the
+  // loss share vanishes.
+  const betz = ctFromCp(16 / 27);
+  const quarter = ctFromCp(0.5625);
+  const e = specOf({model: 'E82'});
+  let floorOk = true;
+  let farGap = 0;
+  for (const [v, cp] of E82_CP) {
+    if (!(cp > 0) || v < e.cutIn || v > 25) continue;
+    const floor = ctFromCp(cp);
+    const ct = ctOf(e, v);
+    if (ct < floor - 1e-9) floorOk = false;
+    if (v >= 20) farGap = Math.max(farGap, ct / floor - 1);
+  }
+  const ok =
+    Math.abs(quarter - 0.75) < 1e-12 &&
+    Math.abs(betz - 8 / 9) < 1e-6 &&
+    ctFromCp(0) < 1e-12 &&
+    floorOk &&
+    farGap < 0.35;
+  check(
+    'actuator-disc floor',
+    ok,
+    `a = 1/4: Cp 0.5625 -> Ct 0.75 exact; Betz -> ${betz.toFixed(9)} (flat-optimum precision); the transferred E-82 thrust clears the floor from ENERCON's own Cp at every row and sits within ${(farGap * 100).toFixed(0)}% of it above 20 m/s`
+  );
+}
+
+{
+  // Jensen at its closed points: full wake on the axis at s -> 0
+  // gives the initial reduction 1 - sqrt(1 - Ct) exactly; when
+  // the wake has doubled its radius (s = r0/k) the deficit is
+  // exactly a quarter of that; the far field decays as s^-2.
+  const ct = 0.798; // the V112's own 8 m/s thrust
+  const init = 1 - Math.sqrt(1 - ct);
+  const d0 = wakeDeficit(ct, 45, 45, 1e-9, 0);
+  const dDouble = wakeDeficit(ct, 45, 1e-9, 45 / WAKE_K, 0);
+  const far1 = wakeDeficit(ct, 45, 1e-9, 8000, 0);
+  const far2 = wakeDeficit(ct, 45, 1e-9, 16000, 0);
+  const ok =
+    Math.abs(d0 - init) < 1e-9 &&
+    Math.abs(dDouble - init / 4) < 1e-12 &&
+    far2 > 0 &&
+    Math.abs(far1 / far2 - ((45 + 0.075 * 16000) / (45 + 0.075 * 8000)) ** 2) <
+      1e-9 &&
+    wakeDeficit(ct, 45, 45, -10, 0) === 0 &&
+    wakeDeficit(0, 45, 45, 100, 0) === 0;
+  check(
+    "Jensen's wake",
+    ok,
+    `initial reduction 1 - sqrt(1 - ${ct}) = ${init.toFixed(4)} exact at the rotor; exactly /4 where the wake has doubled (s = r0/k = ${(45 / WAKE_K).toFixed(0)} m); far field ~ s^-2; nothing upwind, no wake when parked`
+  );
+}
+
+{
+  // Katic partial shadowing - the lens at its exact cases:
+  // separated discs 0, rotor swallowed 1, wake swallowed
+  // rw^2/rj^2, and the equal-circles closed form - two discs of
+  // radius r a distance r apart overlap exactly
+  // (2 pi/3 - sqrt(3)/2) r^2; monotone in the offset.
+  const swallowed = overlapFrac(10, 30, 5);
+  const equal = overlapFrac(30, 30, 30);
+  const equalWant = ((2 * Math.PI) / 3 - Math.sqrt(3) / 2) / Math.PI;
+  let mono = true;
+  let prev = Infinity;
+  for (let c = 0; c <= 80; c += 2) {
+    const f = overlapFrac(30, 20, c);
+    if (f > prev + 1e-12) mono = false;
+    prev = f;
+  }
+  const ok =
+    overlapFrac(30, 20, 60) === 0 &&
+    overlapFrac(30, 20, 5) === 1 &&
+    Math.abs(swallowed - 100 / 900) < 1e-12 &&
+    Math.abs(equal - equalWant) < 1e-12 &&
+    mono;
+  check(
+    'Katic partial shadowing',
+    ok,
+    `disjoint 0, swallowed rotor 1, swallowed wake rw^2/rj^2 = ${swallowed.toFixed(4)} exact, equal circles at one radius = ${equal.toFixed(6)} = (2pi/3 - sqrt(3)/2)/pi exactly; monotone in offset`
+  );
+}
+
+{
+  // Katic root-sum-square: two identical upstream turbines side
+  // by side lay exactly sqrt(2) times one turbine's deficit on a
+  // common downstream point; zero downwind separation lays no
+  // wake (Jensen's s > 0 domain), so the coincident pair and the
+  // front row all keep the free wind.
+  const spec = specOf({model: 'V112'});
+  const wind = {x: 1, z: 0};
+  const v = () => 8;
+  const one = farmFactors(
+    [
+      {x: 0, y: 84, z: 0, spec},
+      {x: 500, y: 84, z: 0, spec}
+    ],
+    wind,
+    v
+  );
+  const two = farmFactors(
+    [
+      {x: 0, y: 84, z: 0, spec},
+      {x: 0, y: 84, z: 1e-6, spec},
+      {x: 500, y: 84, z: 0, spec}
+    ],
+    wind,
+    v
+  );
+  const dOne = 1 - one[1];
+  const dTwo = 1 - two[2];
+  const ok =
+    one[0] === 1 &&
+    dOne > 0.05 &&
+    Math.abs(dTwo - Math.SQRT2 * dOne) < 1e-6 &&
+    two[0] === 1 &&
+    two[1] === 1;
+  check(
+    'Katic superposition',
+    ok,
+    `one V112 500 m upwind at 8 m/s costs ${(dOne * 100).toFixed(1)}%; two coincident upwind cost ${(dTwo * 100).toFixed(1)}% = sqrt(2) x one exactly; the front row keeps the free wind`
+  );
+}
+
+{
+  // The LIVE farm: Juvent's 19 turbines in metres (equirect at
+  // the farm centre), a west wind at 8 m/s. The east-west spread
+  // of the farm guarantees waked machines; front-row machines
+  // (no neighbour upwind within the fan) keep factor 1; every
+  // factor stays physical; calm air wakes nothing.
+  const t = parseTurbines(TURBINES_FIXTURE);
+  const lat0 = 47.19;
+  const lon0 = 7.01;
+  const mLat = 111320;
+  const mLon = mLat * Math.cos((lat0 * Math.PI) / 180);
+  const farm = t.map((x) => ({
+    x: (x.lon - lon0) * mLon,
+    z: (x.lat - lat0) * mLat,
+    y: x.spec.hub,
+    spec: x.spec
+  }));
+  const f = farmFactors(farm, {x: 1, z: 0}, () => 8);
+  const waked = f.filter((v) => v < 0.999).length;
+  const free = f.filter((v) => v === 1).length;
+  const worst = Math.min(...f);
+  const calm = farmFactors(farm, {x: 1, z: 0}, () => 1);
+  const ok =
+    f.length === 19 &&
+    waked >= 4 &&
+    free >= 4 &&
+    worst > 0.5 &&
+    f.every((v) => v > 0 && v <= 1) &&
+    calm.every((v) => v === 1);
+  check(
+    'live Juvent farm',
+    ok,
+    `west wind, 8 m/s: ${waked} of 19 turbines waked, ${free} keep the free wind, deepest runs at ${(worst * 100).toFixed(0)}% of it; below cut-in the farm lays no wakes`
+  );
+}
+
+process.exit(fail ? 1 : 0);

--- a/themes/horizon/wakes.js
+++ b/themes/horizon/wakes.js
@@ -1,0 +1,261 @@
+/**
+ * wakes.js - wind-farm wake interaction: upstream turbines rob
+ * downstream ones of wind, so rotors deep in the farm run
+ * slower. Pure math (node-importable), consumed by the theme on
+ * top of turbines.js.
+ *
+ * The model is the industry-standard PARK scheme, followed from
+ * its sources rather than approximated:
+ *  - Jensen (1983, Risoe-M-2411): a top-hat wake expanding
+ *    linearly, r_w = r0 + k s; momentum balance across the rotor
+ *    gives the initial reduction (1 - Ct) = (V/U0)^2, so the
+ *    centreline deficit is (1 - sqrt(1 - Ct)) (r0/(r0 + k s))^2.
+ *  - Katic, Hoejstrup & Jensen (1986, EWEC Rome, "A Simple Model
+ *    for Cluster Efficiency"): partial-wake shadowing by the
+ *    overlap fraction of the downstream rotor disc with the wake
+ *    disc, and multiple wakes combined by root-sum-square of the
+ *    individual deficits.
+ *  - WAsP (DTU): the wake decay constant k = 0.075 for land
+ *    cases (0.04 offshore) - Mont Crosin is land.
+ *
+ * The thrust coefficient comes from published data end to end:
+ *  - Vestas prints the V112's full Ct table in the General
+ *    Specification (0011-9181 V03, table 12-2, noise mode 0);
+ *    the standard-density 1.225 kg/m^3 column is carried
+ *    verbatim below.
+ *  - No fetchable source publishes the E-82's or V90's table, so
+ *    every other pitch-regulated model rides the SAME published
+ *    curve on the non-dimensional axis v / v_rated (its own
+ *    sheet's rated wind) - a transfer of published data, not an
+ *    invented curve; pitch-controlled thrust curves collapse to
+ *    a common shape on that axis (Atlaskin, Suomi & Lindfors,
+ *    FMI, EGU21-14402). The E-82's storm control tapers its
+ *    thrust across the same published 28-34 m/s window the
+ *    rotor-speed law uses.
+ *  - The gate holds the transfer against a THEOREM rather than a
+ *    feeling: inverting ENERCON's own published Cp curve through
+ *    one-dimensional momentum theory (Cp = 4a(1-a)^2,
+ *    Ct = 4a(1-a), physical branch a <= 1/3) gives a strict
+ *    LOWER bound on the true Ct - real losses only lower Cp at
+ *    fixed induction, so the inverted induction understates the
+ *    true one. The transferred curve must clear that floor at
+ *    every published row and converge to it above rated where
+ *    the loss share vanishes (ctFromCp/E82_CP below exist for
+ *    that check and for anyone wanting the floor itself).
+ */
+
+import {rotorOmega} from './turbines.js';
+
+export const WAKE_K = 0.075; // WAsP wake decay, land
+export const RHO = 1.225; // kg/m^3, the sheets' standard density
+
+// Vestas General Specification V112-3.0 MW, table 12-2 (Ct
+// values, noise mode 0), air density 1.225 kg/m^3 - verbatim.
+export const V112_CT = [
+  [3, 0.913],
+  [3.5, 0.865],
+  [4, 0.833],
+  [4.5, 0.821],
+  [5, 0.817],
+  [5.5, 0.815],
+  [6, 0.812],
+  [6.5, 0.808],
+  [7, 0.804],
+  [7.5, 0.8],
+  [8, 0.798],
+  [8.5, 0.794],
+  [9, 0.781],
+  [9.5, 0.755],
+  [10, 0.711],
+  [10.5, 0.643],
+  [11, 0.567],
+  [11.5, 0.48],
+  [12, 0.409],
+  [12.5, 0.353],
+  [13, 0.308],
+  [13.5, 0.272],
+  [14, 0.241],
+  [14.5, 0.216],
+  [15, 0.194],
+  [15.5, 0.175],
+  [16, 0.159],
+  [16.5, 0.145],
+  [17, 0.133],
+  [17.5, 0.122],
+  [18, 0.112],
+  [18.5, 0.103],
+  [19, 0.096],
+  [19.5, 0.089],
+  [20, 0.083],
+  [20.5, 0.077],
+  [21, 0.072],
+  [21.5, 0.068],
+  [22, 0.064],
+  [22.5, 0.06],
+  [23, 0.056],
+  [23.5, 0.053],
+  [24, 0.05],
+  [24.5, 0.048],
+  [25, 0.045]
+];
+
+// ENERCON product overview, E-82 E2 2,300 kW calculated power
+// curve - the Cp column, verbatim.
+export const E82_CP = [
+  [1, 0],
+  [2, 0.12],
+  [3, 0.29],
+  [4, 0.4],
+  [5, 0.43],
+  [6, 0.46],
+  [7, 0.48],
+  [8, 0.49],
+  [9, 0.5],
+  [10, 0.49],
+  [11, 0.44],
+  [12, 0.38],
+  [13, 0.32],
+  [14, 0.26],
+  [15, 0.22],
+  [16, 0.18],
+  [17, 0.15],
+  [18, 0.12],
+  [19, 0.11],
+  [20, 0.09],
+  [21, 0.08],
+  [22, 0.07],
+  [23, 0.06],
+  [24, 0.05],
+  [25, 0.05]
+];
+
+const lerpTable = (tab, v) => {
+  if (v <= tab[0][0]) return tab[0][1];
+  for (let i = 1; i < tab.length; i++) {
+    if (v <= tab[i][0]) {
+      const [v0, y0] = tab[i - 1];
+      const [v1, y1] = tab[i];
+      return y0 + ((y1 - y0) * (v - v0)) / (v1 - v0);
+    }
+  }
+  return tab[tab.length - 1][1];
+};
+
+/**
+ * One-dimensional momentum (actuator disc) inversion: solve
+ * Cp = 4a(1-a)^2 for the induction factor on the physical branch
+ * a in [0, 1/3] (bisection to machine precision - the cubic is
+ * monotone there), return Ct = 4a(1-a). The Betz point closes it
+ * exactly: Cp = 16/27 -> a = 1/3 -> Ct = 8/9.
+ */
+export function ctFromCp(cp) {
+  const c = Math.min(Math.max(cp, 0), 16 / 27);
+  let lo = 0;
+  let hi = 1 / 3;
+  for (let i = 0; i < 100; i++) {
+    const a = (lo + hi) / 2;
+    if (4 * a * (1 - a) * (1 - a) < c) lo = a;
+    else hi = a;
+  }
+  const a = (lo + hi) / 2;
+  return 4 * a * (1 - a);
+}
+
+// The V112's published rated wind - the non-dimensional
+// transfer's own anchor.
+const V112_VRATED = 13;
+
+/**
+ * Thrust coefficient of one turbine at free wind v (m/s): the
+ * published V112 table, other models on the v / v_rated axis
+ * (see header). Zero outside the operating envelope - a parked,
+ * feathered rotor sheds no wake; ENERCON storm control tapers
+ * the thrust across its published window exactly as it tapers
+ * the speed.
+ */
+export function ctOf(spec, v) {
+  if (rotorOmega(spec, v) === 0) return 0;
+  const vEq = spec.model === 'V112' ? v : (v * V112_VRATED) / spec.vRated;
+  let ct = lerpTable(V112_CT, vEq);
+  if (spec.storm && v > spec.storm[0]) {
+    ct *= (spec.storm[1] - v) / (spec.storm[1] - spec.storm[0]);
+  }
+  return ct;
+}
+
+/**
+ * Overlap fraction of the downstream rotor disc (radius rj,
+ * centre a distance c off the wake axis) with the wake disc
+ * (radius rw): the circle-circle lens, exact (Katic's partial
+ * shadowing).
+ */
+export function overlapFrac(rw, rj, c) {
+  if (c >= rw + rj) return 0;
+  if (c + rj <= rw) return 1; // rotor fully inside the wake
+  const areaJ = Math.PI * rj * rj;
+  if (c + rw <= rj) return (Math.PI * rw * rw) / areaJ; // wake inside rotor
+  const lens =
+    rw * rw * Math.acos((c * c + rw * rw - rj * rj) / (2 * c * rw)) +
+    rj * rj * Math.acos((c * c + rj * rj - rw * rw) / (2 * c * rj)) -
+    0.5 *
+      Math.sqrt((-c + rw + rj) * (c + rw - rj) * (c - rw + rj) * (c + rw + rj));
+  return lens / areaJ;
+}
+
+/**
+ * Jensen deficit one wake lays on one downstream point: the
+ * initial reduction 1 - sqrt(1 - Ct) decayed by
+ * (r0/(r0 + k s))^2 and scaled by the overlap fraction.
+ * s = downwind distance, c = radial offset off the wake axis
+ * (same length units as the radii - the ratios are what matter).
+ */
+export function wakeDeficit(ct, r0, rj, s, c, k = WAKE_K) {
+  if (!(s > 0) || !(ct > 0)) return 0;
+  const rw = r0 + k * s;
+  const f = overlapFrac(rw, rj, c);
+  if (f === 0) return 0;
+  const decay = (r0 / rw) ** 2;
+  return f * (1 - Math.sqrt(1 - ct)) * decay;
+}
+
+/**
+ * The farm: every turbine's effective-wind factor v_eff/v under
+ * every other turbine's wake, Katic root-sum-square combined.
+ * turbines: [{x, y, z, spec}] with x/z horizontal, y the hub
+ * CENTRE height, all in METRES (the caller flattens any warped
+ * vertical axis first - the spec radii are metres and the lens
+ * mixes them with these offsets). wind: {x, z} unit vector
+ * pointing DOWNWIND.
+ * vAt(i): free wind (m/s) at turbine i's hub (sets Ct).
+ * Returns factors[] in (0, 1].
+ */
+export function farmFactors(turbines, wind, vAt, k = WAKE_K) {
+  const n = turbines.length;
+  const out = new Array(n).fill(1);
+  for (let j = 0; j < n; j++) {
+    let sum2 = 0;
+    const tj = turbines[j];
+    for (let i = 0; i < n; i++) {
+      if (i === j) continue;
+      const ti = turbines[i];
+      const dx = tj.x - ti.x;
+      const dz = tj.z - ti.z;
+      const s = dx * wind.x + dz * wind.z; // downwind separation
+      if (s <= 0) continue;
+      const cx = dx - s * wind.x;
+      const cz = dz - s * wind.z;
+      const c = Math.hypot(cx, cz, tj.y - ti.y);
+      const d = wakeDeficit(
+        ctOf(ti.spec, vAt(i)),
+        ti.spec.r,
+        tj.spec.r,
+        s,
+        c,
+        k
+      );
+      sum2 += d * d;
+    }
+    out[j] = Math.max(1 - Math.sqrt(sum2), 0);
+  }
+  return out;
+}


### PR DESCRIPTION
Frontier research on the data shipped in #86: upstream turbines rob downstream ones of wind, so rotors deep in the Juvent farm now visibly run slower — computed by the industry-standard PARK wake scheme followed from its sources.

- **`wakes.js`** — Jensen (1983, Risø-M-2411): top-hat wake expanding at r₀ + ks, momentum initial reduction (1−Ct) = (V/U₀)², centreline deficit (1−√(1−Ct))·(r₀/(r₀+ks))². Katic, Højstrup & Jensen (1986, EWEC Rome, *A Simple Model for Cluster Efficiency*): partial shadowing by the exact circle-circle lens and root-sum-square superposition of overlapping wakes. WAsP's land wake-decay constant k = 0.075.
- **Thrust is published data end to end**: Vestas prints the V112's full Ct table in the General Specification (0011-9181 V03, table 12-2 — the 1.225 kg/m³ column carried verbatim, 45 rows). Other pitch-regulated models ride that curve on the non-dimensional v/v_rated axis of their own sheets' rated winds (pitch-controlled thrust curves collapse on that axis — Atlaskin, Suomi & Lindfors, FMI, EGU21-14402). ENERCON storm control tapers thrust across the same published 28–34 m/s window as its rotor speed.
- **The gate holds the transfer against a theorem, not a feeling**: inverting ENERCON's own published Cp curve through one-dimensional momentum theory (Cp = 4a(1−a)², Ct = 4a(1−a), physical branch a ≤ 1/3) is a strict *lower bound* on true thrust — real losses only lower Cp at fixed induction. The transferred curve clears that floor at every published row and converges to it above rated (within 22% by 20 m/s). This check earned its keep immediately: an earlier draft used the inversion directly as the E-82's thrust, and the cross-check exposed the bias (Cp 0.50 inverts to Ct 0.62 against the V112's published 0.80 in the same regime) — the design changed because the reference caught it.
- **Landmarks (6)**: the published curve verbatim/monotone/physical; the actuator-disc floor (a = 1/4 round trip exact, Betz to the √ε its flat optimum permits); Jensen's closed points (initial reduction exact at the rotor, deficit exactly ÷4 where the wake has doubled, s⁻² far field); the lens closed forms (equal circles at one radius = (2π/3 − √3/2)/π exactly); √2 superposition of two equal wakes; the live Juvent farm (west wind 8 m/s: 6 of 19 waked, deepest at 74% of free wind; calm lays no wakes).
- **Theme**: farm factors computed in metres (the scene's asinh-warped Y is not a length), recomputed on every weather poll; panel records "Jensen wind-farm wakes — 6 of 19 turbines waked · deepest −26% wind (Katic 1986, k 0.075)" in the Mont Crosin smoke, matching the CPU reference.

Gate: **55 sets**, `VALIDATE PASS` including the restored GPU probes; Interlaken smoke unaffected.

Sources:
- Jensen (1983), *A note on wind generator interaction*, Risø-M-2411
- [Katic, Højstrup & Jensen (1986), *A Simple Model for Cluster Efficiency*, EWEC Rome](https://orbit.dtu.dk/en/publications/a-simple-model-for-cluster-efficiency)
- [WAsP wake-effect model (k = 0.075 land, initial reduction (1−Ct) = (V/U₀)²)](https://wasp.dtu.dk/software/wasp/wake-effect-model)
- [Vestas General Specification V112-3.0 MW (Ct table 12-2)](https://docs.wind-watch.org/Vestas-specs-V112-3MW.pdf)
- [ENERCON product overview (E-82 E2 calculated Cp curve, storm control)](https://docs.wind-watch.org/Enercon.pdf)
- [Atlaskin, Suomi & Lindfors (FMI), *Statistical Approximation of Thrust Coefficient*, EGU21-14402](https://presentations.copernicus.org/EGU21/EGU21-14402_presentation-h434262.pdf)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKKBen9kkD562HDVr7cXAx

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKKBen9kkD562HDVr7cXAx)_