### PR TITLE
Horizon: Cox–Munk sun glitter — the lakes' last tuned lobe retired

### DIFF
--- a/themes/Horizon.html
+++ b/themes/Horizon.html
@@ -7386,9 +7386,22 @@
             terrainUniforms.uSnowLine.value) *
           Math.min(dt, 1);
 
-        // Sea-state uniforms: real wind feeds the wave model.
+        // Sea-state uniforms: real wind feeds the wave model. The
+        // Cox-Munk glitter takes the wind at the paper's own
+        // 12.5 m mast height - the forecast model's 80/120 m
+        // levels log-interpolated down (turbines.js hubWind), the
+        // 10 m wind standing in until the levels arrive.
         terrainUniforms.uTime.value = t / 1000;
         terrainUniforms.uWindMs.value = state.wind / 3.6;
+        terrainUniforms.uWind125.value =
+          state.wind80 != null
+            ? hubWind(
+                state.wind / 3.6,
+                state.wind80 / 3.6,
+                (state.wind120 ?? state.wind80) / 3.6,
+                12.5
+              )
+            : state.wind / 3.6;
         // Night lights fade in through civil twilight (streetlights
         // lead the stars); the camera sits under the decks with
         // them, so no cloud dimming applies. The lamp points share

--- a/themes/horizon/WEBGPU-PLAN.md
+++ b/themes/horizon/WEBGPU-PLAN.md
@@ -3067,6 +3067,38 @@ secret put AISSTREAM_KEY && npx wrangler deploy`.
   Berlin smoke (radar stubbed with the captured frame) records
   '16 vehicles tracked - RE8 -> Elsterwerda (ODEG)'. Gate 55
   sets.
+- DONE: Cox & Munk (1954) sun glitter on the lakes (Jul 10, the
+  frontier lane - the LAST tuned lobe in the water path replaced
+  by the published law). The wet-pixel glitter was a Blinn
+  exponent mix(700, 60, U/15); it is now the slope-statistics
+  model Cox & Munk measured from aerial photographs of the sun's
+  glitter - the standard of ocean optical remote sensing since.
+  coxmunk.js carries the laws as reproduced verbatim in Capelle
+  et al. 2023 (the IASI revisit, eq. 9-12): upwind mss 3.16e-3 U,
+  crosswind 3e-3 + 1.92e-3 U (wind at the paper's own 12.5 m
+  mast, clamped to its 1-14 m/s data range), the Gram-Charlier
+  expansion with measured skewness C12 = 0.01 - 0.0086 U,
+  C30 = 0.04 - 0.033 U (waves lean downwind) and peakedness
+  0.23/0.12/0.40, exact unpolarised Fresnel (n = 1.34), and the
+  Breon/MERIS radiance factor rhoF p / (4 cosThetaV cos^4 beta).
+  Landmarks (5): the regressions exact at their anchors with the
+  separately fitted total consistent inside the paper's own
+  +-0.004; the Gram-Charlier structure held by MOMENT IDENTITIES
+  (Hermite orthogonality: normalisation and both second moments
+  untouched by the corrections, the normalised upwind third
+  moment = -C30 exactly - recovered numerically to 0.289 vs
+  0.290); Fresnel closed points incl. Brewster's rs^2/2; the
+  mirror-geometry closed form exact and the photographed
+  observable - wind WIDENS the glitter (peak falls, off-specular
+  brightens); the anisotropy (along-wind slopes likelier than
+  across, downwind lean likelier than up). terrain-tsl mirrors
+  the same expressions on wet pixels (uWind125 uniform); the
+  theme feeds it the 12.5 m wind log-interpolated from the
+  forecast model's own 80/120 m levels (turbines.js hubWind).
+  One scene now shares one wind: trees sway in it, cabins swing
+  in it, rotors spin and wake in it, and the lake glitter
+  widens, elongates and leans with it. Gate 56 sets; Interlaken
+  smoke clean.
 - OPEN (environment, not code) - UPDATE (roam smoke, Jul 7): the
   drift now also manifests as a PER-FRAME uncaught TypeError -
   GPUTexture.createView rejects the `swizzle` field three's

--- a/themes/horizon/coxmunk-reference.mjs
+++ b/themes/horizon/coxmunk-reference.mjs
@@ -1,0 +1,181 @@
+// Reference gate for coxmunk.js (node coxmunk-reference.mjs):
+//  - the published slope regressions exact at their anchors, the
+//    separately fitted total consistent with mu + mc well inside
+//    the paper's own +-0.004
+//  - the Gram-Charlier structure held by MOMENT IDENTITIES:
+//    Hermite orthogonality means the corrections change neither
+//    the normalisation nor the second moments, and the upwind
+//    third moment equals -C30 exactly - all recovered
+//    numerically to quadrature precision
+//  - Cox & Munk's own qualitative findings as numbers: mu > mc,
+//    negative upwind skewness, the peaked-then-heavy-tailed
+//    shape
+//  - Fresnel at its closed points (normal incidence
+//    ((n-1)/(n+1))^2, grazing -> 1, Brewster's zero)
+//  - the glitter geometry at the mirror point exact, and the
+//    photographed observable: wind WIDENS the glitter - the peak
+//    drops, the off-specular sky brightens
+import {
+  CM_RANGE,
+  fresnelWater,
+  gcCoeffs,
+  glintFactor,
+  mssCross,
+  mssUp,
+  N_WATER,
+  slopePDF
+} from './coxmunk.js';
+
+let fail = 0;
+const check = (name, ok, detail) => {
+  console.log(`${ok ? 'REF' : 'FAIL'} ${name}: ${detail}`);
+  if (!ok) fail++;
+};
+
+// Fine-grid quadrature over the slope plane (+-8 sigma).
+const quad = (U, f) => {
+  const su = Math.sqrt(mssUp(U));
+  const sc = Math.sqrt(mssCross(U));
+  const N = 400;
+  let sum = 0;
+  for (let i = 0; i < N; i++) {
+    for (let j = 0; j < N; j++) {
+      const x = (-8 + (16 * (i + 0.5)) / N) * su;
+      const y = (-8 + (16 * (j + 0.5)) / N) * sc;
+      sum += f(x, y) * slopePDF(x, y, U);
+    }
+  }
+  return sum * ((16 * su) / N) * ((16 * sc) / N);
+};
+
+{
+  // The published regressions: exact at U = 10 (mu = 0.0316,
+  // mc = 0.0222); the separately fitted total 3e-3 + 5.12e-3 U
+  // never strays from mu + mc by more than 5.6e-4 over the data
+  // range - an order under the published +-0.004; outside 1-14
+  // m/s the laws hold their end values (no extrapolation beyond
+  // the measurements).
+  let worst = 0;
+  for (let U = CM_RANGE[0]; U <= CM_RANGE[1]; U += 0.5) {
+    worst = Math.max(
+      worst,
+      Math.abs(mssUp(U) + mssCross(U) - (3e-3 + 5.12e-3 * U))
+    );
+  }
+  const ok =
+    Math.abs(mssUp(10) - 0.0316) < 1e-15 &&
+    Math.abs(mssCross(10) - 0.0222) < 1e-15 &&
+    worst < 5.7e-4 &&
+    mssUp(0) === mssUp(1) &&
+    mssCross(30) === mssCross(14);
+  check(
+    'published slope regressions',
+    ok,
+    `mu(10) = 0.0316, mc(10) = 0.0222 exact; |mu + mc - total-fit| <= ${worst.toExponential(1)} over 1-14 m/s (paper allows 4e-3); clamped to the measured range`
+  );
+}
+
+{
+  // Gram-Charlier moment identities (Hermite orthogonality): the
+  // corrections leave the normalisation and both second moments
+  // untouched, and buy the skewness exactly - the upwind third
+  // moment of the NORMALISED slope is -C30. All five recovered
+  // numerically at U = 10.
+  const U = 10;
+  const mu = mssUp(U);
+  const mc = mssCross(U);
+  const {c30} = gcCoeffs(U);
+  const norm = quad(U, () => 1);
+  const m2u = quad(U, (x) => x * x);
+  const m2c = quad(U, (x, y) => y * y);
+  const m3u = quad(U, (x) => (x / Math.sqrt(mu)) ** 3);
+  const ok =
+    Math.abs(norm - 1) < 2e-3 &&
+    Math.abs(m2u / mu - 1) < 5e-3 &&
+    Math.abs(m2c / mc - 1) < 5e-3 &&
+    Math.abs(m3u - -c30) < 2e-2 &&
+    c30 < 0 &&
+    mu > mc;
+  check(
+    'Gram-Charlier moments',
+    ok,
+    `integral ${norm.toFixed(4)}; <su^2>/mu = ${(m2u / mu).toFixed(4)}, <sc^2>/mc = ${(m2c / mc).toFixed(4)}; normalised <u^3> = ${m3u.toFixed(3)} vs -C30 = ${(-c30).toFixed(3)} (negative upwind skew - waves lean with the wind); mu > mc as measured`
+  );
+}
+
+{
+  // Fresnel closed points: normal incidence ((n-1)/(n+1))^2
+  // exact; grazing -> 1; Brewster's angle (tan = n) kills the
+  // p-polarised half, leaving rho = rs^2/2 exactly.
+  const r0 = ((N_WATER - 1) / (N_WATER + 1)) ** 2;
+  const thB = Math.atan(N_WATER);
+  const cB = Math.cos(thB);
+  const s2 = 1 - cB * cB;
+  const ct = Math.sqrt(1 - s2 / (N_WATER * N_WATER));
+  const rs = (cB - N_WATER * ct) / (cB + N_WATER * ct);
+  const ok =
+    Math.abs(fresnelWater(1) - r0) < 1e-15 &&
+    fresnelWater(0) > 0.999999 &&
+    Math.abs(fresnelWater(cB) - (rs * rs) / 2) < 1e-12 &&
+    fresnelWater(0.5) > fresnelWater(0.9);
+  check(
+    'Fresnel closed points',
+    ok,
+    `normal incidence ${fresnelWater(1).toFixed(5)} = ((n-1)/(n+1))^2 exactly; grazing -> 1; at Brewster's angle rho = rs^2/2 to 1e-12; monotone toward grazing`
+  );
+}
+
+{
+  // The glitter geometry: sun and viewer mirrored about the
+  // vertical need a FLAT facet - the factor collapses to the
+  // closed form rhoF(cos th) p(0,0) / (4 cos th) exactly. And
+  // the observable Cox & Munk photographed: wind WIDENS the
+  // glitter - the specular peak drops with U while a facet 12
+  // degrees off brightens.
+  const th = (30 * Math.PI) / 180;
+  const S = {x: Math.sin(th), y: Math.cos(th), z: 0};
+  const V = {x: -Math.sin(th), y: Math.cos(th), z: 0};
+  const up = {x: 1, z: 0};
+  const g = glintFactor(S, V, 8, up);
+  const want =
+    (fresnelWater(Math.cos(th)) * slopePDF(0, 0, 8)) / (4 * Math.cos(th));
+  const peak = (U) => glintFactor(S, V, U, up);
+  const tilt = (12 * Math.PI) / 180;
+  const V2 = {
+    x: -Math.sin(th - 2 * tilt),
+    y: Math.cos(th - 2 * tilt),
+    z: 0
+  };
+  const off = (U) => glintFactor(S, V2, U, up);
+  const ok =
+    Math.abs(g - want) < 1e-15 &&
+    peak(2) > peak(8) &&
+    peak(8) > peak(14) &&
+    off(14) > off(2) &&
+    glintFactor({x: 0.6, y: -0.8, z: 0}, V, 8, up) === 0;
+  check(
+    'glitter geometry',
+    ok,
+    `mirror case exact: ${g.toExponential(3)} = rhoF p(0,0)/(4 cos 30); peak falls with wind (${peak(2).toFixed(1)} > ${peak(8).toFixed(1)} > ${peak(14).toFixed(1)}) while 12 deg off-specular brightens (${off(2).toExponential(1)} -> ${off(14).toExponential(1)}) - the glitter widens exactly as photographed; no sun below the horizon`
+  );
+}
+
+{
+  // Anisotropy: the upwind variance beats the crosswind one, so
+  // a facet tilted along the wind is more probable than the same
+  // tilt across it - the glitter ellipse is elongated in the
+  // wind's vertical plane (CM's finding a).
+  const U = 10;
+  const s = 0.15;
+  const ok =
+    slopePDF(s, 0, U) > slopePDF(0, s, U) &&
+    slopePDF(0, 0, U) > slopePDF(s, 0, U) &&
+    slopePDF(-s, 0, U) > slopePDF(s, 0, U);
+  check(
+    'slope anisotropy',
+    ok,
+    `at 10 m/s a 0.15 slope is likelier along-wind than across (${slopePDF(0.15, 0, U).toFixed(2)} > ${slopePDF(0, 0.15, U).toFixed(2)}), and likelier leaning downwind than up (the negative skew) - the glitter ellipse and its asymmetry`
+  );
+}
+
+process.exit(fail ? 1 : 0);

