### PR TITLE
Firefox theme: sync embedded Firefox's tab URL to the address bar (sa…

### DIFF
--- a/firefox-wasm/main.js
+++ b/firefox-wasm/main.js
@@ -356,6 +356,24 @@ async function start() {
         200
       );
     });
+    if (window.parent !== window) {
+      let lastReported = '';
+      window.setInterval(async () => {
+        let url = '';
+        try {
+          url = await gecko.evalChrome(
+            "try { gBrowser.currentURI.spec } catch (e) { '' }"
+          );
+        } catch (e) {}
+        if (url && url !== lastReported) {
+          lastReported = url;
+          window.parent.postMessage(
+            {type: 'gecko-location', url},
+            location.origin
+          );
+        }
+      }, 800);
+    }
   } catch (e) {
     fail(e);
   }

--- a/themes/Firefox.html
+++ b/themes/Firefox.html
@@ -122,9 +122,25 @@
         document.body.classList.toggle('forward', shown);
         window.parent.postMessage({type: 'shaderwall', state}, location.origin);
       }
+      // Mirror the embedded Firefox's active tab into the real address bar,
+      // but only for pages on this same site: the History API can't set a
+      // cross-origin URL (it throws), and we don't want to leak where the
+      // reader browses off-site into the host's location.
+      function syncLocation(raw) {
+        try {
+          const top = window.top;
+          const u = new URL(raw, location.href);
+          if (u.origin !== top.location.origin) return;
+          top.history.replaceState(null, '', u.pathname + u.search + u.hash);
+        } catch (e) {}
+      }
       addEventListener('message', (e) => {
         if (e.origin != location.origin) return;
         const d = e.data || {};
+        if (d.type === 'gecko-location') {
+          if (typeof d.url === 'string') syncLocation(d.url);
+          return;
+        }
         if (d.type !== 'shaderwall') return;
         if (d.action === 'show') setShown('bare');
         else if (d.action === 'hide') setShown('hidden');


### PR DESCRIPTION
…me-origin)

The embedded Firefox now reports its active tab's URL up to the host page, which reflects it into the outer address bar via history.replaceState — but only for same-origin pages. The History API can't set a cross-origin URL (it throws), and limiting to same-origin avoids leaking off-site browsing into the host's location.

main.js, when embedded, polls gBrowser.currentURI (~800ms) and postMessages the URL to the parent; the theme reflects it only when the origin matches window.top. Because currentURI always tracks the selected tab, this follows both in-tab navigation and tab switches.


Claude-Session: https://claude.ai/code/session_014qsgEhxJ5MQpfnMZDGGzyX