--- a/themes/horizon/coxmunk.js
+++ b/themes/horizon/coxmunk.js
@@ -1,0 +1,125 @@
+/**
+ * coxmunk.js - the Cox & Munk (1954) sun-glitter model: the sea
+ * surface's slope STATISTICS measured from aerial photographs of
+ * the sun's glitter, the standard of ocean optical remote sensing
+ * to this day (Breon & Henriot 2006 re-measured the same laws
+ * from space). Pure math; the terrain shader mirrors these exact
+ * expressions on wet pixels, so the lakes' glitter width IS the
+ * published law rather than a tuned lobe.
+ *
+ * From the paper (regressions as reproduced verbatim in Capelle
+ * et al. 2023, "Revisiting the Cox and Munk wave-slope statistics
+ * using IASI observations", eq. 9-12):
+ *  - mean-square slopes, wind U at the 12.5 m "mast height",
+ *    valid over their 1-14 m/s data range:
+ *      upwind    mu = 3.16e-3 U
+ *      crosswind mc = 3.0e-3 + 1.92e-3 U
+ *    (their separately fitted total 3e-3 + 5.12e-3 U agrees with
+ *    mu + mc to well inside the published +-0.004)
+ *  - the Gram-Charlier expansion about the bivariate Gaussian
+ *    (x axis upwind, u = su/sqrt(mu), c = sc/sqrt(mc)):
+ *      p = (2 pi sqrt(mu mc))^-1 exp(-(u^2+c^2)/2) [ 1
+ *          - C12 u (c^2 - 1)/2 - C30 (u^3 - 3u)/6
+ *          + C40 (u^4 - 6u^2 + 3)/24
+ *          + C22 (u^2 - 1)(c^2 - 1)/4
+ *          + C04 (c^4 - 6c^2 + 3)/24 ]
+ *    with the measured skewness falling linearly in wind
+ *    (C12 = 0.01 - 0.0086 U, C30 = 0.04 - 0.033 U - the surface
+ *    is negatively skewed upwind, waves lean with the wind) and
+ *    the wind-independent peakedness C40 = 0.23, C22 = 0.12,
+ *    C04 = 0.40 (CM's c04/c22/c40 - indices swapped to the
+ *    x-upwind convention).
+ *  - glitter radiance per unit sun irradiance through the facet
+ *    geometry (the Breon & Henriot / MERIS form):
+ *      L/E = rhoF(omega) p(su, sc) / (4 cos(thetaV) cos^4(beta))
+ *    where beta is the facet tilt, omega the incidence on the
+ *    facet, rhoF the unpolarised Fresnel reflectance of water
+ *    (n = 1.34, CM used 1.338).
+ */
+
+export const CM_RANGE = [1, 14]; // the measurements' wind range
+export const N_WATER = 1.34;
+
+const clampU = (U) => Math.min(Math.max(U, CM_RANGE[0]), CM_RANGE[1]);
+
+export function mssUp(U) {
+  return 3.16e-3 * clampU(U);
+}
+
+export function mssCross(U) {
+  return 3.0e-3 + 1.92e-3 * clampU(U);
+}
+
+export function gcCoeffs(U) {
+  const w = clampU(U);
+  return {
+    c12: 0.01 - 0.0086 * w,
+    c30: 0.04 - 0.033 * w,
+    c40: 0.23,
+    c22: 0.12,
+    c04: 0.4
+  };
+}
+
+/**
+ * The slope probability density at (su, sc) - su the slope
+ * component along the UPWIND axis, sc crosswind. The bracket is
+ * clamped at zero: the truncated Gram-Charlier series goes
+ * (unphysically) negative in the far tails, a documented
+ * limitation of the expansion.
+ */
+export function slopePDF(su, sc, U) {
+  const mu = mssUp(U);
+  const mc = mssCross(U);
+  const {c12, c30, c40, c22, c04} = gcCoeffs(U);
+  const u = su / Math.sqrt(mu);
+  const c = sc / Math.sqrt(mc);
+  const bracket =
+    1 -
+    (c12 * u * (c * c - 1)) / 2 -
+    (c30 * (u * u * u - 3 * u)) / 6 +
+    (c40 * (u ** 4 - 6 * u * u + 3)) / 24 +
+    (c22 * (u * u - 1) * (c * c - 1)) / 4 +
+    (c04 * (c ** 4 - 6 * c * c + 3)) / 24;
+  return (
+    (Math.max(bracket, 0) / (2 * Math.PI * Math.sqrt(mu * mc))) *
+    Math.exp(-(u * u + c * c) / 2)
+  );
+}
+
+/** Unpolarised Fresnel reflectance of water at cos(incidence). */
+export function fresnelWater(cosw, n = N_WATER) {
+  const c = Math.min(Math.max(cosw, 0), 1);
+  const s2 = 1 - c * c;
+  const ct = Math.sqrt(Math.max(1 - s2 / (n * n), 0));
+  const rs = (c - n * ct) / (c + n * ct);
+  const rp = (n * c - ct) / (n * c + ct);
+  return (rs * rs + rp * rp) / 2;
+}
+
+/**
+ * Glitter radiance per unit sun irradiance: S and V unit vectors
+ * from the surface toward the sun and the viewer (y up), `up` the
+ * unit upwind direction in the horizontal plane ({x, z}). The
+ * facet that mirrors S into V has normal H = (S+V)/|S+V|; its
+ * slope lands in the Cox-Munk pdf, and the published geometry
+ * factor 1/(4 cos(thetaV) cos^4 beta) turns the density into
+ * radiance. Zero when either ray or the facet dips below the
+ * horizontal.
+ */
+export function glintFactor(S, V, U, up) {
+  const hx = S.x + V.x;
+  const hy = S.y + V.y;
+  const hz = S.z + V.z;
+  const hl = Math.hypot(hx, hy, hz);
+  if (!(hl > 0) || hy <= 0 || S.y <= 0 || V.y <= 0) return 0;
+  const H = {x: hx / hl, y: hy / hl, z: hz / hl};
+  const sx = -H.x / H.y; // facet slope components
+  const sz = -H.z / H.y;
+  const su = sx * up.x + sz * up.z;
+  const sc = -sx * up.z + sz * up.x;
+  const p = slopePDF(su, sc, U);
+  const cosw = Math.min(Math.max(S.x * H.x + S.y * H.y + S.z * H.z, 0), 1);
+  const cosb = H.y;
+  return (fresnelWater(cosw) * p) / (4 * Math.max(V.y, 1e-3) * cosb ** 4);
+}

--- a/themes/horizon/harness/validate.sh
+++ b/themes/horizon/harness/validate.sh
@@ -24,7 +24,7 @@ REFDIR=${REFDIR:-..} # where the *-reference.mjs live
 fail=0
 
 echo "== CPU references (double precision, ground truth) =="
-for name in ocean atmo moon optics surf glint aurora leadr radar igrf scintillation ross-li cn2 airglow zodiacal meteors contrails ships navlights lightning milkyway earthshine nlc sats eclipses skyglow explore roam solarwind metar refraction smoke terrain-sample lakes buildings roads landuse rivers rails trains aerialways turbines wakes peaks snowcover grib2 aerosol nightlights server; do
+for name in ocean atmo moon optics surf glint coxmunk aurora leadr radar igrf scintillation ross-li cn2 airglow zodiacal meteors contrails ships navlights lightning milkyway earthshine nlc sats eclipses skyglow explore roam solarwind metar refraction smoke terrain-sample lakes buildings roads landuse rivers rails trains aerialways turbines wakes peaks snowcover grib2 aerosol nightlights server; do
   ref="$REFDIR/$name-reference.mjs"
   if [ ! -f "$ref" ]; then echo "[FAIL] $name-reference.mjs missing"; fail=1; continue; fi
   if out=$(node "$ref" 2>&1); then

--- a/themes/horizon/terrain-tsl.js
+++ b/themes/horizon/terrain-tsl.js
@@ -102,6 +102,7 @@ export function createTerrainNodeMaterial(momentsTex, aerial) {
     uSnowLine: uniform(2300),
     uTime: uniform(0),
     uWindMs: uniform(3),
+    uWind125: uniform(3),
     uWindVec: uniform(new Vector2(1, 0)),
     uSunDirW: uniform(new Vector3(0, 1, 0)),
     uSunCol: uniform(new Color(0, 0, 0)),
@@ -184,20 +185,77 @@ export function createTerrainNodeMaterial(momentsTex, aerial) {
     return normalize(vec3(grad.x.negate(), 1.0, grad.y.negate()));
   });
 
-  // Sun glitter: Blinn lobe on the wave normals with Schlick fresnel;
-  // calm water gives a tight bright path, wind spreads it.
+  // Sun glitter: Cox & Munk (1954) - the node mirror of
+  // coxmunk.js (same expressions, held by its reference): the
+  // facet that mirrors the sun into the eye lands in the
+  // MEASURED slope pdf - upwind/crosswind variances linear in
+  // the live 12.5 m wind, Gram-Charlier skewness leaning the
+  // waves downwind - through the Breon/MERIS radiance factor
+  // rhoF p / (4 cosThetaV cos^4 beta). No tuned lobe: the
+  // glitter's width, ellipse and asymmetry are the published
+  // law.
   const seaSpec = Fn(([wp]) => {
-    const n = seaNormal(wp);
+    const U = clamp(u.uWind125, 1.0, 14.0);
+    const mu = U.mul(3.16e-3);
+    const mc = U.mul(1.92e-3).add(3.0e-3);
     const V = normalize(cameraPosition.sub(wp));
-    const H = normalize(V.add(u.uSunDirW));
-    const gloss = mix(700.0, 60.0, clamp(u.uWindMs.div(15.0), 0.0, 1.0));
-    const f = pow(clamp(float(1).sub(dot(V, n)), 0.0, 1.0), 5.0)
-      .mul(0.95)
-      .add(0.05);
-    return u.uSunCol
-      .mul(pow(max(dot(n, H), 0.0), gloss))
-      .mul(f)
-      .mul(6.0);
+    const S = u.uSunDirW;
+    const H = normalize(V.add(S));
+    const hy = max(H.y, 1e-3);
+    const upw = normalize(u.uWindVec).negate(); // upwind axis, xz
+    const sx = H.x.negate().div(hy);
+    const sz = H.z.negate().div(hy);
+    const su = sx.mul(upw.x).add(sz.mul(upw.y));
+    const sc = sx.negate().mul(upw.y).add(sz.mul(upw.x));
+    const un = su.div(sqrt(mu));
+    const cn = sc.div(sqrt(mc));
+    const u2 = un.mul(un);
+    const c2 = cn.mul(cn);
+    const c12 = float(0.01).sub(U.mul(0.0086));
+    const c30 = float(0.04).sub(U.mul(0.033));
+    const bracket = float(1.0)
+      .sub(c12.mul(un).mul(c2.sub(1.0)).mul(0.5))
+      .sub(c30.mul(u2.mul(un).sub(un.mul(3.0))).div(6.0))
+      .add(
+        u2
+          .mul(u2)
+          .sub(u2.mul(6.0))
+          .add(3.0)
+          .mul(0.23 / 24)
+      )
+      .add(
+        u2
+          .sub(1.0)
+          .mul(c2.sub(1.0))
+          .mul(0.12 / 4)
+      )
+      .add(
+        c2
+          .mul(c2)
+          .sub(c2.mul(6.0))
+          .add(3.0)
+          .mul(0.4 / 24)
+      );
+    const p = max(bracket, 0.0)
+      .mul(exp(u2.add(c2).mul(-0.5)))
+      .div(sqrt(mu.mul(mc)).mul(2 * Math.PI));
+    // unpolarised Fresnel of water, n = 1.34
+    const cosw = clamp(dot(S, H), 0.0, 1.0);
+    const ct = sqrt(
+      max(
+        float(1.0).sub(
+          float(1.0)
+            .sub(cosw.mul(cosw))
+            .div(1.34 * 1.34)
+        ),
+        0.0
+      )
+    );
+    const rs = cosw.sub(ct.mul(1.34)).div(cosw.add(ct.mul(1.34)));
+    const rp = cosw.mul(1.34).sub(ct).div(cosw.mul(1.34).add(ct));
+    const rhoF = rs.mul(rs).add(rp.mul(rp)).mul(0.5);
+    const geom = hy.mul(hy).mul(hy).mul(hy).mul(max(V.y, 0.05)).mul(4.0);
+    return u.uSunCol.mul(rhoF.mul(p).div(geom)).mul(smoothstep(0.0, 0.02, S.y));
   });
 
   // ---------- Zirr-Kaplanyan snow glints (see snow-glints.js) ----


### PR DESCRIPTION
The wet-pixel glitter was the last tuned lobe in the water path — a Blinn exponent `mix(700, 60, U/15)`. It's now **Cox & Munk (1954)**: the sea-surface slope statistics measured from aerial photographs of the sun's glitter, still the standard model of ocean optical remote sensing seventy years on.

- **`coxmunk.js`** — the laws as reproduced *verbatim* in the IASI revisit (Capelle et al. 2023, eqs. 9–12): upwind mean-square slope 3.16×10⁻³·U, crosswind 3×10⁻³ + 1.92×10⁻³·U, with U at the paper's own 12.5 m mast height and clamped to its 1–14 m/s data range (no extrapolation beyond the measurements). The full Gram–Charlier expansion with the measured skewness (C12 = 0.01 − 0.0086U, C30 = 0.04 − 0.033U — waves lean downwind) and peakedness (0.23 / 0.12 / 0.40), exact unpolarised Fresnel (n = 1.34), and the Bréon & Henriot / MERIS radiance factor ρF·p / (4·cosθᵥ·cos⁴β).
- **The gate holds the Gram–Charlier structure by moment identities** (Hermite orthogonality): the corrections leave the normalisation and both second moments untouched, and the normalised upwind third moment equals −C30 exactly — recovered numerically at 0.289 vs 0.290. Plus: the regressions exact at their anchors with the separately fitted total consistent to 5.6×10⁻⁴ (the paper allows ±4×10⁻³); Fresnel closed points including Brewster's ρ = rs²/2; the mirror-geometry closed form exact; and the observable Cox & Munk actually photographed — **wind widens the glitter** (specular peak falls with U while 12° off-specular brightens), with the anisotropic ellipse (along-wind slopes likelier than across) and its downwind lean.
- **`terrain-tsl.js`** mirrors the same expressions on wet pixels (new `uWind125` uniform); the theme feeds it the 12.5 m wind log-interpolated from the forecast model's own 80/120 m levels via the turbines' `hubWind`.

One scene now shares one measured wind: the trees sway in it, the cable-car cabins swing in it, the turbine rotors spin and wake in it — and the lake glitter widens, elongates, and leans with it.

Gate: **56 sets** + GPU probes, `VALIDATE PASS`; Interlaken smoke clean (1 known TSL warning class).

Sources:
- Cox & Munk (1954), *Measurement of the Roughness of the Sea Surface from Photographs of the Sun's Glitter*, JOSA 44
- [Capelle et al. (2023), *Revisiting the Cox and Munk wave-slope statistics using IASI observations* (arXiv:2210.05456) — eqs. 9–12 verbatim](https://arxiv.org/abs/2210.05456)
- [Bréon & Henriot (2006), *Spaceborne observations of ocean glint reflectance and modeling of wave slope distributions*, JGR Oceans](https://agupubs.onlinelibrary.wiley.com/doi/full/10.1029/2005JC003343)
- [MERIS ATBD 2.13 sun-glint model (the operational radiance form)](https://earth.esa.int/eogateway/documents/20142/37627/MERIS_ATBD_2.13_v4.3+-+2011+-+Sunglint.pdf)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKKBen9kkD562HDVr7cXAx

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKKBen9kkD562HDVr7cXAx)_